### PR TITLE
Add support to forward the original bearer token to the authorizer

### DIFF
--- a/authorization/http.go
+++ b/authorization/http.go
@@ -35,7 +35,14 @@ func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Per
 				return
 			}
 
-			if statusCode, ok := a.Authorize(subject, groups, permission, resource, tenant); !ok {
+			token, ok := authentication.GetAccessToken(r.Context())
+			if !ok {
+				http.Error(w, "error finding access token", http.StatusUnauthorized)
+
+				return
+			}
+
+			if statusCode, ok := a.Authorize(subject, groups, permission, resource, tenant, token); !ok {
 				w.WriteHeader(statusCode)
 
 				return

--- a/rbac/rbac.go
+++ b/rbac/rbac.go
@@ -51,7 +51,7 @@ type RoleBinding struct {
 // Authorizer can authorize a subject's permission for a tenant's resource.
 type Authorizer interface {
 	// Authorize answers the question: can subject S in groups G perform permission P on resource R for Tenant T?
-	Authorize(subject string, groups []string, permission Permission, resource, tenant string) (int, bool)
+	Authorize(subject string, groups []string, permission Permission, resource, tenant, token string) (int, bool)
 }
 
 // tenant represents the read and write permissions of many subjects on a single tenant.
@@ -67,7 +67,7 @@ type tenants map[string]tenant
 type resources map[string]tenants
 
 // Authorize implements the Authorizer interface.
-func (rs resources) Authorize(subject string, groups []string, permission Permission, resource, tenant string) (int, bool) {
+func (rs resources) Authorize(subject string, groups []string, permission Permission, resource, tenant, token string) (int, bool) {
 	ts, ok := rs[resource]
 	if !ok {
 		return http.StatusForbidden, false

--- a/rbac/rbac_test.go
+++ b/rbac/rbac_test.go
@@ -973,7 +973,7 @@ func TestNewAuthorizer(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			a := NewAuthorizer(tc.roles, tc.roleBindings)
 			for i := range tc.ios {
-				sc, out := a.Authorize(tc.ios[i].subject, tc.ios[i].groups, tc.ios[i].permission, tc.ios[i].resource, tc.ios[i].tenant)
+				sc, out := a.Authorize(tc.ios[i].subject, tc.ios[i].groups, tc.ios[i].permission, tc.ios[i].resource, tc.ios[i].tenant, "")
 				if sc != tc.ios[i].statusCode {
 					t.Errorf("test case %d: expected status code %d; got %d", i, tc.ios[i].statusCode, sc)
 				}


### PR DESCRIPTION
This change set introduces support to forward the original user bearer token from the `observatorium-api` to the `opa-authorizer`. Some authorizer implementations need the original token to talk to the target authorization endpoint, e.g. `opa-openshift` talks to the OpenShift API server to request the users' namespaces.

In detail, the user bearer token pass-through can be configured per tenant and is send via the `X-Forwarded-Access-Token` header.