### PR TITLE
List available paths on root path

### DIFF
--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -35,7 +35,7 @@ func onboardNewProvider(providerType string, factory ProviderFactory) {
 // authentication provider.
 type ProviderFactory func(config map[string]interface{}, tenant string, registrationRetryCount *prometheus.CounterVec, logger log.Logger) (Provider, error)
 
-// Provider is an interface that should be implemented to onboard a new authentication.
+// Provider is an interface that should be implemented to onboard a new authentication
 // provider.
 type Provider interface {
 	Middleware() Middleware
@@ -63,7 +63,7 @@ func NewProviderManager(l log.Logger, registrationRetryCount *prometheus.Counter
 	}
 }
 
-// NewTenantAuthenticator initializes an authenticator provider and register the created
+// InitializeProvider initializes an authenticator provider and register the created
 // authentication middleware and handler.
 func (ah *ProviderManager) InitializeProvider(config map[string]interface{},
 	tenant string, authenticatorType string, registrationRetryCount *prometheus.CounterVec, logger log.Logger) chan Provider {
@@ -102,6 +102,7 @@ func (ah *ProviderManager) InitializeProvider(config map[string]interface{},
 	return authCh
 }
 
+// Middleware returns an authentication middleware for a tenant.
 func (ah *ProviderManager) Middlewares(tenant string) (Middleware, bool) {
 	ah.mtx.RLock()
 	mw, ok := ah.middlewares[tenant]
@@ -110,6 +111,7 @@ func (ah *ProviderManager) Middlewares(tenant string) (Middleware, bool) {
 	return mw, ok
 }
 
+// PatternHandler return an http.HandlerFunc for a corresponding pattern.
 func (ah *ProviderManager) PatternHandler(pattern string) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tenant, ok := GetTenant(r.Context())

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gorilla/websocket v1.4.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
-	github.com/metalmatze/signal v0.0.0-20201002154727-d0c16e42a3cf
+	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/oklog/run v1.1.0
 	github.com/open-policy-agent/opa v0.23.2

--- a/go.sum
+++ b/go.sum
@@ -734,8 +734,8 @@ github.com/mattn/go-tty v0.0.0-20180907095812-13ff1204f104/go.mod h1:XPvLUNfbS4f
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/metalmatze/signal v0.0.0-20201002154727-d0c16e42a3cf h1:g30K3kg3GSpKUn4ShNPrCpL4s9sePqmyu5e0K2O4nxA=
-github.com/metalmatze/signal v0.0.0-20201002154727-d0c16e42a3cf/go.mod h1:3OETvrxfELvGsU2RoGGWercfeZ4bCL3+SOwzIWtJH/Q=
+github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a h1:0usWxe5SGXKQovz3p+BiQ81Jy845xSMu2CWKuXsXuUM=
+github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a/go.mod h1:3OETvrxfELvGsU2RoGGWercfeZ4bCL3+SOwzIWtJH/Q=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.22/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=

--- a/main.go
+++ b/main.go
@@ -387,7 +387,7 @@ func main() {
 					&http.Client{Transport: t},
 					cfg.server.healthcheckURL,
 					http.MethodGet,
-					http.StatusNotFound,
+					http.StatusOK,
 					time.Second,
 				),
 			)
@@ -602,6 +602,8 @@ func main() {
 				cancel()
 			})
 		}
+
+		r.Get("/", server.PathsHandlerFunc(logger, r.Routes()))
 
 		s := http.Server{
 			Addr:         cfg.server.listen,

--- a/server/paths.go
+++ b/server/paths.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/go-chi/chi"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+// PathsHandlerFunc lists all paths available from the provided routes.
+func PathsHandlerFunc(logger log.Logger, routes []chi.Route) http.HandlerFunc {
+	paths := make([]string, 0, len(routes))
+	for _, r := range routes {
+		paths = append(paths, r.Pattern)
+	}
+
+	pathsStruct := struct {
+		Paths []string `json:"paths"`
+	}{
+		Paths: paths,
+	}
+
+	return func(w http.ResponseWriter, r *http.Request) {
+		externalPathJSON, err := json.MarshalIndent(pathsStruct, "", "  ")
+		if err != nil {
+			level.Error(logger).Log("msg", "failed to marshal paths input to JSON", "err", err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+
+		w.Header().Add("Content-Type", "application/json")
+		if _, err := w.Write(externalPathJSON); err != nil {
+			level.Error(logger).Log("msg", "could not write external paths", "err", err.Error())
+		}
+	}
+}


### PR DESCRIPTION
This PR adds a new handler for `/` to return a list of available API paths. The purpose of this is to improve discoverability of the API paths and to improve the user experience.

The changes also including bumping the `signal` packaged user for internal server and adds some missing docs.