### PR TITLE
metrics: Added labels + series methods to tenancy isolated paths.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,7 @@ linters-settings:
   errcheck:
     exclude: .errcheck_excludes
   lll:
-    line-length: 140
+    line-length: 160
   funlen:
-    lines: 120
+    lines: 140
     statements: 60

--- a/Makefile
+++ b/Makefile
@@ -120,7 +120,7 @@ proto: ratelimit/gubernator/proto/google ratelimit/gubernator/gubernator.proto $
 container-test: build
 	@docker build \
 		-f Dockerfile.e2e-test \
-		-t $(DOCKER_REPO):latest .
+		-t $(DOCKER_REPO):local_e2e_test .
 
 .PHONY: container
 container: Dockerfile

--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -40,36 +40,36 @@ func Logger(logger log.Logger) HandlerOption {
 	}
 }
 
-// Registry adds a custom Prometheus registry for the handler to use.
-func Registry(r *prometheus.Registry) HandlerOption {
+// WithRegistry adds a custom Prometheus registry for the handler to use.
+func WithRegistry(r *prometheus.Registry) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.registry = r
 	}
 }
 
-// HandlerInstrumenter adds a custom HTTP handler instrument middleware for the handler to use.
-func HandlerInstrumenter(instrumenter handlerInstrumenter) HandlerOption {
+// WithHandlerInstrumenter adds a custom HTTP handler instrument middleware for the handler to use.
+func WithHandlerInstrumenter(instrumenter handlerInstrumenter) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.instrument = instrumenter
 	}
 }
 
-// SpanRoutePrefix adds a prefix before the value of route tag in tracing spans.
-func SpanRoutePrefix(spanRoutePrefix string) HandlerOption {
+// WithSpanRoutePrefix adds a prefix before the value of route tag in tracing spans.
+func WithSpanRoutePrefix(spanRoutePrefix string) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.spanRoutePrefix = spanRoutePrefix
 	}
 }
 
-// ReadMiddleware adds a middleware for all read operations.
-func ReadMiddleware(m func(http.Handler) http.Handler) HandlerOption {
+// WithReadMiddleware adds a middleware for all read operations.
+func WithReadMiddleware(m func(http.Handler) http.Handler) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.readMiddlewares = append(h.readMiddlewares, m)
 	}
 }
 
-// WriteMiddleware adds a middleware for all write operations.
-func WriteMiddleware(m func(http.Handler) http.Handler) HandlerOption {
+// WithWriteMiddleware adds a middleware for all write operations.
+func WithWriteMiddleware(m func(http.Handler) http.Handler) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.writeMiddlewares = append(h.writeMiddlewares, m)
 	}

--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -20,11 +20,22 @@ const (
 	writeTimeout = time.Minute
 )
 
+const (
+	uiRoute          = "/"
+	queryRoute       = "/api/v1/query"
+	queryRangeRoute  = "/api/v1/query_range"
+	seriesRoute      = "/api/v1/series"
+	labelNamesRoute  = "/api/v1/labels"
+	labelValuesRoute = "/api/v1/label/{label_name}/values"
+	receiveRoute     = "/api/v1/receive"
+)
+
 type handlerConfiguration struct {
 	logger           log.Logger
 	registry         *prometheus.Registry
 	instrument       handlerInstrumenter
 	spanRoutePrefix  string
+	queryMiddlewares []func(http.Handler) http.Handler
 	readMiddlewares  []func(http.Handler) http.Handler
 	uiMiddlewares    []func(http.Handler) http.Handler
 	writeMiddlewares []func(http.Handler) http.Handler
@@ -33,50 +44,57 @@ type handlerConfiguration struct {
 // HandlerOption modifies the handler's configuration.
 type HandlerOption func(h *handlerConfiguration)
 
-// Logger add a custom logger for the handler to use.
-func Logger(logger log.Logger) HandlerOption {
+// WithLogger add a custom logger for the handler to use.
+func WithLogger(logger log.Logger) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.logger = logger
 	}
 }
 
-// Registry adds a custom Prometheus registry for the handler to use.
-func Registry(r *prometheus.Registry) HandlerOption {
+// WithRegistry adds a custom Prometheus registry for the handler to use.
+func WithRegistry(r *prometheus.Registry) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.registry = r
 	}
 }
 
-// HandlerInstrumenter adds a custom HTTP handler instrument middleware for the handler to use.
-func HandlerInstrumenter(instrumenter handlerInstrumenter) HandlerOption {
+// WithHandlerInstrumenter adds a custom HTTP handler instrument middleware for the handler to use.
+func WithHandlerInstrumenter(instrumenter handlerInstrumenter) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.instrument = instrumenter
 	}
 }
 
-// SpanRoutePrefix adds a prefix before the value of route tag in tracing spans.
-func SpanRoutePrefix(spanRoutePrefix string) HandlerOption {
+// WithSpanRoutePrefix adds a prefix before the value of route tag in tracing spans.
+func WithSpanRoutePrefix(spanRoutePrefix string) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.spanRoutePrefix = spanRoutePrefix
 	}
 }
 
