### PR TITLE
Enforce tenant labels on rule storage PUT request

### DIFF
--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -13,6 +13,29 @@ import (
 	"github.com/observatorium/api/rules"
 )
 
+func marshalRules(rawRules rules.Rules) ([]byte, error) {
+	body, err := yaml.Marshal(rawRules)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, nil
+}
+
+func unmarshalRules(r io.Reader) (rules.Rules, error) {
+	body, err := ioutil.ReadAll(r)
+	if err != nil {
+		return rules.Rules{}, err
+	}
+
+	var rawRules rules.Rules
+	if err := yaml.Unmarshal(body, &rawRules); err != nil {
+		return rules.Rules{}, err
+	}
+
+	return rawRules, nil
+}
+
 type rulesHandler struct {
 	client      rules.ClientInterface
 	logger      log.Logger
@@ -53,16 +76,10 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	rawRules, err := unmarshalRules(resp.Body)
 	if err != nil {
-		http.Error(w, "error listing rules", http.StatusInternalServerError)
-		return
-	}
-
-	var rawRules rules.Rules
-	if err := yaml.Unmarshal(body, &rawRules); err != nil {
 		level.Error(rh.logger).Log("msg", "could not unmarshal rules", "err", err.Error())
-		http.Error(w, "error unmarshaling rules", http.StatusInternalServerError)
+		http.Error(w, "error unmarshalling rules", http.StatusInternalServerError)
 
 		return
 	}
@@ -94,10 +111,10 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	body, err = yaml.Marshal(rawRules)
+	body, err := marshalRules(rawRules)
 	if err != nil {
-		level.Error(rh.logger).Log("msg", "could not marshal YAML", "err", err.Error())
-		http.Error(w, "error marshaling YAML", http.StatusInternalServerError)
+		level.Error(rh.logger).Log("msg", "could not marshal rules YAML", "err", err.Error())
+		http.Error(w, "error marshaling rules YAML", http.StatusInternalServerError)
 
 		return
 	}
@@ -120,16 +137,10 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	body, err := ioutil.ReadAll(r.Body)
+	rawRules, err := unmarshalRules(r.Body)
 	if err != nil {
-		http.Error(w, "error reading request body", http.StatusInternalServerError)
-		return
-	}
-
-	var rawRules rules.Rules
-	if err := yaml.Unmarshal(body, &rawRules); err != nil {
 		level.Error(rh.logger).Log("msg", "could not unmarshal rules", "err", err.Error())
-		http.Error(w, "error unmarshaling rules", http.StatusInternalServerError)
+		http.Error(w, "error unmarshalling rules", http.StatusInternalServerError)
 
 		return
 	}
@@ -155,10 +166,10 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	body, err = yaml.Marshal(rawRules)
+	body, err := marshalRules(rawRules)
 	if err != nil {
-		level.Error(rh.logger).Log("msg", "could not marshal YAML", "err", err.Error())
-		http.Error(w, "error marshaling YAML", http.StatusInternalServerError)
+		level.Error(rh.logger).Log("msg", "could not marshal rules YAML", "err", err.Error())
+		http.Error(w, "error marshaling rules YAML", http.StatusInternalServerError)
 
 		return
 	}

--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -13,15 +13,6 @@ import (
 	"github.com/observatorium/api/rules"
 )
 
-func marshalRules(rawRules rules.Rules) ([]byte, error) {
-	body, err := yaml.Marshal(rawRules)
-	if err != nil {
-		return nil, err
-	}
-
-	return body, nil
-}
-
 func unmarshalRules(r io.Reader) (rules.Rules, error) {
 	body, err := ioutil.ReadAll(r)
 	if err != nil {
@@ -79,7 +70,7 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 	rawRules, err := unmarshalRules(resp.Body)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not unmarshal rules", "err", err.Error())
-		http.Error(w, "error unmarshalling rules", http.StatusInternalServerError)
+		http.Error(w, "error unmarshaling rules", http.StatusInternalServerError)
 
 		return
 	}
@@ -111,7 +102,7 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	body, err := marshalRules(rawRules)
+	body, err := yaml.Marshal(rawRules)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not marshal rules YAML", "err", err.Error())
 		http.Error(w, "error marshaling rules YAML", http.StatusInternalServerError)
@@ -140,7 +131,7 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 	rawRules, err := unmarshalRules(r.Body)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not unmarshal rules", "err", err.Error())
-		http.Error(w, "error unmarshalling rules", http.StatusInternalServerError)
+		http.Error(w, "error unmarshaling rules", http.StatusInternalServerError)
 
 		return
 	}
@@ -166,7 +157,7 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	body, err := marshalRules(rawRules)
+	body, err := yaml.Marshal(rawRules)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not marshal rules YAML", "err", err.Error())
 		http.Error(w, "error marshaling rules YAML", http.StatusInternalServerError)

--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"bytes"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -71,18 +72,24 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 			switch r := rawRules.Groups[i].Rules[j].(type) {
 			case rules.RecordingRule:
 				if r.Labels.AdditionalProperties == nil {
-					r.Labels.AdditionalProperties = make(map[string]string)
+					http.Error(w, "rule has no label", http.StatusInternalServerError)
+					return
 				}
 
-				r.Labels.AdditionalProperties[rh.tenantLabel] = id
-				rawRules.Groups[i].Rules[j] = r
+				if v, ok := r.Labels.AdditionalProperties[rh.tenantLabel]; !ok || v != id {
+					http.Error(w, "rule has invalid or no tenant label", http.StatusInternalServerError)
+					return
+				}
 			case rules.AlertingRule:
 				if r.Labels.AdditionalProperties == nil {
-					r.Labels.AdditionalProperties = make(map[string]string)
+					http.Error(w, "rule has no label", http.StatusInternalServerError)
+					return
 				}
 
-				r.Labels.AdditionalProperties[rh.tenantLabel] = id
-				rawRules.Groups[i].Rules[j] = r
+				if v, ok := r.Labels.AdditionalProperties[rh.tenantLabel]; !ok || v != id {
+					http.Error(w, "rule has invalid or no tenant label", http.StatusInternalServerError)
+					return
+				}
 			}
 		}
 	}
