### PR TITLE
metrics and logs should be disabled by default

### DIFF
--- a/main.go
+++ b/main.go
@@ -726,7 +726,16 @@ func parseFlags() (config, error) {
 		rawTracingEndpointType  string
 	)
 
-	cfg := config{}
+	// if at least one metrics/logs endpoint (read or write) is set
+	// metrics/logs will be enabled.
+	cfg := config{
+		metrics: metricsConfig{
+			enabled: false,
+		},
+		logs: logsConfig{
+			enabled: false,
+		},
+	}
 
 	flag.StringVar(&cfg.rbacConfigPath, "rbac.config", "rbac.yaml",
 		"Path to the RBAC configuration file.")


### PR DESCRIPTION
this is a bug fix, iniitially, metrics and logs should be disabled,
enable them iff at least one endpoint of each is set.