### PR TITLE
api/metrics/v1: fix rules panic

### DIFF
--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -21,7 +21,13 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := rh.client.ListRules(r.Context(), tenant)
 	if err != nil {
-		http.Error(w, "error listing rules %w", resp.StatusCode)
+		sc := http.StatusInternalServerError
+		if resp != nil {
+			sc = resp.StatusCode
+		}
+
+		http.Error(w, "error listing rules", sc)
+
 		return
 	}
 
@@ -41,7 +47,14 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 
 	resp, err := rh.client.SetRulesWithBody(r.Context(), tenant, r.Header.Get("Content-type"), r.Body)
 	if err != nil {
-		http.Error(w, "error creating rules %w", resp.StatusCode)
+		sc := http.StatusInternalServerError
+		if resp != nil {
+			sc = resp.StatusCode
+		}
+
+		http.Error(w, "error creating rules", sc)
+
+		return
 	}
 
 	defer resp.Body.Close()


### PR DESCRIPTION
This commit fixes two bugs where a failed HTTP request from the rules
client can cause a panic in the Observatorium API.
1. status codes were read prematurely when the HTTP response may have
   been nil, causing a panic; and
2. the set handler did not return after a failed request, causing the
   HTTP response to be set twice.
It also fixes a formatting bug in the HTTP status where an extraneous
`%w` was printed.

Signed-off-by: Lucas Servén Marín <lserven@gmail.com>