### PR TITLE
Respond with status OK on root path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/metalmatze/signal v0.0.0-20201002154727-d0c16e42a3cf
+	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a
 	github.com/oklog/run v1.1.0
 	github.com/open-policy-agent/opa v0.23.2
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -733,8 +733,8 @@ github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4f
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/metalmatze/signal v0.0.0-20201002154727-d0c16e42a3cf h1:g30K3kg3GSpKUn4ShNPrCpL4s9sePqmyu5e0K2O4nxA=
-github.com/metalmatze/signal v0.0.0-20201002154727-d0c16e42a3cf/go.mod h1:3OETvrxfELvGsU2RoGGWercfeZ4bCL3+SOwzIWtJH/Q=
+github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a h1:0usWxe5SGXKQovz3p+BiQ81Jy845xSMu2CWKuXsXuUM=
+github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a/go.mod h1:3OETvrxfELvGsU2RoGGWercfeZ4bCL3+SOwzIWtJH/Q=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.22/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=

--- a/main.go
+++ b/main.go
@@ -398,7 +398,7 @@ func main() {
 					&http.Client{Transport: t},
 					cfg.server.healthcheckURL,
 					http.MethodGet,
-					http.StatusNotFound,
+					http.StatusOK,
 					time.Second,
 				),
 			)
@@ -646,6 +646,10 @@ func main() {
 				cancel()
 			})
 		}
+
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
 
 		s := http.Server{
 			Addr:         cfg.server.listen,


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Small change that makes the API respond with `200` on root path `/` instead of current `404`. This is in order to enable us to do some basic closed-box checking, to differentiate between 'real' not found case and case where API is actually serving.

Also bumps the version for `signal` package used in internal server instantiation.