-// ReadMiddleware adds a middleware for all read operations.
-func ReadMiddleware(m func(http.Handler) http.Handler) HandlerOption {
+// WithReadMiddleware adds a middleware for all "matcher based" read operations (series, label names and values).
+func WithReadMiddleware(m func(http.Handler) http.Handler) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.readMiddlewares = append(h.readMiddlewares, m)
 	}
 }
 
-// UIMiddleware adds a middleware for all ui operations.
-func UIMiddleware(m func(http.Handler) http.Handler) HandlerOption {
+// WithQueryMiddleware adds a middleware for all query operations.
+func WithQueryMiddleware(m func(http.Handler) http.Handler) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.queryMiddlewares = append(h.queryMiddlewares, m)
+	}
+}
+
+// WithUIMiddleware adds a middleware for all non read, non query, non write operations (e.g ui).
+func WithUIMiddleware(m func(http.Handler) http.Handler) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.uiMiddlewares = append(h.uiMiddlewares, m)
 	}
 }
 
-// WriteMiddleware adds a middleware for all write operations.
-func WriteMiddleware(m func(http.Handler) http.Handler) HandlerOption {
+// WithWriteMiddleware adds a middleware for all write operations.
+func WithWriteMiddleware(m func(http.Handler) http.Handler) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.writeMiddlewares = append(h.writeMiddlewares, m)
 	}
@@ -88,7 +106,7 @@ type handlerInstrumenter interface {
 
 type nopInstrumentHandler struct{}
 
-func (n nopInstrumentHandler) NewHandler(labels prometheus.Labels, handler http.Handler) http.HandlerFunc {
+func (n nopInstrumentHandler) NewHandler(_ prometheus.Labels, handler http.Handler) http.HandlerFunc {
 	return handler.ServeHTTP
 }
 
@@ -107,6 +125,39 @@ func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
 	r := chi.NewRouter()
 
 	if read != nil {
+		var proxyQuery http.Handler
+		{
+			middlewares := proxy.Middlewares(
+				proxy.MiddlewareSetUpstream(read),
+				proxy.MiddlewareSetPrefixHeader(),
+				proxy.MiddlewareLogger(c.logger),
+				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "metricsv1-query"}),
+			)
+
+			proxyQuery = &httputil.ReverseProxy{
+				Director: middlewares,
+				ErrorLog: proxy.Logger(c.logger),
+				Transport: otelhttp.NewTransport(
+					&http.Transport{
+						DialContext: (&net.Dialer{
+							Timeout: readTimeout,
+						}).DialContext,
+					},
+				),
+			}
+		}
+		r.Group(func(r chi.Router) {
+			r.Use(c.queryMiddlewares...)
+			r.Handle(queryRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "metricsv1", "handler": "query"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+queryRoute, proxyQuery),
+			))
+			r.Handle(queryRangeRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "metricsv1", "handler": "query_range"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+queryRangeRoute, proxyQuery),
+			))
+		})
+
 		var proxyRead http.Handler
 		{
 			middlewares := proxy.Middlewares(
@@ -130,18 +181,17 @@ func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
 		}
 		r.Group(func(r chi.Router) {
 			r.Use(c.readMiddlewares...)
-			const (
-				queryRoute      = "/api/v1/query"
-				queryRangeRoute = "/api/v1/query_range"
-			)
-
-			r.Handle(queryRoute, c.instrument.NewHandler(
-				prometheus.Labels{"group": "metricsv1", "handler": "query"},
-				otelhttp.WithRouteTag(c.spanRoutePrefix+queryRoute, proxyRead),
+			r.Handle(seriesRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "metricsv1", "handler": "series"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+seriesRoute, proxyRead),
 			))
-			r.Handle(queryRangeRoute, c.instrument.NewHandler(
-				prometheus.Labels{"group": "metricsv1", "handler": "query_range"},
-				otelhttp.WithRouteTag(c.spanRoutePrefix+queryRangeRoute, proxyRead),
+			r.Handle(labelNamesRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "metricsv1", "handler": "label_names"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+labelNamesRoute, proxyRead),
+			))
+			r.Handle(labelValuesRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "metricsv1", "handler": "label_values"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+labelValuesRoute, proxyRead),
 			))
 		})
 
