### PR TITLE
tests: Additional fixes for tail logs integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ PROMETHEUS_VERSION ?= 2.15.2
 LOKI ?= $(BIN_DIR)/loki
 LOKI_VERSION ?= 2.2.1
 WEBSOCAT ?= $(BIN_DIR)/websocat
-WEBSOCAT_VERSION ?= 1.5.0
+WEBSOCAT_VERSION ?= 1.8.0
 WEBSOCAT_PKG =
 ifeq ($(shell go env GOOS),linux)
 	WEBSOCAT_PKG = "websocat_amd64-linux"

--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -202,13 +202,11 @@ func NewHandler(read, tail, write *url.URL, opts ...HandlerOption) http.Handler 
 			tailRead = &httputil.ReverseProxy{
 				Director: middlewares,
 				ErrorLog: proxy.Logger(c.logger),
-				Transport: otelhttp.NewTransport(
-					&http.Transport{
-						DialContext: (&net.Dialer{
-							Timeout: ReadTimeout,
-						}).DialContext,
-					},
-				),
+				Transport: &http.Transport{
+					DialContext: (&net.Dialer{
+						Timeout: ReadTimeout,
+					}).DialContext,
+				},
 			}
 		}
 		r.Group(func(r chi.Router) {
@@ -241,11 +239,13 @@ func NewHandler(read, tail, write *url.URL, opts ...HandlerOption) http.Handler 
 			proxyWrite = &httputil.ReverseProxy{
 				Director: middlewares,
 				ErrorLog: proxy.Logger(c.logger),
-				Transport: &http.Transport{
-					DialContext: (&net.Dialer{
-						Timeout: ReadTimeout,
-					}).DialContext,
-				},
+				Transport: otelhttp.NewTransport(
+					&http.Transport{
+						DialContext: (&net.Dialer{
+							Timeout: ReadTimeout,
+						}).DialContext,
+					},
+				),
 			}
 		}
 		r.Group(func(r chi.Router) {

--- a/test/integration.sh
+++ b/test/integration.sh
@@ -220,13 +220,13 @@ echo "-------------------------------------------"
 write_logs=$(curl \
                -v -H "Authorization: Bearer $token" -H "Content-Type: application/json" \
                --cacert ./tmp/certs/ca.pem \
-               -XPOST -s https://127.0.0.1:8443/api/logs/v1/test-oidc/api/v1/push --data-raw \
+               -XPOST -s https://127.0.0.1:8443/api/logs/v1/test-oidc/loki/api/v1/push --data-raw \
                "{\"streams\": [{ \"stream\": { \"__name__\": \"up_test\", \"foo\": \"bar\" }, \"values\": [ [ \"$(date '+%s%N')\", \"log line 1\" ] ] }]}" \
                2> /dev/null && echo $?)
 
 tail_logs=$($WEBSOCAT \
               -b -1 -U -H="Authorization: Bearer $token" \
-              --ws-c-uri=wss://127.0.0.1:8443/api/logs/v1/test-oidc/api/v1/tail\?query=%7Bfoo%3D%22bar%22%2C__name__%3D%22up_test%22%7D  - \
+              --ws-c-uri=wss://127.0.0.1:8443/api/logs/v1/test-oidc/loki/api/v1/tail\?query=%7Bfoo%3D%22bar%22%2C__name__%3D%22up_test%22%7D  - \
               ws-c:cmd:'openssl s_client -connect 127.0.0.1:8443 -CAfile ./tmp/certs/ca.pem -quiet' \
               1> /dev/null && echo $?)
 


### PR DESCRIPTION
This is a follow up to https://github.com/observatorium/api/pull/154 which attempted to fix the failing log tail tests (related issue - https://github.com/observatorium/api/issues/153).

Fixes:
1. Incorrect write / tail paths in the integration test, which where resulting in `404`
2. Removes tracing instrumentation from the tail reverse proxy, which is resulting in another failure, when trying to tail logs via websocket (excerpt):
```
level=debug name=observatorium ts=2021-08-11T09:09:25.089037723Z caller=proxy.go:61 request=mgera.remote.csb/MnzOda8mO5-000071 msg="request to upstream" url="http://127.0.0.1:3100/loki/api/v1/tail?query=%7Bfoo%3D%22bar%22%2C__name__%3D%22up_test%22%7D"
level=warn name=observatorium ts=2021-08-11T09:09:25.090372901Z caller=stdlib.go:89 caller=reverseproxy.go:474 msg="http: proxy error: internal error: 101 switching protocols response with non-writable body"
level=warn name=observatorium ts=2021-08-11T09:09:25.090573351Z caller=instrumentation.go:33 request=mgera.remote.csb/MnzOda8mO5-000071 proto=HTTP/1.1 method=GET status=502 content= path=/api/logs/v1/test-oidc/loki/api/v1/tail duration=2.038642ms bytes=0
websocat: WebSocketError: Received unexpected status code (502 Bad Gateway)
websocat: error running
```

See also comment https://github.com/observatorium/api/pull/154#issuecomment-880394076

cc @periklis 