### PR TITLE
Rules API: Enforce tenant label and id in rule expression

### DIFF
--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -3,7 +3,6 @@ package v1
 import (
 	"bytes"
 	"fmt"
-	"github.com/prometheus-community/prom-label-proxy/injectproxy"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -13,8 +12,9 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/observatorium/api/authentication"
 	"github.com/observatorium/api/rules"
-	"github.com/prometheus/prometheus/promql/parser"
 	"github.com/prometheus/prometheus/pkg/labels"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus-community/prom-label-proxy/injectproxy"
 )
 
 func enforceLabelsInRules(rawRules rules.Rules, tenantLabel string, tenantID string) error {
@@ -59,17 +59,20 @@ func enforceLabelsInRules(rawRules rules.Rules, tenantLabel string, tenantID str
 			}
 		}
 	}
+
 	return nil
 }
 
-func enforceLabelsInExpr(e *injectproxy.Enforcer, expr string) (string, error){
+func enforceLabelsInExpr(e *injectproxy.Enforcer, expr string) (string, error) {
 	parsedExpr, err := parser.ParseExpr(expr)
 	if err != nil {
 		return "", fmt.Errorf("parse expr error: %w", err)
 	}
+
 	if err := e.EnforceNode(parsedExpr); err != nil {
 		return "", fmt.Errorf("enforce node error: %w", err)
 	}
+
 	return parsedExpr.String(), nil
 }
 
@@ -142,7 +145,6 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 
 		return
 	}
