### PR TITLE
support multiple certificates in mtls ca file

### DIFF
--- a/authentication/mtls.go
+++ b/authentication/mtls.go
@@ -10,7 +10,7 @@ import (
 // MTLSConfig represents the mTLS configuration for a single tenant.
 type MTLSConfig struct {
 	Tenant string
-	CA     []*x509.Certificate
+	CAs    []*x509.Certificate
 }
 
 // NewMTLS creates a set of Middlewares for all specified tenants.
@@ -22,7 +22,7 @@ func NewMTLS(configs []MTLSConfig) map[string]Middleware {
 		middlewares[c.Tenant] = func(next http.Handler) http.Handler {
 			caPool := x509.NewCertPool()
 
-			for _, ca := range c.CA {
+			for _, ca := range c.CAs {
 				caPool.AddCert(ca)
 			}
 

--- a/authentication/mtls.go
+++ b/authentication/mtls.go
@@ -24,6 +24,7 @@ func NewMTLS(configs []MTLSConfig) map[string]Middleware {
 			for _, ca := range c.CA {
 				caPool.AddCert(ca)
 			}
+
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if len(r.TLS.PeerCertificates) == 0 {
 					http.Error(w, "no client certificate presented", http.StatusUnauthorized)

--- a/authentication/mtls.go
+++ b/authentication/mtls.go
@@ -10,7 +10,7 @@ import (
 // MTLSConfig represents the mTLS configuration for a single tenant.
 type MTLSConfig struct {
 	Tenant string
-	CA     *x509.Certificate
+	CA     []*x509.Certificate
 }
 
 // NewMTLS creates a set of Middlewares for all specified tenants.
@@ -21,8 +21,9 @@ func NewMTLS(configs []MTLSConfig) map[string]Middleware {
 		c := c
 		middlewares[c.Tenant] = func(next http.Handler) http.Handler {
 			caPool := x509.NewCertPool()
-			caPool.AddCert(c.CA)
-
+			for _, ca := range c.CA {
+				caPool.AddCert(ca)
+			}
 			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if len(r.TLS.PeerCertificates) == 0 {
 					http.Error(w, "no client certificate presented", http.StatusUnauthorized)

--- a/authentication/mtls.go
+++ b/authentication/mtls.go
@@ -21,6 +21,7 @@ func NewMTLS(configs []MTLSConfig) map[string]Middleware {
 		c := c
 		middlewares[c.Tenant] = func(next http.Handler) http.Handler {
 			caPool := x509.NewCertPool()
+
 			for _, ca := range c.CA {
 				caPool.AddCert(ca)
 			}

--- a/main.go
+++ b/main.go
@@ -254,7 +254,7 @@ func main() {
 						tenantsCfg.Tenants[i] = nil
 						break
 					}
-					t.MTLS.cas = append(t.MTLS.ca, cert)
+					t.MTLS.cas = append(t.MTLS.cas, cert)
 					if len(rest) == 0 {
 						break
 					}

--- a/main.go
+++ b/main.go
@@ -170,7 +170,7 @@ func main() {
 		MTLS *struct {
 			RawCA  []byte `json:"ca"`
 			CAPath string `json:"caPath"`
-			ca     []*x509.Certificate
+			cas    []*x509.Certificate
 		} `json:"mTLS"`
 		OPA *struct {
 			Query      string   `json:"query"`
@@ -254,7 +254,7 @@ func main() {
 						tenantsCfg.Tenants[i] = nil
 						break
 					}
-					t.MTLS.ca = append(t.MTLS.ca, cert)
+					t.MTLS.cas = append(t.MTLS.ca, cert)
 					if len(rest) == 0 {
 						break
 					}
@@ -433,7 +433,7 @@ func main() {
 				case t.MTLS != nil:
 					mTLSs = append(mTLSs, authentication.MTLSConfig{
 						Tenant: t.Name,
-						CA:     t.MTLS.ca,
+						CAs:    t.MTLS.cas,
 					})
 				default:
 					stdlog.Fatalf("tenant %q must specify either an OIDC or an mTLS configuration", t.Name)


### PR DESCRIPTION
This  PR is to fix the issue: https://github.com/observatorium/api/issues/136

It updates CA of MTLSConfig from *x509.Certificate to []*x509.Certificate. When reading ca file, all certificates located in the ca file will be loaded and stored in MTLSConfig.CA. Later, all certificates will be added into certpool to verify the incoming request.
