### PR TITLE
GRPC trace API

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Usage of ./observatorium-api:
     	The percentage of mutex contention events that are reported in the mutex profile. (default 10)
   -debug.name string
     	A name to add as a prefix to log lines. (default "observatorium")
+  -grpc.listen string
+    	The address on which the public gRPC server listens.
   -internal.tracing.endpoint string
     	The full URL of the trace agent or collector. If it's not set, tracing will be disabled.
   -internal.tracing.endpoint-type string
@@ -139,6 +141,12 @@ Usage of ./observatorium-api:
     	File containing the default x509 Certificate for HTTPS. Leave blank to disable TLS.
   -tls.server.key-file string
     	File containing the default x509 private key matching --tls.server.cert-file. Leave blank to disable TLS.
+  -traces.tenant-header string
+    	The name of the HTTP header containing the tenant ID to forward to the logs upstream. (default "X-Tenant")
+  -traces.tls.ca-file string
+    	File containing the TLS CA against which to upstream OTLP trace servers. Leave blank to disable TLS.
+  -traces.write.endpoint string
+    	The endpoint against which to make gRPC write requests for traces.
   -web.healthchecks.url string
     	The URL against which to run healthchecks. (default "http://localhost:8080")
   -web.internal.listen string

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Usage of ./observatorium-api:
   -tls.server.key-file string
     	File containing the default x509 private key matching --tls.server.cert-file. Leave blank to disable TLS.
   -traces.tenant-header string
-    	The name of the HTTP header containing the tenant ID to forward to the logs upstream. (default "X-Tenant")
+    	The name of the HTTP header containing the tenant ID to forward to upstream OpenTelemetry collector. (default "X-Tenant")
   -traces.tls.ca-file string
     	File containing the TLS CA against which to upstream OTLP trace servers. Leave blank to disable TLS.
   -traces.write.endpoint string

--- a/README.md
+++ b/README.md
@@ -143,8 +143,6 @@ Usage of ./observatorium-api:
     	File containing the default x509 private key matching --tls.server.cert-file. Leave blank to disable TLS.
   -traces.tenant-header string
     	The name of the HTTP header containing the tenant ID to forward to upstream OpenTelemetry collector. (default "X-Tenant")
-  -traces.tls.ca-file string
-    	File containing the TLS CA against which to upstream OTLP trace servers. Leave blank to disable TLS.
   -traces.write.endpoint string
     	The endpoint against which to make gRPC write requests for traces.
   -web.healthchecks.url string