-
 
 	body, err := yaml.Marshal(rawRules)
 	if err != nil {

--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -12,9 +12,9 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/observatorium/api/authentication"
 	"github.com/observatorium/api/rules"
+	"github.com/prometheus-community/prom-label-proxy/injectproxy"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
-	"github.com/prometheus-community/prom-label-proxy/injectproxy"
 )
 
 func enforceLabelsInRules(rawRules rules.Rules, tenantLabel string, tenantID string) error {

--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -2,6 +2,8 @@ package v1
 
 import (
 	"bytes"
+	"fmt"
+	"github.com/prometheus-community/prom-label-proxy/injectproxy"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -11,9 +13,18 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/observatorium/api/authentication"
 	"github.com/observatorium/api/rules"
+	"github.com/prometheus/prometheus/promql/parser"
+	"github.com/prometheus/prometheus/pkg/labels"
 )
 
-func enforceLabelsInRules(rawRules rules.Rules, tenantLabel string, tenantID string) {
+func enforceLabelsInRules(rawRules rules.Rules, tenantLabel string, tenantID string) error {
+	// creates new tenant label enforcer
+	e := injectproxy.NewEnforcer([]*labels.Matcher{{
+		Name:  tenantLabel,
+		Type:  labels.MatchEqual,
+		Value: tenantID,
+	}}...)
+
 	for i := range rawRules.Groups {
 		for j := range rawRules.Groups[i].Rules {
 			switch r := rawRules.Groups[i].Rules[j].(type) {
@@ -23,6 +34,13 @@ func enforceLabelsInRules(rawRules rules.Rules, tenantLabel string, tenantID str
 				}
 
 				r.Labels.AdditionalProperties[tenantLabel] = tenantID
+
+				expr, err := enforceLabelsInExpr(e, r.Expr)
+				if err != nil {
+					return err
+				}
+
+				r.Expr = expr
 				rawRules.Groups[i].Rules[j] = r
 			case rules.AlertingRule:
 				if r.Labels.AdditionalProperties == nil {
@@ -30,10 +48,29 @@ func enforceLabelsInRules(rawRules rules.Rules, tenantLabel string, tenantID str
 				}
 
 				r.Labels.AdditionalProperties[tenantLabel] = tenantID
+
+				expr, err := enforceLabelsInExpr(e, r.Expr)
+				if err != nil {
+					return err
+				}
+
+				r.Expr = expr
 				rawRules.Groups[i].Rules[j] = r
 			}
 		}
 	}
+	return nil
+}
+
+func enforceLabelsInExpr(e *injectproxy.Enforcer, expr string) (string, error){
+	parsedExpr, err := parser.ParseExpr(expr)
+	if err != nil {
+		return "", fmt.Errorf("parse expr error: %w", err)
+	}
+	if err := e.EnforceNode(parsedExpr); err != nil {
+		return "", fmt.Errorf("enforce node error: %w", err)
+	}
+	return parsedExpr.String(), nil
 }
 
 func unmarshalRules(r io.Reader) (rules.Rules, error) {
@@ -98,7 +135,14 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	enforceLabelsInRules(rawRules, rh.tenantLabel, id)
+	err = enforceLabelsInRules(rawRules, rh.tenantLabel, id)
+	if err != nil {
+		level.Error(rh.logger).Log("msg", "could not enforce labels in rules", "err", err.Error())
+		http.Error(w, "error enforcing labels in rules", http.StatusInternalServerError)
+
+		return
+	}
+
 
 	body, err := yaml.Marshal(rawRules)
 	if err != nil {
@@ -134,7 +178,13 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	enforceLabelsInRules(rawRules, rh.tenantLabel, id)
+	err = enforceLabelsInRules(rawRules, rh.tenantLabel, id)
+	if err != nil {
+		level.Error(rh.logger).Log("msg", "could not enforce labels in rules", "err", err.Error())
+		http.Error(w, "error enforcing labels in rules", http.StatusInternalServerError)
+
+		return
+	}
 
 	body, err := yaml.Marshal(rawRules)
 	if err != nil {

--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -141,7 +141,7 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 	err = enforceLabelsInRules(rawRules, rh.tenantLabel, id)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not enforce labels in rules", "err", err.Error())
-		http.Error(w, "error enforcing labels in rules", http.StatusInternalServerError)
+		http.Error(w, "failed to process rules", http.StatusInternalServerError)
 
 		return
 	}
@@ -183,7 +183,7 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 	err = enforceLabelsInRules(rawRules, rh.tenantLabel, id)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not enforce labels in rules", "err", err.Error())
-		http.Error(w, "error enforcing labels in rules", http.StatusInternalServerError)
+		http.Error(w, "failed to process rules", http.StatusInternalServerError)
 
 		return
 	}

--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -204,38 +204,38 @@ func createRulesYAML(
 
 const recordingRuleYamlTpl = `
 groups:
-  - name: example
-    interval: 30s
-    rules:
-      - record: id_network_type
-        expr: 0 * topk by (ebs_account) (1, max by (ebs_account,account_type,internal,email_domain) (label_replace(label_replace(label_replace(subscription_labels{email_domain="domain1.com"}*0+5, "class", "Internal", "class", ".*") or label_replace(subscription_labels{class!="Customer",email_domain=~"(.*\\.|^)domain2.com"}*0+4, "class", "Internal", "class", ".*") or (subscription_labels{class="Customer"}*0+3) or (subscription_labels{class="Partner"}*0+2) or (subscription_labels{class="Evaluation"}*0+1) or label_replace(subscription_labels{class!~"Evaluation|Customer|Partner"}*0+0, "class", "", "class", ".*"), "account_type", "$1", "class", "(.+)"), "internal", "true", "email_domain", "domain1.com|(.*\\.|^)domain2.com") ))
+ - name: example
+   interval: 30s
+   rules:
+     - record: id_network_type
+       expr: 0 * topk by (ebs_account) (1, max by (ebs_account,account_type,internal,email_domain) (label_replace(label_replace(label_replace(subscription_labels{email_domain="domain1.com"}*0+5, "class", "Internal", "class", ".*") or label_replace(subscription_labels{class!="Customer",email_domain=~"(.*\\.|^)domain2.com"}*0+4, "class", "Internal", "class", ".*") or (subscription_labels{class="Customer"}*0+3) or (subscription_labels{class="Partner"}*0+2) or (subscription_labels{class="Evaluation"}*0+1) or label_replace(subscription_labels{class!~"Evaluation|Customer|Partner"}*0+0, "class", "", "class", ".*"), "account_type", "$1", "class", "(.+)"), "internal", "true", "email_domain", "domain1.com|(.*\\.|^)domain2.com") ))
 `
 
 const alertingRuleYamlTpl = `
 groups:
-  - name: example
+- name: example
   interval: 30s
   rules:
-    - alert: HighRequestLatency
-      expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
-      for: 10m
-      labels:
-        severity: page
-      annotations:
-        summary: High request latency
+  - alert: HighRequestLatency
+    expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
+    for: 10m
+    labels:
+      severity: page
+    annotations:
+      summary: High request latency
 `
 const recordAndAlertingRulesYamlTpl = `
 groups:
-  - name: node_rules
-    interval: 30s
-    rules:
-      - record: job:up:avg
-        expr: avg without(instance)(up{job="node"})
-      - alert: ManyInstancesDown
-        expr: job:up:avg{job="node"} < 0.5
-      for: 10m
-      annotations:
-        Summary: Many instances down
+- name: node_rules
+  interval: 30s
+  rules:
+  - record: job:up:avg
+    expr: avg without(instance)(up{job="node"})
+  - alert: ManyInstancesDown
+    expr: job:up:avg{job="node"} < 0.5
+    for: 10m
+    annotations:
+      Summary: Many instances down
 `
 
 const invalidRulesYamlTpl = `

--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -204,11 +204,11 @@ func createRulesYAML(
 
 const recordingRuleYamlTpl = `
 groups:
-  - name: example
-    interval: 30s
-    rules:
-      - record: job:http_inprogress_requests:sum
-        expr: sum by (job) (http_inprogress_requests)
+ - name: example
+   interval: 30s
+   rules:
+     - record: id_network_type
+       expr: 0 * topk by (ebs_account) (1, max by (ebs_account,account_type,internal,email_domain) (label_replace(label_replace(label_replace(subscription_labels{email_domain="domain1.com"}*0+5, "class", "Internal", "class", ".*") or label_replace(subscription_labels{class!="Customer",email_domain=~"(.*\\.|^)domain2.com"}*0+4, "class", "Internal", "class", ".*") or (subscription_labels{class="Customer"}*0+3) or (subscription_labels{class="Partner"}*0+2) or (subscription_labels{class="Evaluation"}*0+1) or label_replace(subscription_labels{class!~"Evaluation|Customer|Partner"}*0+0, "class", "", "class", ".*"), "account_type", "$1", "class", "(.+)"), "internal", "true", "email_domain", "domain1.com|(.*\\.|^)domain2.com") ))
 `
 
 const alertingRuleYamlTpl = `

--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -204,38 +204,38 @@ func createRulesYAML(
 
 const recordingRuleYamlTpl = `
 groups:
- - name: example
-   interval: 30s
-   rules:
-     - record: id_network_type
-       expr: 0 * topk by (ebs_account) (1, max by (ebs_account,account_type,internal,email_domain) (label_replace(label_replace(label_replace(subscription_labels{email_domain="domain1.com"}*0+5, "class", "Internal", "class", ".*") or label_replace(subscription_labels{class!="Customer",email_domain=~"(.*\\.|^)domain2.com"}*0+4, "class", "Internal", "class", ".*") or (subscription_labels{class="Customer"}*0+3) or (subscription_labels{class="Partner"}*0+2) or (subscription_labels{class="Evaluation"}*0+1) or label_replace(subscription_labels{class!~"Evaluation|Customer|Partner"}*0+0, "class", "", "class", ".*"), "account_type", "$1", "class", "(.+)"), "internal", "true", "email_domain", "domain1.com|(.*\\.|^)domain2.com") ))
+  - name: example
+    interval: 30s
+    rules:
+      - record: id_network_type
+        expr: 0 * topk by (ebs_account) (1, max by (ebs_account,account_type,internal,email_domain) (label_replace(label_replace(label_replace(subscription_labels{email_domain="domain1.com"}*0+5, "class", "Internal", "class", ".*") or label_replace(subscription_labels{class!="Customer",email_domain=~"(.*\\.|^)domain2.com"}*0+4, "class", "Internal", "class", ".*") or (subscription_labels{class="Customer"}*0+3) or (subscription_labels{class="Partner"}*0+2) or (subscription_labels{class="Evaluation"}*0+1) or label_replace(subscription_labels{class!~"Evaluation|Customer|Partner"}*0+0, "class", "", "class", ".*"), "account_type", "$1", "class", "(.+)"), "internal", "true", "email_domain", "domain1.com|(.*\\.|^)domain2.com") ))
 `
 
 const alertingRuleYamlTpl = `
 groups:
-- name: example
+  - name: example
   interval: 30s
   rules:
-  - alert: HighRequestLatency
-    expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
-    for: 10m
-    labels:
-      severity: page
-    annotations:
-      summary: High request latency
+    - alert: HighRequestLatency
+      expr: job:request_latency_seconds:mean5m{job="myjob"} > 0.5
+      for: 10m
+      labels:
+        severity: page
+      annotations:
+        summary: High request latency
 `
 const recordAndAlertingRulesYamlTpl = `
 groups:
-- name: node_rules
-  interval: 30s
-  rules:
-  - record: job:up:avg
-    expr: avg without(instance)(up{job="node"})
-  - alert: ManyInstancesDown
-    expr: job:up:avg{job="node"} < 0.5
-    for: 10m
-    annotations:
-      Summary: Many instances down
+  - name: node_rules
+    interval: 30s
+    rules:
+      - record: job:up:avg
+        expr: avg without(instance)(up{job="node"})
+      - alert: ManyInstancesDown
+        expr: job:up:avg{job="node"} < 0.5
+      for: 10m
+      annotations:
+        Summary: Many instances down
 `
 
 const invalidRulesYamlTpl = `

--- a/test/e2e/rules_test.go
+++ b/test/e2e/rules_test.go
@@ -83,7 +83,12 @@ func TestRulesAPI(t *testing.T) {
 		body, err := ioutil.ReadAll(res.Body)
 		bodyStr := string(body)
 
-		assertResponse(t, bodyStr, "sum by(job) (http_inprogress_requests{tenant_id=\""+defaultTenantID+"\"})")
+		assertResponse(t, bodyStr, "subscription_labels{email_domain=\"domain1.com\",tenant_id=\""+defaultTenantID+"\"}")
+		assertResponse(t, bodyStr, "subscription_labels{class!=\"Customer\",email_domain=~\"(.*\\\\.|^)domain2.com\",tenant_id=\""+defaultTenantID+"\"}")
+		assertResponse(t, bodyStr, "subscription_labels{class=\"Customer\",tenant_id=\""+defaultTenantID+"\"")
+		assertResponse(t, bodyStr, "subscription_labels{class=\"Partner\",tenant_id=\""+defaultTenantID+"\"")
+		assertResponse(t, bodyStr, "subscription_labels{class=\"Evaluation\",tenant_id=\""+defaultTenantID+"\"")
+		assertResponse(t, bodyStr, "subscription_labels{class!~\"Evaluation|Customer|Partner\",tenant_id=\""+defaultTenantID+"\"}")
 		assertResponse(t, bodyStr, "tenant_id: "+defaultTenantID)
 	})
 

--- a/test/e2e/rules_test.go
+++ b/test/e2e/rules_test.go
@@ -83,7 +83,7 @@ func TestRulesAPI(t *testing.T) {
 		body, err := ioutil.ReadAll(res.Body)
 		bodyStr := string(body)
 
-		assertResponse(t, bodyStr, "sum by (job) (http_inprogress_requests)")
+		assertResponse(t, bodyStr, "sum by(job) (http_inprogress_requests{tenant_id=\""+defaultTenantID+"\"})")
 		assertResponse(t, bodyStr, "tenant_id: "+defaultTenantID)
 	})
 
@@ -117,7 +117,9 @@ func TestRulesAPI(t *testing.T) {
 
 		body, err := ioutil.ReadAll(res.Body)
 		bodyStr := string(body)
+
 		assertResponse(t, bodyStr, "alert: HighRequestLatency")
+		assertResponse(t, bodyStr, "job:request_latency_seconds:mean5m{job=\"myjob\",tenant_id=\""+defaultTenantID+"\"}")
 		assertResponse(t, bodyStr, "tenant_id: "+defaultTenantID)
 	})
 
@@ -151,8 +153,11 @@ func TestRulesAPI(t *testing.T) {
 
 		body, err := ioutil.ReadAll(res.Body)
 		bodyStr := string(body)
+
 		assertResponse(t, bodyStr, "record: job:up:avg")
 		assertResponse(t, bodyStr, "alert: ManyInstancesDown")
+		assertResponse(t, bodyStr, "up{job=\"node\",tenant_id=\""+defaultTenantID+"\"}")
+		assertResponse(t, bodyStr, "job:up:avg{job=\"node\",tenant_id=\""+defaultTenantID+"\"}")
 		assertResponse(t, bodyStr, "tenant_id: "+defaultTenantID)
 	})
 


### PR DESCRIPTION
To help with tenant rules validation (as mentioned in https://github.com/observatorium/api/issues/194), this PR adds a `tenant_id` label to metrics present in a `expr` field in a recording/alerting rule that is written via the Rules API (via `/api/v1/rules/raw` endpoint)

So for the following rule that is written via Rules API:
```yaml
groups:
- name: node_rules
  interval: 30s
  rules:
  - record: job:up:avg
    expr: avg without(instance)(up{job="node"})
  - alert: ManyInstancesDown
    expr: job:up:avg{job="node"} < 0.5
    for: 10m
    annotations:
      Summary: Many instances down
```
We expect that when the rule is read via `GET` request, the rule is changed and a `tenant_id` label is appended to `up` and `avg`:

`expr: avg without(instance)(up{job="node",tenant_id="tenantIDHere"})`
`expr: job:up:avg{job="node",tenant_id="tenantIDHere"} < 0.5`

I've also modified the current e2e tests to support this change.

Signed-off-by: Jéssica Lins <jessicaalins@gmail.com>