### PR TITLE
Interactive test: Run rules services as part of the interactive test

### DIFF
--- a/test/e2e/interactive_test.go
+++ b/test/e2e/interactive_test.go
@@ -22,11 +22,13 @@ func TestInteractiveSetup(t *testing.T) {
 	_, token, rateLimiterAddr := startBaseServices(t, e, interactive)
 	readEndpoint, writeEndpoint, readExtEndpoint := startServicesForMetrics(t, e)
 	logsEndpoint, logsExtEndpoint := startServicesForLogs(t, e)
+	rulesEndpoint := startServicesForRules(t, e)
 
 	api, err := newObservatoriumAPIService(
 		e,
 		withMetricsEndpoints("http://"+readEndpoint, "http://"+writeEndpoint),
 		withLogsEndpoints("http://"+logsEndpoint),
+		withRulesEndpoint("http://"+rulesEndpoint),
 		withRateLimiter(rateLimiterAddr),
 	)
 	testutil.Ok(t, err)

--- a/test/e2e/rules_test.go
+++ b/test/e2e/rules_test.go
@@ -75,9 +75,9 @@ func TestRulesAPI(t *testing.T) {
 		testutil.Ok(t, err)
 
 		res, err = client.Do(r)
+		testutil.Ok(t, err)
 		defer res.Body.Close()
 
-		testutil.Ok(t, err)
 		testutil.Equals(t, http.StatusOK, res.StatusCode)
 
 		body, err := ioutil.ReadAll(res.Body)
@@ -110,9 +110,9 @@ func TestRulesAPI(t *testing.T) {
 		testutil.Ok(t, err)
 
 		res, err = client.Do(r)
+		testutil.Ok(t, err)
 		defer res.Body.Close()
 
-		testutil.Ok(t, err)
 		testutil.Equals(t, http.StatusOK, res.StatusCode)
 
 		body, err := ioutil.ReadAll(res.Body)
@@ -144,9 +144,9 @@ func TestRulesAPI(t *testing.T) {
 		testutil.Ok(t, err)
 
 		res, err = client.Do(r)
+		testutil.Ok(t, err)
 		defer res.Body.Close()
 
-		testutil.Ok(t, err)
 		testutil.Equals(t, http.StatusOK, res.StatusCode)
 
 		body, err := ioutil.ReadAll(res.Body)


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Adds rules service to run when running the interactive setup.