@@ -107,7 +114,56 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "error finding tenant", http.StatusUnauthorized)
 	}
 
-	resp, err := rh.client.SetRulesWithBody(r.Context(), tenant, r.Header.Get("Content-type"), r.Body)
+	id, ok := authentication.GetTenantID(r.Context())
+	if !ok {
+		http.Error(w, "error finding tenant ID", http.StatusUnauthorized)
+		return
+	}
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "error reading request body", http.StatusInternalServerError)
+		return
+	}
+
+	var rawRules rules.Rules
+	if err := yaml.Unmarshal(body, &rawRules); err != nil {
+		level.Error(rh.logger).Log("msg", "could not unmarshal rules", "err", err.Error())
+		http.Error(w, "error unmarshaling rules", http.StatusInternalServerError)
+
+		return
+	}
+
+	for i := range rawRules.Groups {
+		for j := range rawRules.Groups[i].Rules {
+			switch r := rawRules.Groups[i].Rules[j].(type) {
+			case rules.RecordingRule:
+				if r.Labels.AdditionalProperties == nil {
+					r.Labels.AdditionalProperties = make(map[string]string)
+				}
+
+				r.Labels.AdditionalProperties[rh.tenantLabel] = id
+				rawRules.Groups[i].Rules[j] = r
+			case rules.AlertingRule:
+				if r.Labels.AdditionalProperties == nil {
+					r.Labels.AdditionalProperties = make(map[string]string)
+				}
+
+				r.Labels.AdditionalProperties[rh.tenantLabel] = id
+				rawRules.Groups[i].Rules[j] = r
+			}
+		}
+	}
+
+	body, err = yaml.Marshal(rawRules)
+	if err != nil {
+		level.Error(rh.logger).Log("msg", "could not marshal YAML", "err", err.Error())
+		http.Error(w, "error marshaling YAML", http.StatusInternalServerError)
+
+		return
+	}
+
+	resp, err := rh.client.SetRulesWithBody(r.Context(), tenant, r.Header.Get("Content-type"), bytes.NewReader(body))
 	if err != nil {
 		sc := http.StatusInternalServerError
 		if resp != nil {

--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -80,24 +80,18 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 			switch r := rawRules.Groups[i].Rules[j].(type) {
 			case rules.RecordingRule:
 				if r.Labels.AdditionalProperties == nil {
-					http.Error(w, "rule has no label", http.StatusInternalServerError)
-					return
+					r.Labels.AdditionalProperties = make(map[string]string)
 				}
 
-				if v, ok := r.Labels.AdditionalProperties[rh.tenantLabel]; !ok || v != id {
-					http.Error(w, "rule has invalid or no tenant label", http.StatusInternalServerError)
-					return
-				}
+				r.Labels.AdditionalProperties[rh.tenantLabel] = id
+				rawRules.Groups[i].Rules[j] = r
 			case rules.AlertingRule:
 				if r.Labels.AdditionalProperties == nil {
-					http.Error(w, "rule has no label", http.StatusInternalServerError)
-					return
+					r.Labels.AdditionalProperties = make(map[string]string)
 				}
 
-				if v, ok := r.Labels.AdditionalProperties[rh.tenantLabel]; !ok || v != id {
-					http.Error(w, "rule has invalid or no tenant label", http.StatusInternalServerError)
-					return
-				}
+				r.Labels.AdditionalProperties[rh.tenantLabel] = id
+				rawRules.Groups[i].Rules[j] = r
 			}
 		}
 	}

