### PR TITLE
Create an API to dynamically manage multi tenant Prometheus rules/alerts

### DIFF
--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -1,0 +1,257 @@
+package v1
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"html/template"
+	"io/ioutil"
+	"net/http"
+	"os"
+
+	"github.com/go-chi/chi"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"gopkg.in/yaml.v3"
+
+	"github.com/observatorium/observatorium/authentication"
+)
+
+// RuleNotFoundErr is returned when a particular rule wasn't found by its name.
+var RuleNotFoundErr = errors.New("rule not found")
+
+type RuleGroups struct {
+	Groups []RuleGroup `yaml:"groups"`
+}
+
+type RuleGroup struct {
+	Name     string         `yaml:"name"`
+	Interval model.Duration `yaml:"interval"`
+	Rules    []rulefmt.Rule `yaml:"rules"`
+}
+
+type RulesRepository interface {
+	RulesLister
+	RulesGetter
+	//CreateRules()
+	RulesUpdater
+	//DeleteRules()
+}
+
+// WithRulesAPI adds the rules APIs to the API router.
+func WithRulesAPI(repository RulesRepository) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.router.Get("/rules", h.instrument.NewHandler(
+			prometheus.Labels{"group": "metricsv1", "handler": "rules"},
+			listRulesHandler(h.logger, repository),
+		))
+		h.router.Get("/rules/{name}", h.instrument.NewHandler(
+			prometheus.Labels{"group": "metricsv1", "handler": "rulesGet"},
+			getRuleHandler(h.logger, repository),
+		))
+		h.router.Get("/rules/{name}/edit", h.instrument.NewHandler(
+			prometheus.Labels{"group": "metricsv1", "handler": "rulesEdit"},
+			editRuleHandler(h.logger, repository),
+		))
+		h.router.Post("/rules/{name}", h.instrument.NewHandler(
+			prometheus.Labels{"group": "metricsv1", "handler": "rulesUpdate"},
+			updateRuleHandler(h.logger, repository),
+		))
+	}
+}
+
+type RulesLister interface {
+	ListRuleGroups(ctx context.Context, tenant string) (RuleGroups, error)
+}
+
+func listRulesHandler(logger log.Logger, lister RulesLister) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tenant, ok := authentication.GetTenant(r.Context())
+		if !ok {
+			http.Error(w, "failed to get tenant", http.StatusInternalServerError)
+			return
+		}
+
+		rules, err := lister.ListRuleGroups(r.Context(), tenant)
+		if err != nil {
+			http.Error(w, "failed to list rules", http.StatusInternalServerError)
+			return
+		}
+
+		bytes, err := yaml.Marshal(rules)
+		if err != nil {
+			http.Error(w, "failed to marshal rules", http.StatusInternalServerError)
+			return
+		}
+
+		_, _ = w.Write(bytes)
+	}
+}
+
+type RulesGetter interface {
+	GetRules(ctx context.Context, tenant string, name string) (RuleGroup, error)
+}
+
+func getRuleHandler(logger log.Logger, repository RulesGetter) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tenant, ok := authentication.GetTenant(r.Context())
+		if !ok {
+			http.Error(w, "failed to get tenant", http.StatusInternalServerError)
+			return
+		}
+		name := chi.URLParam(r, "name")
+
+		rules, err := repository.GetRules(r.Context(), tenant, name)
+		if err == RuleNotFoundErr {
+			const msg = "rule not found"
+			level.Debug(logger).Log("msg", msg)
+			http.Error(w, msg, http.StatusNotFound)
+			return
+		}
+		if err != nil {
+			const msg = "failed to get rules"
+			level.Warn(logger).Log("msg", msg, "err", err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		bytes, err := yaml.Marshal(rules)
+		if err != nil {
+			const msg = "failed to marshal rules"
+			level.Warn(logger).Log("msg", msg, "err", err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		_, _ = w.Write(bytes)
+	}
+}
+
+const editHTML = `
+<html lang="en">
+<head>
+    <title>Edit Rules - Observatorium</title>
+</head>
+<body>
+    <h3>Edit Rule {{ .Name }}</h3>
+    <form action="/api/metrics/v1/{{ .Tenant }}/rules/{{ .Name }}" method="post">
+        <textarea cols="120" rows="30" name="rulegroup">{{ .Rules }}</textarea><br>
+        <button type="submit">Update</button>
+    </form>
+</body>
+</html>
+`
+
+func editRuleHandler(logger log.Logger, repository RulesGetter) http.HandlerFunc {
+	tmpl, err := template.New("edit").Parse(editHTML)
+	if err != nil {
+		level.Error(logger).Log("msg", "failed to parse rule edit HTML", "err", err)
+		os.Exit(1)
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		tenant, ok := authentication.GetTenant(r.Context())
+		if !ok {
+			http.Error(w, "failed to get tenant", http.StatusInternalServerError)
+			return
+		}
+		name := chi.URLParam(r, "name")
+
+		rules, err := repository.GetRules(r.Context(), tenant, name)
+		if err == RuleNotFoundErr {
+			const msg = "rule not found"
+			level.Debug(logger).Log("msg", msg)
+			http.Error(w, msg, http.StatusNotFound)
+			return
+		}
+		if err != nil {
+			const msg = "failed to get rules"
+			level.Warn(logger).Log("msg", msg, "err", err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		bytes, err := yaml.Marshal(rules)
+		if err != nil {
+			const msg = "failed to marshal rules"
+			level.Warn(logger).Log("msg", msg, "err", err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		_ = tmpl.Execute(w, struct {
+			Name   string
+			Rules  string
+			Tenant string
+		}{
+			Name:   name,
+			Rules:  string(bytes),
+			Tenant: tenant,
+		})
+	}
+}
+
+type RulesUpdater interface {
+	UpdateRule(ctx context.Context, tenant string, name string, content []byte) error
+}
+
+func updateRuleHandler(logger log.Logger, repository RulesUpdater) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		tenant, ok := authentication.GetTenant(r.Context())
+		if !ok {
+			const msg = "failed to get tenant"
+			level.Warn(logger).Log("msg", msg)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+		name := chi.URLParam(r, "name")
+
+		defer r.Body.Close()
+
+		//mediaType, params, err := mime.ParseMediaType(r.Header.Get("Content-Type"))
+		//if err != nil {
+		//	const msg = "failed to parse media type"
+		//	level.Warn(logger).Log("msg", msg, "err", err)
+		//	http.Error(w, msg, http.StatusBadRequest)
+		//	return
+		//}
+
+		body, err := ioutil.ReadAll(r.Body)
+		if err != nil {
+			const msg = "failed to read rules from request body"
+			level.Warn(logger).Log("msg", msg, "err", err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		fmt.Println(string(body))
+
+		var group RuleGroup
+		if err := yaml.Unmarshal(body, &group); err != nil {
+			const msg = "failed to unmarshal YAMl to rule group"
+			level.Warn(logger).Log("msg", msg, "err", err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		// TODO: VALIDATE input
+
+		rules, err := yaml.Marshal(group.Rules)
+		if err != nil {
+			const msg = "failed to unmarshal YAMl to rule group"
+			level.Warn(logger).Log("msg", msg, "err", err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+
+		if err := repository.UpdateRule(r.Context(), tenant, name, rules); err != nil {
+			const msg = "failed to save rules"
+			level.Warn(logger).Log("msg", msg, "err", err)
+			http.Error(w, msg, http.StatusInternalServerError)
+			return
+		}
+	}
+}

--- a/api/metrics/v1/rules_postgres.go
+++ b/api/metrics/v1/rules_postgres.go
@@ -1,0 +1,98 @@
+package v1
+
+import (
+	"context"
+	"database/sql"
+
+	"github.com/prometheus/prometheus/pkg/rulefmt"
+	"gopkg.in/yaml.v3"
+)
+
+// NewRulesRepository implements RulesRepository interface with Postgres
+// which the RulesAPI requires.
+func NewRulesRepository(db *sql.DB) *RulesRepositoryPostgres {
+	return &RulesRepositoryPostgres{db: db}
+}
+
+// RulesRepositoryPostgres the actual implementation of RulesRepository for Postgres.
+type RulesRepositoryPostgres struct {
+	db *sql.DB
+}
+
+func (r *RulesRepositoryPostgres) ListRuleGroups(ctx context.Context, tenant string) (RuleGroups, error) {
+	var groups RuleGroups
+
+	query := `SELECT name, rules FROM metrics_rules WHERE tenant = $1 ORDER BY name ASC`
+	rows, err := r.db.QueryContext(ctx, query, tenant)
+	if err != nil {
+		return groups, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var name, r string
+		if err := rows.Scan(&name, &r); err != nil {
+			return groups, err
+		}
+
+		var rules []rulefmt.Rule
+		if err := yaml.Unmarshal([]byte(r), &rules); err != nil {
+			return groups, err
+		}
+
+		groups.Groups = append(groups.Groups, RuleGroup{
+			Name:     name,
+			Interval: 0,
+			Rules:    rules,
+		})
+	}
+	if err := rows.Close(); err != nil {
+		return groups, err
+	}
+	if err := rows.Err(); err != nil {
+		return groups, err
+	}
+
+	return groups, nil
+}
+
+func (r *RulesRepositoryPostgres) GetRules(ctx context.Context, tenant, name string) (RuleGroup, error) {
+	query := `SELECT rules FROM metrics_rules WHERE tenant = $1 AND name = $2 LIMIT 1;`
+
+	var rulesYAML string
+	err := r.db.QueryRowContext(ctx, query, tenant, name).Scan(&rulesYAML)
+	if err == sql.ErrNoRows {
+		return RuleGroup{}, RuleNotFoundErr
+	}
+	if err != nil {
+		return RuleGroup{}, err
+	}
+
+	var rules []rulefmt.Rule
+	if err := yaml.Unmarshal([]byte(rulesYAML), &rules); err != nil {
+		return RuleGroup{}, err
+	}
+
+	return RuleGroup{
+		Name:  name,
+		Rules: rules,
+	}, nil
+}
+
+func (r *RulesRepositoryPostgres) UpdateRule(ctx context.Context, tenant string, name string, content []byte) error {
+	query := `UPDATE metrics_rules SET rules = $3 WHERE tenant = $1 AND name = $2`
+
+	result, err := r.db.ExecContext(ctx, query, tenant, name, content)
+	if err != nil {
+		return err
+	}
+	affectedRows, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if affectedRows != 1 {
+		return RuleNotFoundErr
+	}
+
+	return nil
+}

--- a/authentication/oidc.go
+++ b/authentication/oidc.go
@@ -195,7 +195,9 @@ func (p *OIDCProvider) Middleware() Middleware {
 					}
 					// Redirect users to the OIDC login
 					w.Header().Set("Location", path.Join("/oidc", tenant, "/login"))
-					http.Error(w, "failed to find token", http.StatusFound)
+					const msg = "failed to find token"
+					level.Debug(p.logger).Log("msg", msg)
+					http.Error(w, msg, http.StatusFound)
 					return
 				}
 				token = cookie.Value

--- a/database/migrations/20210122142216_create_metrics_rules_table.down.sql
+++ b/database/migrations/20210122142216_create_metrics_rules_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS metrics_rules;

--- a/database/migrations/20210122142216_create_metrics_rules_table.up.sql
+++ b/database/migrations/20210122142216_create_metrics_rules_table.up.sql
@@ -1,0 +1,9 @@
+create table if not exists metrics_rules
+(
+    tenant  varchar not null,
+    name    varchar not null,
+    rules   text,
+    created timestamp with time zone default now(),
+    updated timestamp with time zone default now(),
+    constraint metrics_rules_pk unique (tenant, name)
+);

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/google/go-cmp v0.5.1 // indirect
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/lib/pq v1.3.0 // indirect
+	github.com/lib/pq v1.3.0
 	github.com/mattn/go-sqlite3 v1.11.0 // indirect
 	github.com/metalmatze/signal v0.0.0-20201002154727-d0c16e42a3cf
 	github.com/oklog/run v1.1.0
@@ -36,5 +36,6 @@ require (
 	google.golang.org/protobuf v1.23.0
 	gopkg.in/square/go-jose.v2 v2.4.1 // indirect
 	gopkg.in/yaml.v2 v2.3.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	k8s.io/component-base v0.18.0
 )

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -81,6 +81,8 @@ done
     --rbac.config=./test/config/rbac.yaml \
     --middleware.rate-limiter.grpc-address=127.0.0.1:8881 \
     --tenants.config=./test/config/tenants.yaml \
+    --database.enable=true \
+    --database.dsn=postgres://postgres:postgres@localhost:5432/postgres?sslmode=disable \
     --log.level=debug
 ) &
 


### PR DESCRIPTION
Here is the Observatorium API part of the dynamic multi-tenant Prometheus rules configuration.
The migrations are based upon [migrate](https://github.com/golang-migrate/migrate).

Sadly most of this is still in a WIP state as I never got the OIDC parts properly working with the thanos-rule-syncer and therefore used another mocked API in the meantime. This should be a good foundation and baseline for anyone who wants to continue working on this.
