### PR TITLE
Forward the tenant prefix with all requests to upstream

### DIFF
--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -85,7 +85,7 @@ func (n nopInstrumentHandler) NewHandler(labels prometheus.Labels, handler http.
 	return handler.ServeHTTP
 }
 
-func NewHandler(read, tail, write *url.URL, prefixHeader string, opts ...HandlerOption) http.Handler {
+func NewHandler(read, tail, write *url.URL, opts ...HandlerOption) http.Handler {
 	c := &handlerConfiguration{
 		logger:     log.NewNopLogger(),
 		registry:   prometheus.NewRegistry(),
@@ -103,7 +103,7 @@ func NewHandler(read, tail, write *url.URL, prefixHeader string, opts ...Handler
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(read),
-				proxy.MiddlewareSetPrefixHeader(prefixHeader),
+				proxy.MiddlewareSetPrefixHeader(),
 				proxy.MiddlewareLogger(c.logger),
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "logsv1-read"}),
 			)
@@ -184,7 +184,7 @@ func NewHandler(read, tail, write *url.URL, prefixHeader string, opts ...Handler
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(tail),
-				proxy.MiddlewareSetPrefixHeader(prefixHeader),
+				proxy.MiddlewareSetPrefixHeader(),
 				proxy.MiddlewareLogger(c.logger),
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "logsv1-tail"}),
 			)
@@ -223,7 +223,7 @@ func NewHandler(read, tail, write *url.URL, prefixHeader string, opts ...Handler
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(write),
-				proxy.MiddlewareSetPrefixHeader(prefixHeader),
+				proxy.MiddlewareSetPrefixHeader(),
 				proxy.MiddlewareLogger(c.logger),
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "logsv1-write"}),
 			)

--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -85,7 +85,7 @@ func (n nopInstrumentHandler) NewHandler(labels prometheus.Labels, handler http.
 	return handler.ServeHTTP
 }
 
-func NewHandler(read, tail, write *url.URL, opts ...HandlerOption) http.Handler {
+func NewHandler(read, tail, write *url.URL, prefixHeader string, opts ...HandlerOption) http.Handler {
 	c := &handlerConfiguration{
 		logger:     log.NewNopLogger(),
 		registry:   prometheus.NewRegistry(),
@@ -103,6 +103,7 @@ func NewHandler(read, tail, write *url.URL, opts ...HandlerOption) http.Handler 
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(read),
+				proxy.MiddlewareSetPrefixHeader(prefixHeader),
 				proxy.MiddlewareLogger(c.logger),
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "logsv1-read"}),
 			)
@@ -183,6 +184,7 @@ func NewHandler(read, tail, write *url.URL, opts ...HandlerOption) http.Handler 
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(tail),
+				proxy.MiddlewareSetPrefixHeader(prefixHeader),
 				proxy.MiddlewareLogger(c.logger),
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "logsv1-tail"}),
 			)
@@ -221,6 +223,7 @@ func NewHandler(read, tail, write *url.URL, opts ...HandlerOption) http.Handler 
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(write),
+				proxy.MiddlewareSetPrefixHeader(prefixHeader),
 				proxy.MiddlewareLogger(c.logger),
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "logsv1-write"}),
 			)

--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -85,7 +85,7 @@ func (n nopInstrumentHandler) NewHandler(labels prometheus.Labels, handler http.
 }
 
 // NewHandler creates the new metrics v1 handler.
-func NewHandler(read, write *url.URL, prefixHeader string, opts ...HandlerOption) http.Handler {
+func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
 	c := &handlerConfiguration{
 		logger:     log.NewNopLogger(),
 		registry:   prometheus.NewRegistry(),
@@ -103,7 +103,7 @@ func NewHandler(read, write *url.URL, prefixHeader string, opts ...HandlerOption
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(read),
-				proxy.MiddlewareSetPrefixHeader(prefixHeader),
+				proxy.MiddlewareSetPrefixHeader(),
 				proxy.MiddlewareLogger(c.logger),
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "metricsv1-read"}),
 			)
@@ -141,7 +141,7 @@ func NewHandler(read, write *url.URL, prefixHeader string, opts ...HandlerOption
 			{
 				middlewares := proxy.Middlewares(
 					proxy.MiddlewareSetUpstream(read),
-					proxy.MiddlewareSetPrefixHeader(prefixHeader),
+					proxy.MiddlewareSetPrefixHeader(),
 					proxy.MiddlewareLogger(c.logger),
 					proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "metricsv1-ui"}),
 				)
@@ -163,7 +163,7 @@ func NewHandler(read, write *url.URL, prefixHeader string, opts ...HandlerOption
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(write),
-				proxy.MiddlewareSetPrefixHeader(prefixHeader),
+				proxy.MiddlewareSetPrefixHeader(),
 				proxy.MiddlewareLogger(c.logger),
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "metricsv1-write"}),
 			)

--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -85,7 +85,7 @@ func (n nopInstrumentHandler) NewHandler(labels prometheus.Labels, handler http.
 }
 
 // NewHandler creates the new metrics v1 handler.
-func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
+func NewHandler(read, write *url.URL, prefixHeader string, opts ...HandlerOption) http.Handler {
 	c := &handlerConfiguration{
 		logger:     log.NewNopLogger(),
 		registry:   prometheus.NewRegistry(),
@@ -103,6 +103,7 @@ func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(read),
+				proxy.MiddlewareSetPrefixHeader(prefixHeader),
 				proxy.MiddlewareLogger(c.logger),
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "metricsv1-read"}),
 			)
@@ -140,6 +141,7 @@ func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
 			{
 				middlewares := proxy.Middlewares(
 					proxy.MiddlewareSetUpstream(read),
+					proxy.MiddlewareSetPrefixHeader(prefixHeader),
 					proxy.MiddlewareLogger(c.logger),
 					proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "metricsv1-ui"}),
 				)
@@ -161,6 +163,7 @@ func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(write),
+				proxy.MiddlewareSetPrefixHeader(prefixHeader),
 				proxy.MiddlewareLogger(c.logger),
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "metricsv1-write"}),
 			)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -85,7 +85,7 @@ func getPrefix(ctx context.Context) (string, bool) {
 // WithPrefix adds the provided prefix to the request context.
 func WithPrefix(prefix string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		next.ServeHTTP(w, r.Clone(
+		next.ServeHTTP(w, r.WithContext(
 			context.WithValue(r.Context(), prefixKey, prefix),
 		))
 	})


### PR DESCRIPTION
With this PR, Obs. API will forward the tenant prefix we strip from the incoming requests (for ex. `/api/metrics/v1/{tenant}/` for metrics API) to the upstream using a HTTP header. The header key is configurable and the default is `X-Forwarded-Prefix`, which is not a standard, but is widely used for the same purpose (e.g. in Traefik).

This forwarding is useful if the upstream applications wants to do some redirection, if they serve a UI, etc. The immediate use case is for serving the Thanos UI properly.