### PR TITLE
Debug problems of authorization

### DIFF
--- a/authorization/http.go
+++ b/authorization/http.go
@@ -75,7 +75,8 @@ func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Per
 
 			statusCode, ok, data := a.Authorize(subject, groups, permission, resource, tenant, tenantID, token)
 			if !ok {
-				http.Error(w, "authorization declined", statusCode)
+				// Send 403 http.StatusForbidden
+				w.WriteHeader(statusCode)
 
 				return
 			}

--- a/authorization/http.go
+++ b/authorization/http.go
@@ -75,7 +75,7 @@ func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Per
 
 			statusCode, ok, data := a.Authorize(subject, groups, permission, resource, tenant, tenantID, token)
 			if !ok {
-				w.WriteHeader(statusCode)
+				http.Error(w, "authorization declined", statusCode)
 
 				return
 			}

--- a/main.go
+++ b/main.go
@@ -329,7 +329,7 @@ func main() {
 			stdlog.Fatalf("cannot read RBAC configuration file from path %q: %v", cfg.rbacConfigPath, err)
 		}
 		defer f.Close()
-		if authorizer, err = rbac.Parse(f); err != nil {
+		if authorizer, err = rbac.Parse(f, logger); err != nil {
 			stdlog.Fatalf("unable to read RBAC YAML: %v", err)
 		}
 	}

--- a/rbac/rbac.go
+++ b/rbac/rbac.go
@@ -190,8 +190,5 @@ func Parse(r io.Reader, logger log.Logger) (Authorizer, error) {
 		return nil, fmt.Errorf("could not parse RBAC data: %w", err)
 	}
 
-	level.Debug(logger).Log("msg",
-		fmt.Sprintf("RBAC roles %#v; role bindings %#v",
-			rbac.Roles, rbac.RoleBindings))
 	return NewAuthorizer(rbac.Roles, rbac.RoleBindings, logger), nil
 }

--- a/rbac/rbac.go
+++ b/rbac/rbac.go
@@ -71,11 +71,13 @@ func (rs resources) Authorize(subject string, groups []string, permission Permis
 	tenantID, token string) (int, bool, string) {
 	ts, ok := rs[resource]
 	if !ok {
+		fmt.Printf("TODO LOG AT DEBUG authorization resource %q unknown; valid resources are %v\n", resource, rs)
 		return http.StatusForbidden, false, ""
 	}
 
 	t, ok := ts[tenant]
 	if !ok {
+		fmt.Printf("TODO LOG AT DEBUG tenant %q unknown; valid tenants are %v\n", tenant, ts)
 		return http.StatusForbidden, false, ""
 	}
 
@@ -100,6 +102,7 @@ func (rs resources) Authorize(subject string, groups []string, permission Permis
 		}
 	}
 
+	fmt.Printf("TODO LOG AT DEBUG subject %q unknown; groups %v unknown\n", subject, groups)
 	return http.StatusForbidden, false, ""
 }
 

--- a/rbac/rbac.go
+++ b/rbac/rbac.go
@@ -86,6 +86,7 @@ func (rs resources) Authorize(subject string, groups []string, permission Permis
 		level.Debug(rs.logger).Log("msg",
 			fmt.Sprintf("authorization: tenant %q unknown (%d valid tenants for resource %q)",
 				tenant, len(ts), resource))
+
 		return http.StatusForbidden, false, ""
 	}
 
@@ -113,6 +114,7 @@ func (rs resources) Authorize(subject string, groups []string, permission Permis
 	level.Debug(rs.logger).Log("msg",
 		fmt.Sprintf("authorization: %q unknown; groups %v unknown",
 			subject, groups))
+
 	return http.StatusForbidden, false, ""
 }
 

--- a/rbac/rbac_test.go
+++ b/rbac/rbac_test.go
@@ -3,6 +3,8 @@ package rbac
 import (
 	"net/http"
 	"testing"
+
+	"github.com/observatorium/api/logger"
 )
 
 // nolint:dupl,funlen,scopelint
@@ -1013,7 +1015,7 @@ func TestNewAuthorizer(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			a := NewAuthorizer(tc.roles, tc.roleBindings)
+			a := NewAuthorizer(tc.roles, tc.roleBindings, logger.NewLogger("info", logger.LogFormatLogfmt, "observatorium"))
 			for i := range tc.ios {
 				sc, out, data := a.Authorize(tc.ios[i].subject, tc.ios[i].groups, tc.ios[i].permission, tc.ios[i].resource,
 					tc.ios[i].tenant, tc.ios[i].tenantID, "")


### PR DESCRIPTION
It is quite difficult to debug 403 problems.  This allows the admin to see the problems.

For example, when I tried to substitute Keycloak as OIDC provider, I must have misconfigured it.  Without this PR, nothing is logged and the user just sees "403".  With this log the user sees "403 authorization declined", which gives a hint to where to look in the code.

The **admin** sees 

```
tenant "test-oidc" unknown; valid tenants are map[test:{map[{admin@example.com user}:{}] map[{admin@example.com user}:{}]}]
```

(Probably this currently logs too much.  That is another TODO)