### PR TITLE
test: Use latest stable Thanos version for integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ CONTAINER_CMD := docker run --rm \
 		quay.io/coreos/jsonnet-ci
 
 THANOS ?= $(BIN_DIR)/thanos
-THANOS_VERSION ?= 0.13.0
+THANOS_VERSION ?= 0.21.1
 PROMETHEUS ?= $(BIN_DIR)/prometheus
 PROMETHEUS_VERSION ?= 2.15.2
 LOKI ?= $(BIN_DIR)/loki

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -88,6 +88,7 @@ done
   $THANOS receive \
     --receive.hashrings-file=./test/config/hashrings.json \
     --receive.local-endpoint=127.0.0.1:10901 \
+    --label "receive_replica=\"0\"" \
     --receive.default-tenant-id="1610b0c3-c509-4592-a256-a1871353dbfa" \
     --grpc-address=127.0.0.1:10901 \
     --http-address=127.0.0.1:10902 \
@@ -101,8 +102,7 @@ done
     --grpc-address=127.0.0.1:10911 \
     --http-address=127.0.0.1:9091 \
     --store=127.0.0.1:10901 \
-    --log.level=error \
-    --web.external-prefix=.
+    --log.level=error
 ) &
 
 (
@@ -142,7 +142,6 @@ if $UP \
   --endpoint-read=https://127.0.0.1:8443/api/metrics/v1/test-oidc/api/v1/query \
   --endpoint-write=https://127.0.0.1:8443/api/metrics/v1/test-oidc/api/v1/receive \
   --period=500ms \
-  --initial-query-delay=250ms \
   --threshold=1 \
   --latency=10s \
   --duration=10s \

--- a/test/run-local.sh
+++ b/test/run-local.sh
@@ -60,8 +60,7 @@ done
     --grpc-address=127.0.0.1:10911 \
     --http-address=127.0.0.1:9091 \
     --store=127.0.0.1:10901 \
-    --log.level=error \
-    --web.external-prefix=.
+    --log.level=error
 ) &
 
 (


### PR DESCRIPTION
While doing some local manual testing, I noticed that the currently used version of Thanos in integration tests is `0.13.0` whereas the latest stable version is [`0.21.1`](https://github.com/thanos-io/thanos/releases/tag/v0.21.1) (which explained some discrepancies between my manual tests vs. running tests via `make test`).

Includes additional changes to test script that reflect changes in Thanos configuration (e.g. passing label to receiver).