### PR TITLE
Update CircleCI machine image to fix Docker image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
 
   container-push:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202107-02
     steps:
       - checkout
       - run: |
@@ -61,7 +61,7 @@ jobs:
 
   container-release:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202107-02
     steps:
       - checkout
       - run: |


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

It seems that after https://github.com/observatorium/api/pull/166, pushing images to Quay is broken (see failed workflow https://app.circleci.com/pipelines/github/observatorium/api/164/workflows/12129f16-5980-4887-9bc0-7a14451105d9/jobs/710). 

This is due to change in the version of Alpine image used, see discussion https://discuss.circleci.com/t/unable-to-use-make/40552/2.

To fix the issue, this PR updates the image used by the CircleCI machine executor to the latest Ubuntu image, which includes the required minimal Docker version (which is [`v20.10.7`](https://circleci.com/docs/2.0/configuration-reference/#available-machine-images); per [Alpine notes](https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.14.0#faccessat2) minimum required is `v20.10.0`).