### PR TITLE
Update the RBAC example

### DIFF
--- a/examples/rbac/simple.yaml
+++ b/examples/rbac/simple.yaml
@@ -12,4 +12,5 @@ roleBindings:
   roles:
   - read-write
   subjects:
-  - admin@example.com
+  - kind: user
+    name: admin@example.com


### PR DESCRIPTION
Although the example RBAC config is not being used anywhere _per se_, experimenting with and trying to run the API 'plainly' with example YAMLs should work. Currently that is not the case due to:

```
api ❯ ./observatorium-api --metrics.read.endpoint=http://localhost:9090 --log.level=debug --tenants.config=./examples/tenants/simple.yaml --rbac.config=./examples/rbac/simple.yaml                            main
2021/07/13 11:44:18 unable to read RBAC YAML: could not parse RBAC data: error unmarshaling JSON: json: cannot unmarshal string into Go struct field RoleBinding.roleBindings.subjects of type rbac.Subject
```

This PR provides a small update to make it work.