### PR TITLE
tests: Add unit tests for rate limiter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-chi/httprate v0.4.0
 	github.com/go-kit/kit v0.10.0
 	github.com/golang/protobuf v1.5.2
+	github.com/google/go-cmp v0.5.6
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/lib/pq v1.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/go-chi/httprate v0.4.0
 	github.com/go-kit/kit v0.10.0
 	github.com/golang/protobuf v1.5.2
-	github.com/google/go-cmp v0.5.6
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/lib/pq v1.3.0 // indirect

--- a/ratelimit/client.go
+++ b/ratelimit/client.go
@@ -28,6 +28,10 @@ type Client struct {
 	client   gubernator.V1Client
 }
 
+type SharedRateLimiter interface {
+	GetRateLimits(ctx context.Context, req *request) (remaining, resetTime int64, err error)
+}
+
 // NewClient creates a new gubernator client with default configuration.
 func NewClient(reg prometheus.Registerer) *Client {
 	grpcMetrics := grpc_prometheus.NewClientMetrics()

--- a/ratelimit/http_test.go
+++ b/ratelimit/http_test.go
@@ -1,0 +1,212 @@
+package ratelimit_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/google/go-cmp/cmp"
+	"github.com/observatorium/api/authentication"
+	"github.com/observatorium/api/ratelimit"
+)
+
+const (
+	testPathOne = "/test-one"
+	testPathTwo = "/test-two"
+	testTenant  = "test-tenant"
+)
+
+func TestWithLocalRateLimiter(t *testing.T) {
+	type pathTestParams struct {
+		path                    string
+		waitBetween             time.Duration
+		expectedOK              int
+		expectedTooManyRequests int
+	}
+
+	matcherOne, err := regexp.Compile(testPathOne)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matcherTwo, err := regexp.Compile(testPathTwo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name      string
+		reqNum    int
+		configs   []ratelimit.Config
+		pathTests []pathTestParams
+	}{
+		{
+			name:   "no config",
+			reqNum: 5,
+			pathTests: []pathTestParams{
+				{
+					path:                    testPathOne,
+					waitBetween:             1 * time.Millisecond,
+					expectedOK:              5,
+					expectedTooManyRequests: 0,
+				},
+			},
+		},
+		{
+			name: "one rate limiter",
+			configs: []ratelimit.Config{
+				{
+					Tenant:  testTenant,
+					Matcher: matcherOne,
+					Limit:   1,
+					Window:  10 * time.Second,
+				},
+			},
+			reqNum: 5,
+			pathTests: []pathTestParams{
+				{
+					path:                    testPathOne,
+					waitBetween:             1 * time.Millisecond,
+					expectedOK:              1,
+					expectedTooManyRequests: 4,
+				},
+			},
+		},
+		{
+			name: "two rate limiters",
+			configs: []ratelimit.Config{
+				{
+					Tenant:  testTenant,
+					Matcher: matcherOne,
+					Limit:   1,
+					Window:  10 * time.Second,
+				},
+				{
+					Tenant:  testTenant,
+					Matcher: matcherTwo,
+					Limit:   3,
+					Window:  10 * time.Second,
+				},
+			},
+			reqNum: 5,
+			pathTests: []pathTestParams{
+				{
+					path:                    testPathOne,
+					waitBetween:             1 * time.Millisecond,
+					expectedOK:              1,
+					expectedTooManyRequests: 4,
+				},
+				{
+					path:                    testPathTwo,
+					waitBetween:             1 * time.Millisecond,
+					expectedOK:              3,
+					expectedTooManyRequests: 2,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			rlmw := ratelimit.WithLocalRateLimiter(c.configs...)
+
+			r := chi.NewMux()
+
+			r.Group(func(r chi.Router) {
+				r.Use(authentication.WithTenant)
+				r.Use(rlmw)
+
+				r.HandleFunc(testPathOne+"/{tenant}", func(res http.ResponseWriter, req *http.Request) {
+					res.WriteHeader(http.StatusOK)
+				})
+				r.HandleFunc(testPathTwo+"/{tenant}", func(res http.ResponseWriter, req *http.Request) {
+					res.WriteHeader(http.StatusOK)
+				})
+			})
+
+			ts := httptest.NewServer(r)
+
+			for _, pathTest := range c.pathTests {
+				results := make(chan int)
+				errCh := make(chan error)
+				var wg sync.WaitGroup
+				for i := 0; i < c.reqNum; i++ {
+					wg.Add(1)
+					time.Sleep(pathTest.waitBetween)
+					go func() {
+						defer wg.Done()
+
+						req, err := http.NewRequest(
+							http.MethodGet,
+							ts.URL+pathTest.path+"/"+testTenant,
+							nil,
+						)
+						if err != nil {
+							errCh <- err
+							return
+						}
+
+						res, err := http.DefaultClient.Do(req)
+						if err != nil {
+							errCh <- err
+							return
+						}
+
+						results <- res.StatusCode
+					}()
+				}
+
+				go func() {
+					wg.Wait()
+					close(errCh)
+					close(results)
+				}()
+
+				select {
+				case err := <-errCh:
+					if err != nil {
+						t.Fatal(err)
+					}
+				default:
+				}
+
+				var (
+					gotOKs             int
+					gotTooManyRequests int
+				)
+				for r := range results {
+					switch r {
+					case http.StatusOK:
+						gotOKs++
+					case http.StatusTooManyRequests:
+						gotTooManyRequests++
+					}
+				}
+
+				if out := cmp.Diff(pathTest.expectedOK, gotOKs); out != "" {
+					t.Fatalf(
+						"unexpected number of OK responses: wanted %v, got %v",
+						pathTest.expectedOK,
+						gotOKs,
+					)
+				}
+				if out := cmp.Diff(pathTest.expectedTooManyRequests, gotTooManyRequests); out != "" {
+					t.Fatalf(
+						"unexpected number of Too Many Requests responses: wanted %v, got %v",
+						pathTest.expectedTooManyRequests,
+						gotTooManyRequests,
+					)
+				}
+			}
+
+		})
+	}
+}
+
+func TestWithLocalSharedRateLimiter(t *testing.T) {
+
+}

--- a/ratelimit/http_test.go
+++ b/ratelimit/http_test.go
@@ -1,17 +1,18 @@
-package ratelimit_test
+package ratelimit
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"regexp"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi"
-	"github.com/google/go-cmp/cmp"
 	"github.com/observatorium/api/authentication"
-	"github.com/observatorium/api/ratelimit"
+	"github.com/observatorium/api/logger"
 )
 
 const (
@@ -20,28 +21,21 @@ const (
 	testTenant  = "test-tenant"
 )
 
+var mockResetTime = time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+
+type pathTestParams struct {
+	path                    string
+	waitBetween             time.Duration
+	expectedOK              int
+	expectedTooManyRequests int
+}
+
 func TestWithLocalRateLimiter(t *testing.T) {
-	type pathTestParams struct {
-		path                    string
-		waitBetween             time.Duration
-		expectedOK              int
-		expectedTooManyRequests int
-	}
-
-	matcherOne, err := regexp.Compile(testPathOne)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	matcherTwo, err := regexp.Compile(testPathTwo)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	matcherOne, matcherTwo := compileMatchers(t)
 	cases := []struct {
 		name      string
 		reqNum    int
-		configs   []ratelimit.Config
+		configs   []Config
 		pathTests []pathTestParams
 	}{
 		{
@@ -58,7 +52,7 @@ func TestWithLocalRateLimiter(t *testing.T) {
 		},
 		{
 			name: "one rate limiter",
-			configs: []ratelimit.Config{
+			configs: []Config{
 				{
 					Tenant:  testTenant,
 					Matcher: matcherOne,
@@ -78,7 +72,7 @@ func TestWithLocalRateLimiter(t *testing.T) {
 		},
 		{
 			name: "two rate limiters",
-			configs: []ratelimit.Config{
+			configs: []Config{
 				{
 					Tenant:  testTenant,
 					Matcher: matcherOne,
@@ -112,7 +106,7 @@ func TestWithLocalRateLimiter(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			rlmw := ratelimit.WithLocalRateLimiter(c.configs...)
+			rlmw := WithLocalRateLimiter(c.configs...)
 
 			r := chi.NewMux()
 
@@ -131,72 +125,20 @@ func TestWithLocalRateLimiter(t *testing.T) {
 			ts := httptest.NewServer(r)
 
 			for _, pathTest := range c.pathTests {
-				results := make(chan int)
-				errCh := make(chan error)
-				var wg sync.WaitGroup
-				for i := 0; i < c.reqNum; i++ {
-					wg.Add(1)
-					time.Sleep(pathTest.waitBetween)
-					go func() {
-						defer wg.Done()
+				gotOKs, gotTooManyRequests, _ := launchTestRequests(t, ts.URL, pathTest, c.reqNum)
 
-						req, err := http.NewRequest(
-							http.MethodGet,
-							ts.URL+pathTest.path+"/"+testTenant,
-							nil,
-						)
-						if err != nil {
-							errCh <- err
-							return
-						}
-
-						res, err := http.DefaultClient.Do(req)
-						if err != nil {
-							errCh <- err
-							return
-						}
-
-						results <- res.StatusCode
-					}()
-				}
-
-				go func() {
-					wg.Wait()
-					close(errCh)
-					close(results)
-				}()
-
-				select {
-				case err := <-errCh:
-					if err != nil {
-						t.Fatal(err)
-					}
-				default:
-				}
-
-				var (
-					gotOKs             int
-					gotTooManyRequests int
-				)
-				for r := range results {
-					switch r {
-					case http.StatusOK:
-						gotOKs++
-					case http.StatusTooManyRequests:
-						gotTooManyRequests++
-					}
-				}
-
-				if out := cmp.Diff(pathTest.expectedOK, gotOKs); out != "" {
+				if pathTest.expectedOK != gotOKs {
 					t.Fatalf(
-						"unexpected number of OK responses: wanted %v, got %v",
+						"%v: unexpected number of OK responses: wanted %v, got %v",
+						pathTest.path,
 						pathTest.expectedOK,
 						gotOKs,
 					)
 				}
-				if out := cmp.Diff(pathTest.expectedTooManyRequests, gotTooManyRequests); out != "" {
+				if pathTest.expectedTooManyRequests != gotTooManyRequests {
 					t.Fatalf(
-						"unexpected number of Too Many Requests responses: wanted %v, got %v",
+						"%v: unexpected number of Too Many Requests responses: wanted %v, got %v",
+						pathTest.path,
 						pathTest.expectedTooManyRequests,
 						gotTooManyRequests,
 					)
@@ -207,6 +149,253 @@ func TestWithLocalRateLimiter(t *testing.T) {
 	}
 }
 
-func TestWithLocalSharedRateLimiter(t *testing.T) {
+type mockSharedLimiter struct {
+	mtx      sync.Mutex
+	received int64
+}
 
+func (m *mockSharedLimiter) GetRateLimits(ctx context.Context, req *request) (remaining, resetTime int64, err error) {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	if req.limit > m.received {
+		m.received++
+		return m.received, mockResetTime, nil
+	}
+
+	return m.received, mockResetTime, errOverLimit
+}
+
+func (m *mockSharedLimiter) reset() {
+	m.mtx.Lock()
+	defer m.mtx.Unlock()
+
+	m.received = 0
+}
+
+func TestWithSharedRateLimiter(t *testing.T) {
+	matcherOne, matcherTwo := compileMatchers(t)
+	cases := []struct {
+		name      string
+		reqNum    int
+		configs   []Config
+		pathTests []pathTestParams
+	}{
+		{
+			name:   "no config",
+			reqNum: 5,
+			pathTests: []pathTestParams{
+				{
+					path:                    testPathOne,
+					waitBetween:             1 * time.Millisecond,
+					expectedOK:              5,
+					expectedTooManyRequests: 0,
+				},
+			},
+		},
+		{
+			name: "one rate limiter",
+			configs: []Config{
+				{
+					Tenant:  testTenant,
+					Matcher: matcherOne,
+					Limit:   1,
+					Window:  10 * time.Second,
+				},
+			},
+			reqNum: 5,
+			pathTests: []pathTestParams{
+				{
+					path:                    testPathOne,
+					waitBetween:             1 * time.Millisecond,
+					expectedOK:              1,
+					expectedTooManyRequests: 4,
+				},
+			},
+		},
+		{
+			name: "two rate limiters",
+			configs: []Config{
+				{
+					Tenant:  testTenant,
+					Matcher: matcherOne,
+					Limit:   1,
+					Window:  10 * time.Second,
+				},
+				{
+					Tenant:  testTenant,
+					Matcher: matcherTwo,
+					Limit:   3,
+					Window:  10 * time.Second,
+				},
+			},
+			reqNum: 5,
+			pathTests: []pathTestParams{
+				{
+					path:                    testPathOne,
+					waitBetween:             1 * time.Millisecond,
+					expectedOK:              1,
+					expectedTooManyRequests: 4,
+				},
+				{
+					path:                    testPathTwo,
+					waitBetween:             1 * time.Millisecond,
+					expectedOK:              3,
+					expectedTooManyRequests: 2,
+				},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			limiter := &mockSharedLimiter{}
+			logger := logger.NewLogger("debug", "logfmt", "observatorium")
+			rlmw := WithSharedRateLimiter(logger, limiter, c.configs...)
+
+			r := chi.NewMux()
+
+			r.Group(func(r chi.Router) {
+				r.Use(authentication.WithTenant)
+				r.Use(rlmw)
+
+				r.HandleFunc(testPathOne+"/{tenant}", func(res http.ResponseWriter, req *http.Request) {
+					res.WriteHeader(http.StatusOK)
+				})
+				r.HandleFunc(testPathTwo+"/{tenant}", func(res http.ResponseWriter, req *http.Request) {
+					res.WriteHeader(http.StatusOK)
+				})
+			})
+
+			ts := httptest.NewServer(r)
+
+			for _, pathTest := range c.pathTests {
+				limiter.reset()
+				gotOKs, gotTooManyRequests, gotHeaders := launchTestRequests(t, ts.URL, pathTest, c.reqNum)
+
+				if pathTest.expectedOK != gotOKs {
+					t.Fatalf(
+						"%v: unexpected number of OK responses: wanted %v, got %v",
+						pathTest.path,
+						pathTest.expectedOK,
+						gotOKs,
+					)
+				}
+				if pathTest.expectedTooManyRequests != gotTooManyRequests {
+					t.Fatalf(
+						"%v: unexpected number of Too Many Requests responses: wanted %v, got %v",
+						pathTest.path,
+						pathTest.expectedTooManyRequests,
+						gotTooManyRequests,
+					)
+				}
+
+				// If no rate limiter configured, skip checking headers.
+				if len(c.configs) == 0 {
+					continue
+				}
+
+				if len(gotHeaders) == 0 {
+					t.Fatalf("%v: no headers found", pathTest.path)
+				}
+
+				for _, hh := range gotHeaders {
+					if limit := hh.Get(headerKeyLimit); limit == "" {
+						t.Fatalf("%v: header with key '%v' not found", pathTest.path, headerKeyLimit)
+					}
+					if remaining := hh.Get(headerKeyRemaining); remaining == "" {
+						t.Fatalf("%v: header with key '%v' not found", pathTest.path, headerKeyRemaining)
+					}
+					if reset := hh.Get(headerKeyReset); reset == "" {
+						t.Fatalf("%v: header with key '%v' not found", pathTest.path, headerKeyReset)
+
+						if reset != strconv.FormatInt(mockResetTime, 10) {
+							t.Fatalf("%v: unexpected reset time header: wanted %v, got %v",
+								pathTest.path,
+								mockResetTime,
+								reset,
+							)
+						}
+					}
+				}
+
+			}
+
+		})
+	}
+}
+
+func launchTestRequests(t *testing.T, baseURL string, pathTest pathTestParams, reqNum int) (int, int, []http.Header) {
+	type result struct {
+		statusCode int
+		headers    http.Header
+	}
+
+	results := make(chan result)
+	errCh := make(chan error)
+	var wg sync.WaitGroup
+	for i := 0; i < reqNum; i++ {
+		wg.Add(1)
+		time.Sleep(pathTest.waitBetween)
+		go func() {
+			defer wg.Done()
+
+			res, err := http.Get(baseURL + pathTest.path + "/" + testTenant)
+			if err != nil {
+				errCh <- err
+				return
+			}
+
+			results <- result{
+				res.StatusCode,
+				res.Header,
+			}
+		}()
+	}
+
+	go func() {
+		wg.Wait()
+		close(errCh)
+		close(results)
+	}()
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatal(err)
+		}
+	default:
+	}
+
+	var (
+		gotOKs             int
+		gotTooManyRequests int
+		gotHeaders         []http.Header
+	)
+	for r := range results {
+		switch r.statusCode {
+		case http.StatusOK:
+			gotOKs++
+		case http.StatusTooManyRequests:
+			gotTooManyRequests++
+		}
+
+		gotHeaders = append(gotHeaders, r.headers)
+	}
+
+	return gotOKs, gotTooManyRequests, gotHeaders
+}
+
+func compileMatchers(t *testing.T) (*regexp.Regexp, *regexp.Regexp) {
+	matcherOne, err := regexp.Compile(testPathOne)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matcherTwo, err := regexp.Compile(testPathTwo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return matcherOne, matcherTwo
 }


### PR DESCRIPTION
In light of the fact that we are increasing activity in the repository, working with and refactoring the existing code, and with regards to previous discussions in https://github.com/observatorium/api/pull/146#discussion_r676417635, it would be useful to increase test coverage in the repository.

This PR starts by adding unit tests for local and shared rate limiter.