### PR TITLE
Dockerfile: Add mistakenly dropped labels again

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,24 @@ ARG VERSION
 ARG VCS_REF
 ARG DOCKERFILE_PATH
 
+LABEL vendor="Observatorium" \
+    name="observatorium/api" \
+    description="Observatorium API" \
+    io.k8s.display-name="observatorium/api" \
+    io.k8s.description="Observatorium API" \
+    maintainer="Observatorium <team-monitoring@redhat.com>" \
+    version="$VERSION" \
+    org.label-schema.build-date=$BUILD_DATE \
+    org.label-schema.description="Observatorium API" \
+    org.label-schema.docker.cmd="docker run --rm observatorium/api" \
+    org.label-schema.docker.dockerfile=$DOCKERFILE_PATH \
+    org.label-schema.name="observatorium/api" \
+    org.label-schema.schema-version="1.0" \
+    org.label-schema.vcs-branch=$VCS_BRANCH \
+    org.label-schema.vcs-ref=$VCS_REF \
+    org.label-schema.vcs-url="https://github.com/observatorium/api" \
+    org.label-schema.vendor="observatorium/api" \
+    org.label-schema.version=$VERSION
+
+
 ENTRYPOINT ["/bin/observatorium-api"]


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

The labels were dropped by mistake in https://github.com/observatorium/api/pull/160. This PR re-adds them.