--- a/api/traces/v1/api.go
+++ b/api/traces/v1/api.go
@@ -42,7 +42,7 @@ func NewOTelConnection(write string, opts ...ClientOption) (*grpc.ClientConn, er
 	// service supporting opentelemetry.proto.collector.trace.v1.TraceService
 	level.Info(c.logger).Log("msg", "gRPC dialing OTel", "endpoint", write)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	return grpc.DialContext(ctx, write,

--- a/api/traces/v1/api.go
+++ b/api/traces/v1/api.go
@@ -53,7 +53,6 @@ func NewHandler(write string, opts ...HandlerOption) grpcproxy.StreamDirector {
 				// Create the connection lazily, when we first receive a trace to forward
 				level.Info(c.logger).Log("msg", "gRPC dialing OTel collector")
 
-				// TODO test where the keep-alive fails and the connection closes
 				conn, err = grpc.DialContext(ctx, write,
 					// Note that CustomCodec() is deprecated.  The fix for this isn't calling WithDefaultCallOptions(ForceCodec(...)) as suggested,
 					// because the codec we need to register is also deprecated.  A better fix, if Google removes

--- a/api/traces/v1/api.go
+++ b/api/traces/v1/api.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -44,17 +43,11 @@ func NewHandler(write string, opts ...HandlerOption) grpcproxy.StreamDirector {
 	var conn *grpc.ClientConn
 
 	director := func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
-		fmt.Printf("@@@ ecs REACHED NewHandler/director\n")
 		// example method name is /opentelemetry.proto.collector.trace.v1.TraceService/Export
 		// md will include headers and also pseudo-headers such as ":authority"
-		md, ok := metadata.FromIncomingContext(ctx)
-		if !ok {
-			return ctx, nil, status.Error(codes.Internal, "metadata failure")
-		}
+		md, _ := metadata.FromIncomingContext(ctx)
 
-		outCtx, _ := context.WithCancel(ctx) // TODO call cancel function
-		outCtx = metadata.NewOutgoingContext(outCtx, md.Copy())
-		// @@@ outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
+		outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
 
 		if fullMethodName == traceRoute {
 			var err error

--- a/api/traces/v1/api.go
+++ b/api/traces/v1/api.go
@@ -8,6 +8,7 @@ import (
 	grpcproxy "github.com/mwitkow/grpc-proxy/proxy"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 )
@@ -58,7 +59,7 @@ func NewHandler(write string, opts ...HandlerOption) grpcproxy.StreamDirector {
 					// because the codec we need to register is also deprecated.  A better fix, if Google removes
 					// the deprecated type, is https://github.com/mwitkow/grpc-proxy/pull/48
 					grpc.WithCodec(grpcproxy.Codec()), // nolint: staticcheck
-					grpc.WithInsecure(),               // nolint: staticcheck
+					grpc.WithTransportCredentials(insecure.NewCredentials()),
 					grpc.WithBlock())
 
 				if err == nil {

--- a/api/traces/v1/api.go
+++ b/api/traces/v1/api.go
@@ -1,0 +1,90 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	grpcproxy "github.com/mwitkow/grpc-proxy/proxy"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	traceRoute = "/opentelemetry.proto.collector.trace.v1.TraceService/Export"
+)
+
+type handlerConfiguration struct {
+	logger log.Logger
+}
+
+// HandlerOption modifies the handler's configuration.
+type HandlerOption func(h *handlerConfiguration)
+
+// WithLogger add a custom logger for the handler to use.
+func WithLogger(logger log.Logger) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.logger = logger
+	}
+}
+
+// NewHandler creates the new traces v1 handler.
+func NewHandler(write string, opts ...HandlerOption) grpcproxy.StreamDirector {
+	c := &handlerConfiguration{
+		logger: log.NewNopLogger(),
+	}
+
+	for _, o := range opts {
+		o(c)
+	}
+
+	var conn *grpc.ClientConn
+
+	director := func(ctx context.Context, fullMethodName string) (context.Context, *grpc.ClientConn, error) {
+		fmt.Printf("@@@ ecs REACHED NewHandler/director\n")
+		// example method name is /opentelemetry.proto.collector.trace.v1.TraceService/Export
+		// md will include headers and also pseudo-headers such as ":authority"
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return ctx, nil, status.Error(codes.Internal, "metadata failure")
+		}
+
+		outCtx, _ := context.WithCancel(ctx) // TODO call cancel function
+		outCtx = metadata.NewOutgoingContext(outCtx, md.Copy())
+		// @@@ outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
+
+		if fullMethodName == traceRoute {
+			var err error
+
+			if conn == nil {
+				// Create the connection lazily, when we first receive a trace to forward
+				level.Info(c.logger).Log("msg", "gRPC dialing OTel collector")
+
+				conn, err = grpc.DialContext(ctx, write,
+					// Note that CustomCodec() is deprecated.  The fix for this isn't calling WithDefaultCallOptions(ForceCodec(...)) as suggested,
+					// because the codec we need to register is also deprecated.  A better fix, if Google removes
+					// the deprecated type, is https://github.com/mwitkow/grpc-proxy/pull/48
+					grpc.WithCodec(grpcproxy.Codec()), // nolint: staticcheck
+					grpc.WithInsecure(),
+					grpc.WithBlock())
+
+				if err == nil {
+					level.Info(c.logger).Log("msg", "gRPC connected to OTel collector")
+				} else {
+					level.Warn(c.logger).Log("msg", "gRPC did not connect to OTel collector")
+				}
+			}
+
+			return outCtx, conn, err
+		}
+
+		level.Info(c.logger).Log("msg", "gRPC reverse proxy director caught unknown method", "methodName", fullMethodName)
+
+		return outCtx, nil, status.Errorf(codes.Unimplemented, "Unknown method")
+	}
+
+	return director
+}

--- a/api/traces/v1/api.go
+++ b/api/traces/v1/api.go
@@ -61,7 +61,7 @@ func NewHandler(write string, opts ...HandlerOption) grpcproxy.StreamDirector {
 					// because the codec we need to register is also deprecated.  A better fix, if Google removes
 					// the deprecated type, is https://github.com/mwitkow/grpc-proxy/pull/48
 					grpc.WithCodec(grpcproxy.Codec()), // nolint: staticcheck
-					grpc.WithInsecure(),
+					grpc.WithInsecure(),               // nolint: staticcheck
 					grpc.WithBlock())
 
 				if err == nil {

--- a/api/traces/v1/api.go
+++ b/api/traces/v1/api.go
@@ -37,7 +37,7 @@ func NewOTelConnection(write string, opts ...HandlerOption) (*grpc.ClientConn, e
 		o(c)
 	}
 
-	level.Info(c.logger).Log("msg", "gRPC dialing OTel collector")
+	level.Info(c.logger).Log("msg", "gRPC dialing OTel collector", "endpoint", write)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()

--- a/authentication/grpc.go
+++ b/authentication/grpc.go
@@ -1,0 +1,90 @@
+package authentication
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware/v2"
+	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+// GRPCMiddlewareFunc is a function type able to return authentication middleware for
+// a given tenant. If no middleware is found, the second return value should be false.
+type GRPCMiddlewareFunc func(tenant string) (grpc.StreamServerInterceptor, bool)
+
+// WithGRPCTenantHeader returns a new StreamServerInterceptor that adds the tenant and tenantid
+// to the stream Context.
+func WithGRPCTenantHeader(header string, tenantIDs map[string]string) grpc.StreamServerInterceptor {
+	header = strings.ToLower(header)
+
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ctx := ss.Context()
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return fmt.Errorf("gRPC tenant header interceptor: metadata not found")
+		}
+
+		headerTenants := md[header]
+		if len(headerTenants) == 0 {
+			return fmt.Errorf("header %q not set", header)
+		}
+		if len(headerTenants) > 1 {
+			return fmt.Errorf("header %q requested multiple tenants", header)
+		}
+
+		tenant := headerTenants[0]
+		ctx = context.WithValue(ctx, tenantKey, tenant)
+
+		id, ok := tenantIDs[tenant]
+		if !ok {
+			return status.Error(codes.InvalidArgument, "unknown tenant")
+		}
+		ctx = context.WithValue(ctx, tenantIDKey, id)
+
+		wrapped := grpc_middleware.WrapServerStream(ss)
+		wrapped.WrappedContext = ctx
+
+		return handler(srv, wrapped)
+	}
+}
+
+func WithGRPCAccessToken() grpc.StreamServerInterceptor {
+	return grpc_middleware_auth.StreamServerInterceptor(func(ctx context.Context) (context.Context, error) {
+		md, ok := metadata.FromIncomingContext(ctx)
+		if !ok {
+			return nil, status.Error(codes.Internal, "metadata error")
+		}
+		rawTokens := md["authorization"]
+		if len(rawTokens) == 0 {
+			// No header to add to context; it will fail later; but for now we let it pass.
+			return ctx, nil
+		}
+		rawToken := rawTokens[len(rawTokens)-1]
+		token := rawToken[strings.LastIndex(rawToken, " ")+1:]
+		return context.WithValue(ctx, accessTokenKey, token), nil
+	})
+}
+
+// WithGRPCTenantInterceptors creates a single Middleware for all
+// provided tenant-middleware sets.
+func WithGRPCTenantInterceptors(mwFns ...GRPCMiddlewareFunc) grpc.StreamServerInterceptor {
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		tenant, ok := GetTenant(ss.Context())
+		if !ok {
+			return status.Error(codes.InvalidArgument, "error finding tenant")
+		}
+
+		for _, mwFn := range mwFns {
+			if m, ok := mwFn(tenant); ok {
+				return m(srv, ss, info, handler)
+			}
+		}
+
+		return status.Error(codes.PermissionDenied, "tenant not found, have you registered it?")
+	}
+}

--- a/authentication/mtls.go
+++ b/authentication/mtls.go
@@ -10,8 +10,12 @@ import (
 	"net/http"
 
 	"github.com/go-kit/log"
+	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/mitchellh/mapstructure"
 	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 // MTLSAuthenticatorType represents the mTLS authentication provider type.
@@ -141,6 +145,12 @@ func (a MTLSAuthenticator) Middleware() Middleware {
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+func (a MTLSAuthenticator) GRPCMiddleware() grpc.StreamServerInterceptor {
+	return grpc_middleware_auth.StreamServerInterceptor(func(ctx context.Context) (context.Context, error) {
+		return ctx, status.Error(codes.Unimplemented, "internal error")
+	})
 }
 
 func (a MTLSAuthenticator) Handler() (string, http.Handler) {

--- a/authentication/oidc.go
+++ b/authentication/oidc.go
@@ -329,9 +329,7 @@ func (a oidcAuthenticator) GRPCMiddleware() grpc.StreamServerInterceptor {
 			if authorizationHeaders[0] != "" {
 				authorization := strings.Split(authorizationHeaders[0], " ")
 				if len(authorization) != 2 {
-					const msg = "invalid Authorization header"
-					level.Debug(a.logger).Log("msg", msg)
-					return ctx, status.Error(codes.InvalidArgument, msg)
+					return ctx, status.Error(codes.InvalidArgument, "invalid Authorization header")
 				}
 
 				token = authorization[1]
@@ -350,15 +348,12 @@ func (a oidcAuthenticator) GRPCMiddleware() grpc.StreamServerInterceptor {
 func (a oidcAuthenticator) checkAuth(ctx context.Context, token string) (context.Context, string, int, codes.Code) {
 	idToken, err := a.verifier.Verify(oidc.ClientContext(ctx, a.client), token)
 	if err != nil {
-		const msg = "failed to authenticate"
-
-		level.Info(a.logger).Log("msg", msg, "err", err)
-
 		// We tell the user what went wrong.  This is more than the HTTP version did, but
 		// it lets the caller see messages such as
 		// "failed to authenticate: oidc: token is expired (Token Expiry: 2022-02-03 14:05:36 -0500 EST)"
 		// which are super-helpful in troubleshooting.
-		return ctx, fmt.Sprintf("%s: %v", msg, err), http.StatusBadRequest, codes.InvalidArgument
+		return ctx, fmt.Sprintf("%s: %v", "failed to authenticate", err),
+			http.StatusBadRequest, codes.InvalidArgument
 	}
 
 	sub := idToken.Subject

--- a/authentication/openshift.go
+++ b/authentication/openshift.go
@@ -17,12 +17,16 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/golang-jwt/jwt/v4"
+	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/mitchellh/mapstructure"
 	"github.com/observatorium/api/authentication/openshift"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/authentication/authenticator"
 )
@@ -492,6 +496,12 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
+}
+
+func (a OpenShiftAuthenticator) GRPCMiddleware() grpc.StreamServerInterceptor {
+	return grpc_middleware_auth.StreamServerInterceptor(func(ctx context.Context) (context.Context, error) {
+		return ctx, status.Error(codes.Unimplemented, "internal error")
+	})
 }
 
 func (a OpenShiftAuthenticator) Handler() (string, http.Handler) {

--- a/authorization/grpc.go
+++ b/authorization/grpc.go
@@ -13,39 +13,38 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-type MethodName string
-
+// AccessRequirement holds a permission for a particular resource type.
 type AccessRequirement struct {
 	Permission rbac.Permission
-	Resource   string
+	// Resource is typically "logs", "metrics", or "traces"
+	Resource string
 }
 
-type GRPCRBac map[MethodName]AccessRequirement
+// GRPCRBac represents the RBAC requirements for a particular fully-qualified gRPC Method.
+// For example, "opentelemetry.proto.collector.trace.v1.TraceService/Export"
+// requires "write" permission for "traces".
+type GRPCRBac map[string]AccessRequirement
 
 // WithGRPCAuthorizers is the gRPC version of WithAuthorizers
 func WithGRPCAuthorizers(authorizers map[string]rbac.Authorizer, methReq GRPCRBac, logger log.Logger) grpc_middleware_auth.AuthFunc {
 	return func(ctx context.Context) (context.Context, error) {
 		fullMethodName, ok := grpc.Method(ctx)
 		if !ok {
-			level.Warn(logger).Log("msg", "fullMethodName not in context")
 			return ctx, status.Error(codes.Internal, "fullMethodName not in context")
 		}
 
-		accessReq, ok := methReq[MethodName(fullMethodName)]
+		accessReq, ok := methReq[fullMethodName]
 		if !ok {
-			level.Debug(logger).Log("msg", "method never permitted", "method", fullMethodName)
 			return ctx, status.Error(codes.PermissionDenied, "method never permitted")
 		}
 
 		tenant, ok := authentication.GetTenant(ctx)
 		if !ok {
-			level.Debug(logger).Log("msg", "gRPC Authorizer: no tenant")
 			return ctx, status.Error(codes.Internal, "error finding tenant")
 		}
 
 		subject, ok := authentication.GetSubject(ctx)
 		if !ok {
-			level.Debug(logger).Log("msg", "gRPC Authorizer: unknown subject")
 			return ctx, status.Error(codes.PermissionDenied, "unknown subject")
 		}
 
@@ -55,19 +54,16 @@ func WithGRPCAuthorizers(authorizers map[string]rbac.Authorizer, methReq GRPCRBa
 		}
 		a, ok := authorizers[tenant]
 		if !ok {
-			level.Debug(logger).Log("msg", "gRPC Authorizer: unregistered tenant", "tenant", tenant)
 			return ctx, status.Error(codes.Unauthenticated, "error finding tenant")
 		}
 
 		token, ok := authentication.GetAccessToken(ctx)
 		if !ok {
-			level.Debug(logger).Log("msg", "gRPC Authorizer: no access token")
 			return ctx, status.Error(codes.Unauthenticated, "error finding access token")
 		}
 
 		tenantID, ok := authentication.GetTenantID(ctx)
 		if !ok {
-			level.Debug(logger).Log("msg", "gRPC Authorizer: finding tenant id")
 			return ctx, status.Error(codes.Unauthenticated, "error finding tenant id")
 		}
 

--- a/authorization/grpc.go
+++ b/authorization/grpc.go
@@ -1,0 +1,60 @@
+package authorization
+
+import (
+	"context"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
+	"github.com/observatorium/api/authentication"
+	"github.com/observatorium/api/rbac"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// WithGRPCAuthorizers is the gRPC version of WithAuthorizers
+func WithGRPCAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Permission, resource string, logger log.Logger) grpc_middleware_auth.AuthFunc {
+	return func(ctx context.Context) (context.Context, error) {
+		tenant, ok := authentication.GetTenant(ctx)
+		if !ok {
+			level.Debug(logger).Log("msg", "gRPC Authorizer: no tenant")
+			return ctx, status.Error(codes.Internal, "error finding tenant")
+		}
+
+		subject, ok := authentication.GetSubject(ctx)
+		if !ok {
+			level.Debug(logger).Log("msg", "gRPC Authorizer: unknown subject")
+			return ctx, status.Error(codes.PermissionDenied, "unknown subject")
+		}
+
+		groups, ok := authentication.GetGroups(ctx)
+		if !ok {
+			groups = []string{}
+		}
+		a, ok := authorizers[tenant]
+		if !ok {
+			level.Debug(logger).Log("msg", "gRPC Authorizer: unregistered tenant", "tenant", tenant)
+			return ctx, status.Error(codes.Unauthenticated, "error finding tenant")
+		}
+
+		token, ok := authentication.GetAccessToken(ctx)
+		if !ok {
+			level.Debug(logger).Log("msg", "gRPC Authorizer: no access token")
+			return ctx, status.Error(codes.Unauthenticated, "error finding access token")
+		}
+
+		tenantID, ok := authentication.GetTenantID(ctx)
+		if !ok {
+			level.Debug(logger).Log("msg", "gRPC Authorizer: finding tenant id")
+			return ctx, status.Error(codes.Unauthenticated, "error finding tenant id")
+		}
+
+		_, ok, data := a.Authorize(subject, groups, permission, resource, tenant, tenantID, token)
+		if !ok {
+			level.Debug(logger).Log("msg", "gRPC Authorizer: insufficient auth", "subject", subject, "tenant", tenant)
+			return ctx, status.Error(codes.PermissionDenied, "forbidden")
+		}
+
+		return context.WithValue(ctx, authorizationDataKey, data), nil
+	}
+}

--- a/authorization/grpc.go
+++ b/authorization/grpc.go
@@ -8,13 +8,35 @@ import (
 	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/observatorium/api/authentication"
 	"github.com/observatorium/api/rbac"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
+type MethodName string
+
+type AccessRequirement struct {
+	Permission rbac.Permission
+	Resource   string
+}
+
+type GRPCRBac map[MethodName]AccessRequirement
+
 // WithGRPCAuthorizers is the gRPC version of WithAuthorizers
-func WithGRPCAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Permission, resource string, logger log.Logger) grpc_middleware_auth.AuthFunc {
+func WithGRPCAuthorizers(authorizers map[string]rbac.Authorizer, methReq GRPCRBac, logger log.Logger) grpc_middleware_auth.AuthFunc {
 	return func(ctx context.Context) (context.Context, error) {
+		fullMethodName, ok := grpc.Method(ctx)
+		if !ok {
+			level.Warn(logger).Log("msg", "fullMethodName not in context")
+			return ctx, status.Error(codes.Internal, "fullMethodName not in context")
+		}
+
+		accessReq, ok := methReq[MethodName(fullMethodName)]
+		if !ok {
+			level.Debug(logger).Log("msg", "method never permitted", "method", fullMethodName)
+			return ctx, status.Error(codes.PermissionDenied, "method never permitted")
+		}
+
 		tenant, ok := authentication.GetTenant(ctx)
 		if !ok {
 			level.Debug(logger).Log("msg", "gRPC Authorizer: no tenant")
@@ -49,7 +71,7 @@ func WithGRPCAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac
 			return ctx, status.Error(codes.Unauthenticated, "error finding tenant id")
 		}
 
-		_, ok, data := a.Authorize(subject, groups, permission, resource, tenant, tenantID, token)
+		_, ok, data := a.Authorize(subject, groups, accessReq.Permission, accessReq.Resource, tenant, tenantID, token)
 		if !ok {
 			level.Debug(logger).Log("msg", "gRPC Authorizer: insufficient auth", "subject", subject, "tenant", tenant)
 			return ctx, status.Error(codes.PermissionDenied, "forbidden")

--- a/go.mod
+++ b/go.mod
@@ -19,9 +19,11 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20211207221722-a5b9e0b0458c // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a
 	github.com/mitchellh/mapstructure v1.4.3
+	github.com/mwitkow/grpc-proxy v0.0.0-20220126150247-db34e7bfee32 // indirect
 	github.com/oklog/run v1.1.0
 	github.com/onsi/ginkgo v1.16.3 // indirect
 	github.com/onsi/gomega v1.13.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,11 +19,11 @@ require (
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/websocket v1.5.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.3.0
-	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20211207221722-a5b9e0b0458c // indirect
+	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20211207221722-a5b9e0b0458c
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
 	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a
 	github.com/mitchellh/mapstructure v1.4.3
-	github.com/mwitkow/grpc-proxy v0.0.0-20220126150247-db34e7bfee32 // indirect
+	github.com/mwitkow/grpc-proxy v0.0.0-20181017164139-0f1106ef9c76
 	github.com/oklog/run v1.1.0
 	github.com/onsi/ginkgo v1.16.3 // indirect
 	github.com/onsi/gomega v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1012,8 +1012,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-proto-validators v0.0.0-20180403085117-0950a7990007/go.mod h1:m2XC9Qq0AlmmVksL6FktJCdTYyLk7V3fKyp0sl1yWQo=
 github.com/mwitkow/go-proto-validators v0.2.0/go.mod h1:ZfA1hW+UH/2ZHOWvQ3HnQaU0DtnpXu850MZiy+YUgcc=
-github.com/mwitkow/grpc-proxy v0.0.0-20220126150247-db34e7bfee32 h1:CC9KzU7WPrK6DTppkUGiwmttoHCNwOLT7Z+stp1eIpU=
-github.com/mwitkow/grpc-proxy v0.0.0-20220126150247-db34e7bfee32/go.mod h1:MvMXoufZAtqExNexqi4cjrNYE9MefKddKylxjS+//n0=
+github.com/mwitkow/grpc-proxy v0.0.0-20181017164139-0f1106ef9c76 h1:0xuRacu/Zr+jX+KyLLPPktbwXqyOvnOPUQmMLzX1jxU=
+github.com/mwitkow/grpc-proxy v0.0.0-20181017164139-0f1106ef9c76/go.mod h1:x5OoJHDHqxHS801UIuhqGl6QdSAEJvtausosHSdazIo=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
@@ -1590,7 +1590,6 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
-golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
 golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
@@ -1716,7 +1715,6 @@ golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1957,7 +1955,6 @@ google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210331142528-b7513248f0ba/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
-google.golang.org/genproto v0.0.0-20210401141331-865547bb08e2/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210413151531-c14fb6ef47c3/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210510173355-fb37daa5cd7a/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
@@ -2001,6 +1998,7 @@ google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9K
 google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/examples v0.0.0-20210424002626-9572fd6faeae h1:qvsHH4rznMyt8C0umnWLr/oTJPjYrtZ2OMnPZaYLIK8=
 google.golang.org/grpc/examples v0.0.0-20210424002626-9572fd6faeae/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
@@ -2072,7 +2070,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 honnef.co/go/tools v0.1.4 h1:SadWOkti5uVN1FAMgxn165+Mw00fuQKyk4Gyn/inxNQ=
 honnef.co/go/tools v0.1.4/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 k8s.io/api v0.17.5/go.mod h1:0zV5/ungglgy2Rlm3QK8fbxkXVs+BSJWpJP/+8gUVLY=

--- a/go.sum
+++ b/go.sum
@@ -727,6 +727,8 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de
 github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaDEhniwNedqGo9FuLFzppDr3uwI=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0 h1:+9834+KizmvFV7pXQGSXQTsaWhq2GjuNUt0aUU0YBYw=
 github.com/grpc-ecosystem/go-grpc-middleware v1.3.0/go.mod h1:z0ButlSOZa5vEBq9m2m2hlwIgKw+rp3sdCBRoJY+30Y=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20211207221722-a5b9e0b0458c h1:7EiDBX4Vu3/AqgvkV+8IcVLCk20eV52Rtc/rlANuYUg=
+github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.0.0-rc.2.0.20211207221722-a5b9e0b0458c/go.mod h1:hTxjzRcX49ogbTGVJ1sM5mz5s+SSgiGIyL3jjPxl32E=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -1010,6 +1012,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f h1:KUppIJq7/+
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-proto-validators v0.0.0-20180403085117-0950a7990007/go.mod h1:m2XC9Qq0AlmmVksL6FktJCdTYyLk7V3fKyp0sl1yWQo=
 github.com/mwitkow/go-proto-validators v0.2.0/go.mod h1:ZfA1hW+UH/2ZHOWvQ3HnQaU0DtnpXu850MZiy+YUgcc=
+github.com/mwitkow/grpc-proxy v0.0.0-20220126150247-db34e7bfee32 h1:CC9KzU7WPrK6DTppkUGiwmttoHCNwOLT7Z+stp1eIpU=
+github.com/mwitkow/grpc-proxy v0.0.0-20220126150247-db34e7bfee32/go.mod h1:MvMXoufZAtqExNexqi4cjrNYE9MefKddKylxjS+//n0=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=
@@ -1586,8 +1590,10 @@ golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210224082022-3d97a244fca7/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
+golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
+golang.org/x/net v0.0.0-20210423184538-5f58ad60dda6/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210510120150-4163338589ed/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -1710,6 +1716,7 @@ golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210331175145-43e1dd70ce54/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210420072515-93ed5bcd2bfe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -1937,6 +1944,7 @@ google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEY
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200806141610-86f49bd18e98/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20201109203340-2640f1f9cdfb/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
@@ -1949,6 +1957,7 @@ google.golang.org/genproto v0.0.0-20210303154014-9728d6b83eeb/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210331142528-b7513248f0ba/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
+google.golang.org/genproto v0.0.0-20210401141331-865547bb08e2/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210413151531-c14fb6ef47c3/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/genproto v0.0.0-20210510173355-fb37daa5cd7a/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
@@ -1992,6 +2001,7 @@ google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9K
 google.golang.org/grpc v1.44.0 h1:weqSxi/TMs1SqFRMHCtBgXRs8k3X39QIDEZ0pRcttUg=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
+google.golang.org/grpc/examples v0.0.0-20210424002626-9572fd6faeae/go.mod h1:Ly7ZA/ARzg8fnPU9TyZIxoz33sEUuWX7txiqs8lPTgE=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -2062,6 +2072,7 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 honnef.co/go/tools v0.1.4 h1:SadWOkti5uVN1FAMgxn165+Mw00fuQKyk4Gyn/inxNQ=
 honnef.co/go/tools v0.1.4/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
 k8s.io/api v0.17.5/go.mod h1:0zV5/ungglgy2Rlm3QK8fbxkXVs+BSJWpJP/+8gUVLY=

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -115,7 +115,7 @@ function(params) {
                     '--metrics.write.endpoint=' + api.config.metrics.writeEndpoint,
                   ] + (
                     if std.objectHas(api.config.metrics, 'rulesEndpoint') then [
-                      '--metrics.rules.endpoint=' +  api.config.metrics.rulesEndpoint,
+                      '--metrics.rules.endpoint=' + api.config.metrics.rulesEndpoint,
                     ]
                     else []
                   )

--- a/main.go
+++ b/main.go
@@ -864,8 +864,6 @@ func parseFlags() (config, error) {
 		"The name of the PromQL label that should hold the tenant ID in metrics upstreams.")
 	flag.StringVar(&rawTracesWriteEndpoint, "traces.write.endpoint", "",
 		"The endpoint against which to make gRPC write requests for traces.")
-	flag.StringVar(&cfg.traces.upstreamCAFile, "traces.tls.ca-file", "",
-		"File containing the TLS CA against which to upstream OTLP trace servers. Leave blank to disable TLS.")
 	flag.StringVar(&cfg.traces.tenantHeader, "traces.tenant-header", "X-Tenant",
 		"The name of the HTTP header containing the tenant ID to forward to upstream OpenTelemetry collector.")
 	flag.StringVar(&cfg.tls.serverCertFile, "tls.server.cert-file", "",

--- a/main.go
+++ b/main.go
@@ -215,6 +215,7 @@ func main() {
 	}
 
 	if !cfg.metrics.enabled && !cfg.logs.enabled {
+		// Currently we don't support the case where only the gRPC trace endpoint is enabled
 		stdlog.Fatal("Neither logging nor metrics endpoints are enabled. " +
 			"Specifying at least a logging or a metrics endpoint is mandatory")
 	}
@@ -1060,8 +1061,8 @@ var gRPCRBAC = authorization.GRPCRBac{
 		Permission: rbac.Write,
 		Resource:   "traces",
 	},
-	// TODO(...): Add add trace read permission for Jaeger queries, etc.
-	// TODO(...): Add Loki gRPC methods, etc.
+	// Add trace read permission for Jaeger queries, etc.
+	// Add Loki gRPC methods, etc.
 }
 
 func newGRPCServer(cfg *config, tenantHeader string, tenantIDs map[string]string, pmis authentication.GRPCMiddlewareFunc,

--- a/main.go
+++ b/main.go
@@ -140,9 +140,8 @@ type logsConfig struct {
 }
 
 type tracesConfig struct {
-	writeEndpoint  string
-	upstreamCAFile string
-	tenantHeader   string
+	writeEndpoint string
+	tenantHeader  string
 	// enable traces if writeEndpoint is provided.
 	enabled bool
 }

--- a/main.go
+++ b/main.go
@@ -1063,7 +1063,7 @@ func gRPCServer(cfg *config, tenantHeader string, tenantIDs map[string]string, p
 		// Note that CustomCodec() is deprecated.  The fix for this isn't calling RegisterCodec() as suggested,
 		// because the codec we need to register is also deprecated.  A better fix, if Google removes
 		// the deprecated type, is https://github.com/mwitkow/grpc-proxy/pull/48
-		grpc.CustomCodec(grpcproxy.Codec()),
+		grpc.CustomCodec(grpcproxy.Codec()), // nolint: staticcheck
 		grpc.UnknownServiceHandler(grpcproxy.TransparentHandler(director)),
 		// Authorization (tenant)
 		grpc.ChainStreamInterceptor(


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

This PR creates an Open Telemetry gRPC endpoint for the method `/opentelemetry.proto.collector.trace.v1.TraceService/Export`.  **This proof-of-concept does not (yet) contain RBAC security or tenancy.**  This version uses https://github.com/mwitkow/grpc-proxy to proxy the gRPC without deserializing it.

Previously I created [pull 196](https://github.com/observatorium/api/pull/196) which exposed the OTLP Trace **HTTP** endpoint.  That was straightforward using the Chi-router.

The final implementation needs RBAC and tenancy.  I haven't yet found anything that is the equivalent to the `chi.Router` for gRPC.  Maybe https://github.com/grpc-ecosystem/go-grpc-middleware ?

It is too early to review this code, beyond the architectural ideas and the choice of libraries, parameter names, etc.