### PR TITLE
OIDC Auth: Redirect to a valid URL after `/callback`

### DIFF
--- a/authentication/oidc.go
+++ b/authentication/oidc.go
@@ -149,6 +149,7 @@ func newOIDCAuthenticator(c map[string]interface{}, tenant string,
 		verifier:     verifier,
 		client:       client,
 		cookieName:   fmt.Sprintf("observatorium_%s", tenant),
+		redirectURL:  path.Join("/", tenant),
 	}
 
 	r := chi.NewRouter()


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Currently, if a user goes through the authentication flow in the browser, the last step is to call `/callback` endpooint, which subsequently redirects user further with authentication set up. However, at the moment we are not setting any redirect URL, causing the user to end up at route `/oidc/{tenant}`, which does not exist.

This PR adjusts the flow to redirect the user to `/{tenant}` which in turn redirects to the Thanos UI (`/graph` endpoint), which is much better user experience.

Tested locally.