@@ -161,8 +211,6 @@ func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
 		}
 		r.Group(func(r chi.Router) {
 			r.Use(c.uiMiddlewares...)
-			const uiRoute = "/"
-
 			r.Mount(uiRoute, c.instrument.NewHandler(
 				prometheus.Labels{"group": "metricsv1", "handler": "ui"},
 				otelhttp.WithRouteTag(c.spanRoutePrefix+uiRoute, uiProxy),
@@ -194,7 +242,6 @@ func NewHandler(read, write *url.URL, opts ...HandlerOption) http.Handler {
 		}
 		r.Group(func(r chi.Router) {
 			r.Use(c.writeMiddlewares...)
-			const receiveRoute = "/api/v1/receive"
 			r.Handle(receiveRoute, c.instrument.NewHandler(
 				prometheus.Labels{"group": "metricsv1", "handler": "receive"},
 				otelhttp.WithRouteTag(c.spanRoutePrefix+receiveRoute, proxyWrite),

--- a/main.go
+++ b/main.go
@@ -474,7 +474,7 @@ func main() {
 			}
 			r.Mount("/oidc/{tenant}", oh.Router())
 
-			// Metrics
+			// Metrics.
 			if cfg.metrics.enabled {
 				r.Group(func(r chi.Router) {
 					r.Use(authentication.WithTenantMiddlewares(oh.GetTenantMiddleware, mTLSMiddlewareFunc))
@@ -498,13 +498,13 @@ func main() {
 					r.Mount("/api/v1/{tenant}",
 						metricslegacy.NewHandler(
 							cfg.metrics.readEndpoint,
-							metricslegacy.Logger(logger),
-							metricslegacy.Registry(reg),
-							metricslegacy.HandlerInstrumenter(ins),
-							metricslegacy.SpanRoutePrefix("/api/v1/{tenant}"),
-							metricslegacy.ReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
-							metricslegacy.ReadMiddleware(metricsv1.WithEnforceTenantLabel(cfg.metrics.tenantLabel)),
-							metricslegacy.UIMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
+							metricslegacy.WithLogger(logger),
+							metricslegacy.WithRegistry(reg),
+							metricslegacy.WithHandlerInstrumenter(ins),
+							metricslegacy.WithSpanRoutePrefix("/api/v1/{tenant}"),
+							metricslegacy.WithQueryMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
+							metricslegacy.WithQueryMiddleware(metricsv1.WithEnforceTenancyOnQuery(cfg.metrics.tenantLabel)),
+							metricslegacy.WithUIMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
 						),
 					)
 
@@ -513,21 +513,23 @@ func main() {
 							metricsv1.NewHandler(
 								cfg.metrics.readEndpoint,
 								cfg.metrics.writeEndpoint,
-								metricsv1.Logger(logger),
-								metricsv1.Registry(reg),
-								metricsv1.HandlerInstrumenter(ins),
-								metricsv1.SpanRoutePrefix("/api/metrics/v1/{tenant}"),
-								metricsv1.ReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
-								metricsv1.ReadMiddleware(metricsv1.WithEnforceTenantLabel(cfg.metrics.tenantLabel)),
-								metricsv1.UIMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
-								metricsv1.WriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "metrics")),
+								metricsv1.WithLogger(logger),
+								metricsv1.WithRegistry(reg),
+								metricsv1.WithHandlerInstrumenter(ins),
+								metricsv1.WithSpanRoutePrefix("/api/metrics/v1/{tenant}"),
+								metricsv1.WithQueryMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
+								metricsv1.WithQueryMiddleware(metricsv1.WithEnforceTenancyOnQuery(cfg.metrics.tenantLabel)),
+								metricsv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
+								metricsv1.WithReadMiddleware(metricsv1.WithEnforceTenancyOnMatchers(cfg.metrics.tenantLabel)),
+								metricsv1.WithUIMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "metrics")),
+								metricsv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "metrics")),
 							),
 						),
 					)
 				})
 			}
 
-			// Logs
+			// Logs.
 			if cfg.logs.enabled {
 				r.Group(func(r chi.Router) {
 					r.Use(authentication.WithTenantMiddlewares(oh.GetTenantMiddleware, mTLSMiddlewareFunc))
@@ -540,11 +542,11 @@ func main() {
 								cfg.logs.tailEndpoint,
 								cfg.logs.writeEndpoint,
 								logsv1.Logger(logger),
-								logsv1.Registry(reg),
-								logsv1.HandlerInstrumenter(ins),
-								logsv1.SpanRoutePrefix("/api/logs/v1/{tenant}"),
-								logsv1.ReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "logs")),
-								logsv1.WriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "logs")),
+								logsv1.WithRegistry(reg),
+								logsv1.WithHandlerInstrumenter(ins),
+								logsv1.WithSpanRoutePrefix("/api/logs/v1/{tenant}"),
+								logsv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "logs")),
+								logsv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "logs")),
 							),
 						),
 					)

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	apiImage = "quay.io/observatorium/api:latest"
+	apiImage = "quay.io/observatorium/api:local_e2e_test" // Image that is built if you run `make container-test`.
 
-	thanosImage = "quay.io/thanos/thanos:v0.22.0"
+	// Labels matching below thanos v0.24 will fail with "no matchers specified (excluding external labels)" if you specify only tenant matcher. Fixed later on.
+	thanosImage = "quay.io/thanos/thanos:main-2021-09-23-177b4f23"
 	lokiImage   = "grafana/loki:2.3.0"
 	upImage     = "quay.io/observatorium/up:master-2021-02-12-03ef2f2"
 


### PR DESCRIPTION
Also:
* Renamed all option function to `With...`.
* Extended tests to test new methods.
* Moved to special docker tag (local_e2e_test) so we don't by mistake run e2e tests against some random latest
image.

Before changes tests were failing with (zero isolation):

```
    	exp: v1.Warnings{"No StoreAPIs matched for this query"}

        	got: v1.Warnings(nil)
```

Signed-off-by: Bartlomiej Plotka <bwplotka@gmail.com>