### PR TITLE
Do not override the prefix header if it's already set

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -46,6 +46,11 @@ func MiddlewareSetPrefixHeader() Middleware {
 			return
 		}
 
+		// Do not override the prefix header if it is already set.
+		if r.Header.Get(prefixHeader) != "" {
+			return
+		}
+
 		r.Header.Set(prefixHeader, prefix)
 	}
 }


### PR DESCRIPTION
This change will allow tenants to use their own reverse proxies and still be able to view the UI properly as they can override the prefix header according to their needs.