### PR TITLE
Makefile: Adjust `container-test` target to work for MacOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,10 +122,18 @@ proto: ratelimit/gubernator/proto/google ratelimit/gubernator/gubernator.proto $
 	PATH=$$PATH:$(BIN_DIR):$(FIRST_GOPATH)/bin scripts/generate_proto.sh
 
 .PHONY: container-test
+container-test: # Use 'shortcut' to build test image if on Linux, otherwise full build.
+ifeq ($(OS)_$(ARCH), linux_x86_64)
 container-test: build
 	@docker build \
 		-f Dockerfile.e2e-test \
 		-t $(DOCKER_REPO):local_e2e_test .
+else
+container-test:
+	@docker build \
+		-f Dockerfile \
+		-t $(DOCKER_REPO):local_e2e_test .
+endif
 
 .PHONY: container
 container: Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -123,7 +123,7 @@ proto: ratelimit/gubernator/proto/google ratelimit/gubernator/gubernator.proto $
 
 .PHONY: container-test
 container-test: # Use 'shortcut' to build test image if on Linux, otherwise full build.
-ifeq ($(OS)_$(ARCH), linux_x86_64)
+ifeq ($(OS), linux)
 container-test: build
 	@docker build \
 		-f Dockerfile.e2e-test \


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

We have a report that running the interactive and E2E tests does not work on MacOS, which is due to the fact that we use single stage Docker build for local tests and simply copy the built API binary into the image. This does not work for e.g. MacOS users.

The fix is to use the 'full' build for other OS users and build the API for right platform instead of copying the binary.

Resolves #189.