### PR TITLE
Propagate rules client status code

### DIFF
--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -122,6 +122,8 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 
 	defer resp.Body.Close()
 
+	w.WriteHeader(resp.StatusCode)
+
 	if _, err := io.Copy(w, resp.Body); err != nil {
 		http.Error(w, "error writing rules response", http.StatusInternalServerError)
 		return


### PR DESCRIPTION
Currently, the API returns 200 status codes for all responses of the rules client. So even if the rules file in a PUT request is invalid, API returns 200 with the body `request body failed rule group validation` as observed in #198.

This PR ensures that the correct HTTP status code received from the rules client is propagated by the API, for the `rules/raw` endpoint.

Fixes [MON-2176](https://issues.redhat.com/browse/MON-2176).