### PR TITLE
Replace deprecated gRPC dial option

### DIFF
--- a/ratelimit/client.go
+++ b/ratelimit/client.go
@@ -9,6 +9,7 @@ import (
 	grpc_prometheus "github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/observatorium/api/ratelimit/gubernator"
 )
@@ -43,7 +44,7 @@ func NewClient(reg prometheus.Registerer) *Client {
 		grpc.WithStreamInterceptor(
 			grpc_middleware.ChainStreamClient(grpcMetrics.StreamClientInterceptor()),
 		),
-		grpc.WithInsecure(),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	}
 
 	if reg != nil {


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Seems like one more lint issue went uncaught during previous dependency update - fixing it here to replace deprecated gRPC dial option. See also: https://pkg.go.dev/google.golang.org/grpc#WithInsecure