### PR TITLE
Allow specific method access for endpoints

### DIFF
--- a/main.go
+++ b/main.go
@@ -501,6 +501,7 @@ func main() {
 			r.Use(authentication.WithTenant)
 			r.Use(authentication.WithTenantID(tenantIDs))
 			r.Use(authentication.WithAccessToken())
+			r.MethodNotAllowed(blockNonDefinedMethods())
 
 			// Metrics.
 			if cfg.metrics.enabled {
@@ -973,4 +974,11 @@ type otelErrorHandler struct {
 
 func (oh otelErrorHandler) Handle(err error) {
 	level.Error(oh.logger).Log("msg", "opentelemetry", "err", err.Error())
+}
+
+func blockNonDefinedMethods() http.HandlerFunc {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(405)
+	}
+	return http.HandlerFunc(fn)
 }

--- a/main.go
+++ b/main.go
@@ -978,7 +978,8 @@ func (oh otelErrorHandler) Handle(err error) {
 
 func blockNonDefinedMethods() http.HandlerFunc {
 	fn := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(405)
+		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
+
 	return http.HandlerFunc(fn)
 }


### PR DESCRIPTION
#### Implementation for [Issue-183](https://github.com/observatorium/api/issues/183):
#####  Overview
Add handlerFunc to block methods with chi router with methodNotAllowed