--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -205,6 +205,7 @@ func createRulesYAML(
 const recordingRuleYamlTpl = `
 groups:
   - name: example
+    interval: 30s
     rules:
       - record: job:http_inprogress_requests:sum
         expr: sum by (job) (http_inprogress_requests)
@@ -213,6 +214,7 @@ groups:
 const alertingRuleYamlTpl = `
 groups:
 - name: example
+  interval: 30s
   rules:
   - alert: HighRequestLatency
     expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
@@ -225,11 +227,15 @@ groups:
 const recordAndAlertingRulesYamlTpl = `
 groups:
 - name: node_rules
+  interval: 30s
   rules:
   - record: job:up:avg
     expr: avg without(instance)(up{job="node"})
   - alert: ManyInstancesDown
     expr: job:up:avg{job="node"} < 0.5
+    for: 10m
+    annotations:
+      Summary: Many instances down
 `
 
 const invalidRulesYamlTpl = `
@@ -240,4 +246,17 @@ invalid:
    expr: avg without(instance)(up{job="node"})
  - rule2: ManyInstancesDown
    expr: job:up:avg{job="node"} < 0.5
+`
+
+const validYamlWithInvalidRulesYamlTpl = `
+groups:
+  - name: example
+    interval: 30TB
+    rules:
+      - record: job:http_inprogress_requests:sum
+        expr: sum by (job) (http_inprogress_requests)
+      - alert: ManyInstancesDown
+        expr: job:up:avg{job="node"} < 0.5
+        for: 10GB
+        annotations: {}
 `

--- a/test/e2e/rules_test.go
+++ b/test/e2e/rules_test.go
@@ -31,7 +31,7 @@ func TestRulesAPI(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(api))
 
-	rulesEndpointURL := "https://" + api.Endpoint("https") + "/api/metrics/v1/"+defaultTenantName+"/api/v1/rules/raw"
+	rulesEndpointURL := "https://" + api.Endpoint("https") + "/api/metrics/v1/" + defaultTenantName + "/api/v1/rules/raw"
 	tr := &http.Transport{
 		TLSClientConfig: getTLSClientConfig(t, e),
 	}
@@ -155,6 +155,7 @@ func TestRulesAPI(t *testing.T) {
 		assertResponse(t, bodyStr, "alert: ManyInstancesDown")
 		assertResponse(t, bodyStr, "tenant_id: "+defaultTenantID)
 	})
+
 	t.Run("write-invalid-rules", func(t *testing.T) {
 		// Set an invalid rules file
 		invalidRules := []byte(invalidRulesYamlTpl)
@@ -167,7 +168,22 @@ func TestRulesAPI(t *testing.T) {
 
 		res, err := client.Do(r)
 		testutil.Ok(t, err)
+		testutil.Equals(t, http.StatusInternalServerError, res.StatusCode)
+	})
+
+	t.Run("write-valid-yaml-with-invalid-rules", func(t *testing.T) {
+		// set valid YAML with invalid rules
+		validYamlWithinvalidRules := []byte(validYamlWithInvalidRulesYamlTpl)
+		r, err := http.NewRequest(
+			http.MethodPut,
+			rulesEndpointURL,
+			bytes.NewReader(validYamlWithinvalidRules),
+		)
+		testutil.Ok(t, err)
+
+		res, err := client.Do(r)
+		testutil.Ok(t, err)
 		testutil.Equals(t, http.StatusBadRequest, res.StatusCode)
 	})
-}
 
+}


### PR DESCRIPTION
Currently, we enforce tenant labels on rules by adding the labels to them when Observatorium API gets it from the rules storage client i.e, the rules will only have the tenant labels when we get it from the API `rules/raw` endpoint.

With the recent changes in thanos-rule-syncer and rules-objstore, this means,
- Observatorium API doesn’t add a tenant label while writing rules to rules-objstore
- With the `listallrules` endpoint, thanos-rule-syncer will try to get all rules by hitting rules-objstore directly (so enforcing labels won’t work as we’re no longer relying on the API read path, but read from rules-objstore directly)
- So the rule file generated by thanos-rule-syncer, which is to be used by Thanos Ruler won’t have any tenant labels, so any resultant series will also not have labels

This PR fixes the above issue, by ensuring that the API adds tenant labels while making the PUT request to the rules storage client and validating the labels when a GET request is made. This way tenant labels are propagated to the rules storage client and then eventually to thanos-rule-syncer and Thanos Ruler.

For more diagrammatic context see [MON-2169](https://issues.redhat.com/browse/MON-2169).