### PR TITLE
Do not attempt to enforce tenant label on UI endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -482,6 +482,8 @@ func main() {
 						metricslegacy.HandlerInstrumenter(ins),
 						metricslegacy.SpanRoutePrefix("/api/v1/{tenant}"),
 						metricslegacy.ReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
+						metricslegacy.ReadMiddleware(authorization.WithEnforceTenantLabel(cfg.metrics.tenantLabel)),
+						metricslegacy.UIMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
 					),
 				)
 

--- a/main.go
+++ b/main.go
@@ -496,6 +496,7 @@ func main() {
 							metricsv1.SpanRoutePrefix("/api/metrics/v1/{tenant}"),
 							metricsv1.ReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
 							metricsv1.ReadMiddleware(authorization.WithEnforceTenantLabel(cfg.metrics.tenantLabel)),
+							metricsv1.UIMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
 							metricsv1.WriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "metrics")),
 						),
 					),


### PR DESCRIPTION
The `uiProxy` and `proxyRead` in metrics API were using the same set of `readMiddlerwares`. Due to this the Obs. API was trying to enforce tenant label on UI/assets requests as well. This resulted in all UI requests failing with error "query not found".

- This PR introduced new option `UIMiddleware` and uses this instead of the `ReadMiddleware` for UI.
- This PR also fixes the missing label enforcing middleware for the legacy API as well.