### PR TITLE
Enable Rate Limiting for Logs endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -568,6 +568,12 @@ func main() {
 					r.Use(authentication.WithTenantMiddlewares(pm.Middlewares))
 					r.Use(authentication.WithTenantHeader(cfg.logs.tenantHeader, tenantIDs))
 
+					if rateLimitClient != nil {
+						r.Use(ratelimit.WithSharedRateLimiter(logger, rateLimitClient, rateLimits...))
+					} else {
+						r.Use(ratelimit.WithLocalRateLimiter(rateLimits...))
+					}
+
 					r.Mount("/api/logs/v1/{tenant}",
 						stripTenantPrefix("/api/logs/v1",
 							logsv1.NewHandler(


### PR DESCRIPTION
Currently, Rate Limiting is only enabled for metrics, this commit
enables it also for logs endpoints.