### PR TITLE
Trace query API

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Usage of ./observatorium-api:
     	File containing the default x509 Certificate for HTTPS. Leave blank to disable TLS.
   -tls.server.key-file string
     	File containing the default x509 private key matching --tls.server.cert-file. Leave blank to disable TLS.
+  -traces.read.endpoint string
+    	The endpoint against which to make HTTP read requests for traces.
   -traces.tenant-header string
     	The name of the HTTP header containing the tenant ID to forward to upstream OpenTelemetry collector. (default "X-Tenant")
   -traces.write.endpoint string

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -1,11 +1,17 @@
 package v1
 
 import (
+	"bytes"
+	"compress/flate"
+	"compress/gzip"
 	"fmt"
+	"io"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/go-chi/chi"
@@ -182,8 +188,9 @@ func NewUIHandler(read *url.URL, opts ...HandlerOption) http.Handler {
 			ErrorLog:  proxy.Logger(c.logger),
 			Transport: otelhttp.NewTransport(t),
 			ErrorHandler: func(rw http.ResponseWriter, r *http.Request, e error) {
-				fmt.Printf("@@@ ecs in NewUIHandler anon ErrorHandler for request %#v\n", r)
+				fmt.Printf("@@@ ecs in NewUIHandler anon ErrorHandler for request %q: %v\n", r.URL.String(), e)
 			},
+			ModifyResponse: jaegerUIResponseModifier,
 		}
 	}
 	r.Group(func(r chi.Router) {
@@ -210,4 +217,93 @@ func NewUIHandler(read *url.URL, opts ...HandlerOption) http.Handler {
 	})
 
 	return r
+}
+
+func jaegerUIResponseModifier(response *http.Response) error {
+	// fmt.Printf("@@@ ecs REACHED jaegerUIResponseModifier(), content type is %q\n", response.Header.Get("Content-Type"))
+	// @@@ md, err := metadata.FromIncomingContext(response.Request.Context())
+	// fmt.Printf("@@@ ecs REACHED jaegerUIResponseModifier, request tenant was %v\n", response.Request.Context().Value("tenant"))
+	// fmt.Printf("@@@ ecs REACHED jaegerUIResponseModifier, request tenantID was %v\n", response.Request.Context().Value("tenantID"))
+	// fmt.Printf("@@@ ecs REACHED jaegerUIResponseModifier, request context is %#v, a %T\n", response.Request.Context(), response.Request.Context())
+	// fmt.Printf("@@@ ecs REACHED jaegerUIResponseModifier, request header is %#v, a %T\n", response.Request.Header, response.Request.Header)
+
+	// if response.StatusCode == http.StatusOK && response.Header.Get("Content-Type") == "text/html; charset=utf-8" {
+	if response.StatusCode == http.StatusOK && response.Header.Get("Content-Type") == "text/html; charset=utf-8" {
+		fmt.Printf("@@@ ecs in jaegerUIResponseModifier() for %v\n", response.Request.URL)
+		var reader io.ReadCloser
+		var err error
+		switch response.Header.Get("Content-Encoding") {
+		case "gzip":
+			reader, err = gzip.NewReader(response.Body)
+			if err != nil {
+				return err
+			}
+			defer reader.Close()
+		case "deflate":
+			fmt.Printf("@@@ ecs jaegerUIResponseModifier got deflated data for %v\n", response.Request.URL.String())
+			reader = flate.NewReader(response.Body)
+			defer reader.Close()
+		default:
+			fmt.Printf("@@@ ecs jaegerUIResponseModifier got content encoding %q for %v\n", response.Header.Get("Content-Encoding"), response.Request.URL.String())
+			reader = response.Body
+		}
+
+		b, err := ioutil.ReadAll(reader)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("@@@ ecs jaegerUIResponseModifier() decoded body\n")
+
+		// JaegerUI insists on a <base>, so create one but use Observatorium's
+		// opinion of the base href, not Jaeger Query's opinion.
+		// TODO Use github.com/observatorium/api/proxy/prefixHeader
+		forwardedPrefix := response.Request.Header.Get("X-Forwarded-Prefix")
+		if forwardedPrefix == "" {
+			// TODO Log the first time this happens?  It should never happen.
+			forwardedPrefix = "/api/traces/v1/dummy"
+		}
+
+		// fmt.Printf("@@@ ecs in jaegerUIResponseModifier, b is %q\n", b)
+		strResponse := string(b)
+		const expectedBaseTag = `<base href="/" data-inject-target="BASE_URL"/>`
+		replacementBaseTag := fmt.Sprintf(`<base href="%s/" data-inject-target="BASE_URL"/>`, forwardedPrefix)
+		if strings.Contains(strResponse, expectedBaseTag) {
+			fmt.Printf("@@@ ecs found <base> tag, removing\n")
+			strResponse = strings.Replace(strResponse, expectedBaseTag, replacementBaseTag, 1)
+
+			// En-encode the body to match the promised content-encoding
+
+			switch response.Header.Get("Content-Encoding") {
+			case "gzip":
+				var buf bytes.Buffer
+				writer := gzip.NewWriter(&buf)
+				writer.Write([]byte(strResponse))
+				writer.Close()
+				response.Header["Content-Length"] = []string{fmt.Sprint(buf.Len())}
+				fmt.Printf("@@@ ecs replying with gzipped data of length %v\n", buf.Len())
+				response.Body = ioutil.NopCloser(&buf)
+			case "deflate":
+				var buf bytes.Buffer
+				writer, _ := flate.NewWriter(&buf, 1)
+				writer.Write([]byte(strResponse))
+				writer.Close()
+				response.Header["Content-Length"] = []string{fmt.Sprint(buf.Len())}
+				fmt.Printf("@@@ ecs replying with deflated data of length %v\n", buf.Len())
+				response.Body = ioutil.NopCloser(&buf)
+			default:
+				buf := bytes.NewBufferString(strResponse)
+				response.Header["Content-Length"] = []string{fmt.Sprint(buf.Len())}
+				fmt.Printf("@@@ ecs replying with uncompressed data of length %v\n", buf.Len())
+				response.Body = ioutil.NopCloser(buf)
+			}
+
+		} else {
+			fmt.Printf("@@@ ecs jaegerUIResponseModifier() did not find <base> tag in %v\n", response.Header)
+		}
+	} else {
+		fmt.Printf("@@@ ecs jaegerUIResponseModifier() ignored %v\n", response.Request.URL)
+	}
+
+	return nil
 }

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -131,9 +131,16 @@ func NewV2APIHandler(read *url.URL, opts ...HandlerOption) http.Handler {
 			Transport: otelhttp.NewTransport(t),
 		}
 	}
+
 	r.Group(func(r chi.Router) {
 		r.Use(c.readMiddlewares...)
-		r.Handle("/*", c.instrument.NewHandler(
+		r.Get("/traces*", c.instrument.NewHandler(
+			prometheus.Labels{"group": "tracesv1api", "handler": "api"},
+			proxyRead))
+		r.Get("/services*", c.instrument.NewHandler(
+			prometheus.Labels{"group": "tracesv1api", "handler": "api"},
+			proxyRead))
+		r.Get("/dependencies*", c.instrument.NewHandler(
 			prometheus.Labels{"group": "tracesv1api", "handler": "api"},
 			proxyRead))
 	})
@@ -179,7 +186,7 @@ func NewUIStaticHandler(read *url.URL, opts ...HandlerOption) http.Handler {
 	}
 	r.Group(func(r chi.Router) {
 		r.Use(c.readMiddlewares...)
-		r.Handle("/*", c.instrument.NewHandler(
+		r.Get("/*", c.instrument.NewHandler(
 			prometheus.Labels{"group": "tracesv1ui", "handler": "search"},
 			proxyRead))
 	})
@@ -231,7 +238,7 @@ func NewUIHandler(read *url.URL, opts ...HandlerOption) http.Handler {
 
 	r.Group(func(r chi.Router) {
 		r.Use(c.readMiddlewares...)
-		r.Handle("/*", c.instrument.NewHandler(
+		r.Get("/*", c.instrument.NewHandler(
 			prometheus.Labels{"group": "tracesv1ui", "handler": "search"},
 			proxyRead))
 	})

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -1,0 +1,213 @@
+package v1
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
+	"github.com/observatorium/api/proxy"
+)
+
+const (
+	ReadTimeout  = 15 * time.Minute
+	WriteTimeout = time.Minute
+)
+
+type handlerConfiguration struct {
+	logger           log.Logger
+	registry         *prometheus.Registry
+	instrument       handlerInstrumenter
+	spanRoutePrefix  string
+	readMiddlewares  []func(http.Handler) http.Handler
+	writeMiddlewares []func(http.Handler) http.Handler
+}
+
+// HandlerOption modifies the handler's configuration.
+type HandlerOption func(h *handlerConfiguration)
+
+// Logger add a custom logger for the handler to use.
+func Logger(logger log.Logger) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.logger = logger
+	}
+}
+
+// WithJaegerQueryV3 adds a custom Jaeger query for the handler to use.
+func WithRegistry(r *prometheus.Registry) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.registry = r
+	}
+}
+
+// WithHandlerInstrumenter adds a custom HTTP handler instrument middleware for the handler to use.
+func WithHandlerInstrumenter(instrumenter handlerInstrumenter) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.instrument = instrumenter
+	}
+}
+
+// WithSpanRoutePrefix adds a prefix before the value of route tag in tracing spans.
+func WithSpanRoutePrefix(spanRoutePrefix string) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.spanRoutePrefix = spanRoutePrefix
+	}
+}
+
+// WithReadMiddleware adds a middleware for all read operations.
+func WithReadMiddleware(m func(http.Handler) http.Handler) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.readMiddlewares = append(h.readMiddlewares, m)
+	}
+}
+
+// WithWriteMiddleware adds a middleware for all write operations.
+func WithWriteMiddleware(m func(http.Handler) http.Handler) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.writeMiddlewares = append(h.writeMiddlewares, m)
+	}
+}
+
+type handlerInstrumenter interface {
+	NewHandler(labels prometheus.Labels, handler http.Handler) http.HandlerFunc
+}
+
+type nopInstrumentHandler struct{}
+
+func (n nopInstrumentHandler) NewHandler(labels prometheus.Labels, handler http.Handler) http.HandlerFunc {
+	return handler.ServeHTTP
+}
+
+// NewV2APIHandler creates a trace query handler for Jaeger V2 HTTP queries
+func NewV2APIHandler(read *url.URL, opts ...HandlerOption) http.Handler {
+	fmt.Printf("@@@ ecs REACHED NewV2APIHandler()\n")
+	c := &handlerConfiguration{
+		logger:     log.NewNopLogger(),
+		registry:   prometheus.NewRegistry(),
+		instrument: nopInstrumentHandler{},
+	}
+
+	for _, o := range opts {
+		o(c)
+	}
+
+	r := chi.NewRouter()
+
+	var proxyRead http.Handler
+	{
+		level.Debug(c.logger).Log("msg", "Configuring upstream Jaeger query v2", "queryv2", read)
+		middlewares := proxy.Middlewares(
+			proxy.MiddlewareSetUpstream(read),
+			proxy.MiddlewareSetPrefixHeader(),
+			proxy.MiddlewareLogger(c.logger),
+			// @@@ TODO restore? proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "tracesv1-read"}),
+		)
+
+		t := &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: ReadTimeout,
+			}).DialContext,
+		}
+
+		fmt.Printf("@@@ ecs constructing reverse proxy for traces\n")
+		proxyRead = &httputil.ReverseProxy{
+			Director:     middlewares,
+			ErrorLog:     proxy.Logger(c.logger),
+			Transport:    otelhttp.NewTransport(t),
+			ErrorHandler: func(rw http.ResponseWriter, r *http.Request, e error) {},
+		}
+	}
+	r.Group(func(r chi.Router) {
+		r.Use(c.readMiddlewares...)
+		const (
+			queryRoute      = "/api/traces"
+			servicesRoute   = "/api/services"
+			operationsRoute = "/api/operations"
+		)
+		r.Handle(queryRoute, c.instrument.NewHandler(
+			prometheus.Labels{"group": "tracesv1", "handler": "query"},
+			otelhttp.WithRouteTag(c.spanRoutePrefix+queryRoute, proxyRead)))
+		r.Handle(servicesRoute, c.instrument.NewHandler(
+			prometheus.Labels{"group": "tracesv1", "handler": "query_range"},
+			otelhttp.WithRouteTag(c.spanRoutePrefix+servicesRoute, proxyRead)))
+		r.Handle(operationsRoute, c.instrument.NewHandler(
+			prometheus.Labels{"group": "tracesv1", "handler": "query_range"},
+			otelhttp.WithRouteTag(c.spanRoutePrefix+operationsRoute, proxyRead)))
+	})
+
+	return r
+}
+
+// NewUIHandler creates a trace handler for Jaeger UI
+func NewUIHandler(read *url.URL, opts ...HandlerOption) http.Handler {
+	fmt.Printf("@@@ ecs REACHED NewUIHandler()\n")
+	c := &handlerConfiguration{
+		logger:     log.NewNopLogger(),
+		registry:   prometheus.NewRegistry(),
+		instrument: nopInstrumentHandler{},
+	}
+
+	for _, o := range opts {
+		o(c)
+	}
+
+	r := chi.NewRouter()
+
+	var proxyRead http.Handler
+	{
+		level.Debug(c.logger).Log("msg", "Configuring upstream Jaeger UI", "ui", read)
+		middlewares := proxy.Middlewares(
+			proxy.MiddlewareSetUpstream(read),
+			proxy.MiddlewareSetPrefixHeader(),
+			proxy.MiddlewareLogger(c.logger),
+			// @@@ TODO restore? proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "tracesv1-read"}),
+		)
+
+		t := &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: ReadTimeout,
+			}).DialContext,
+		}
+
+		proxyRead = &httputil.ReverseProxy{
+			Director:  middlewares,
+			ErrorLog:  proxy.Logger(c.logger),
+			Transport: otelhttp.NewTransport(t),
+			ErrorHandler: func(rw http.ResponseWriter, r *http.Request, e error) {
+				fmt.Printf("@@@ ecs in NewUIHandler anon ErrorHandler for request %#v\n", r)
+			},
+		}
+	}
+	r.Group(func(r chi.Router) {
+		r.Use(c.readMiddlewares...)
+		/*
+			const (
+				searchRoute  = "/search"
+				staticRoute  = "/static/*"
+				faviconRoute = "/favicon.ico"
+			)
+			r.Handle(searchRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "tracesv1ui", "handler": "search"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+searchRoute, proxyRead)))
+			r.Handle(staticRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "tracesv1ui", "handler": "static"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+staticRoute, proxyRead)))
+			r.Handle(faviconRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "tracesv1ui", "handler": "static"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+faviconRoute, proxyRead)))
+		*/
+		r.Handle("/*", c.instrument.NewHandler(
+			prometheus.Labels{"group": "tracesv1ui", "handler": "search"},
+			proxyRead))
+	})
+
+	return r
+}

--- a/main.go
+++ b/main.go
@@ -636,18 +636,21 @@ func main() {
 								tracesv1.Logger(logger),
 								tracesv1.WithRegistry(reg),
 								tracesv1.WithHandlerInstrumenter(ins),
+								tracesv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "traces")),
+								tracesv1.WithReadMiddleware(logsv1.WithEnforceAuthorizationLabels()),
 							),
 						),
 					)
 
-					// Single page app, not protected by RBAC -- any user can see UI
 					uiHandler := tracesv1.NewUIHandler(
 						cfg.traces.readEndpoint,
 						tracesv1.Logger(logger),
 						tracesv1.WithRegistry(reg),
 						tracesv1.WithHandlerInstrumenter(ins),
+						tracesv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "traces")),
+						tracesv1.WithReadMiddleware(logsv1.WithEnforceAuthorizationLabels()),
 					)
-					// Jaeger's main page
+					// Jaeger's main page (single page app)
 					r.Mount("/api/traces/v1/{tenant}/search",
 						stripTenantPrefix("/api/traces/v1",
 							uiHandler,

--- a/main.go
+++ b/main.go
@@ -849,7 +849,7 @@ func (d *duration) UnmarshalJSON(b []byte) error {
 	}
 }
 
-//nolint:funlen
+//nolint:funlen,gocognit
 func parseFlags() (config, error) {
 	var (
 		rawTLSCipherSuites      string

--- a/main.go
+++ b/main.go
@@ -636,14 +636,14 @@ func main() {
 
 					// @@@ r.Mount("/api/traces/v1/{tenant}/search",
 					r.Mount("/api/traces/v1/{tenant}",
-						//stripTenantPrefix("/api/traces/v1",
-						tracesv1.NewUIHandler(
-							cfg.traces.readEndpoint,
-							tracesv1.Logger(logger),
-							tracesv1.WithRegistry(reg),
-							tracesv1.WithHandlerInstrumenter(ins),
+						stripTenantPrefix("/api/traces/v1",
+							tracesv1.NewUIHandler(
+								cfg.traces.readEndpoint,
+								tracesv1.Logger(logger),
+								tracesv1.WithRegistry(reg),
+								tracesv1.WithHandlerInstrumenter(ins),
+							),
 						),
-						//),
 					)
 
 					/*

--- a/main.go
+++ b/main.go
@@ -749,7 +749,9 @@ func main() {
 			}, func(err error) {
 				level.Info(logger).Log("msg", "shutting down the gRPC server")
 				gs.GracefulStop()
-				_ = lis.Close()
+				if lis != nil {
+					_ = lis.Close()
+				}
 			})
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -607,7 +607,7 @@ func main() {
 			}
 
 			// Traces.
-			if cfg.traces.enabled {
+			if cfg.traces.enabled && cfg.traces.readEndpoint != nil {
 				r.Group(func(r chi.Router) {
 					r.Use(authentication.WithTenantMiddlewares(pm.Middlewares))
 					r.Use(authentication.WithTenantHeader(cfg.traces.tenantHeader, tenantIDs))
@@ -1025,18 +1025,18 @@ func parseFlags() (config, error) {
 		cfg.logs.writeEndpoint = logsWriteEndpoint
 	}
 
-	if rawTracesWriteEndpoint != "" {
+	if rawTracesReadEndpoint != "" {
 		cfg.traces.enabled = true
 
 		tracesReadEndpoint, err := url.ParseRequestURI(rawTracesReadEndpoint)
 		if err != nil {
-			return cfg, fmt.Errorf("--traces.read.endpoint is invalid, raw %s: %w", rawTracesReadEndpoint, err)
+			return cfg, fmt.Errorf("--traces.read.endpoint %q is invalid: %w", rawTracesReadEndpoint, err)
 		}
 
 		cfg.traces.readEndpoint = tracesReadEndpoint
 	}
 
-	if rawTracesReadEndpoint != "" {
+	if rawTracesWriteEndpoint != "" {
 		cfg.traces.enabled = true
 
 		_, _, err := net.SplitHostPort(rawTracesWriteEndpoint)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"context"
-	"fmt"
 	stdlog "log"
 	"net/http"
 	"net/url"
@@ -37,7 +36,7 @@ func MiddlewareSetUpstream(upstream *url.URL) Middleware {
 		r.URL.Scheme = upstream.Scheme
 		r.URL.Host = upstream.Host
 		r.URL.Path = path.Join(upstream.Path, r.URL.Path)
-		fmt.Printf("@@@ ecs after MiddlewareSetUpstream anon middleware, r.URL=%#v\n", r.URL)
+		// fmt.Printf("@@@ ecs after MiddlewareSetUpstream anon middleware, r.URL=%#v\n", r.URL)
 	}
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -32,11 +32,6 @@ func Middlewares(middlewares ...Middleware) func(r *http.Request) {
 }
 
 func MiddlewareSetUpstream(upstream *url.URL) Middleware {
-	// Verify that the middleware upstream is valid now; rather than failing during processing
-	if upstream == nil {
-		panic("no upstream")
-	}
-
 	return func(r *http.Request) {
 		r.URL.Scheme = upstream.Scheme
 		r.URL.Host = upstream.Host

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"context"
+	"fmt"
 	stdlog "log"
 	"net/http"
 	"net/url"
@@ -36,6 +37,7 @@ func MiddlewareSetUpstream(upstream *url.URL) Middleware {
 		r.URL.Scheme = upstream.Scheme
 		r.URL.Host = upstream.Host
 		r.URL.Path = path.Join(upstream.Path, r.URL.Path)
+		fmt.Printf("@@@ ecs after MiddlewareSetUpstream anon middleware, r.URL=%#v\n", r.URL)
 	}
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -32,6 +32,11 @@ func Middlewares(middlewares ...Middleware) func(r *http.Request) {
 }
 
 func MiddlewareSetUpstream(upstream *url.URL) Middleware {
+	// Verify that the middleware upstream is valid now; rather than failing during processing
+	if upstream == nil {
+		panic("no upstream")
+	}
+
 	return func(r *http.Request) {
 		r.URL.Scheme = upstream.Scheme
 		r.URL.Host = upstream.Host

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -18,7 +18,7 @@ type contextKey string
 const (
 	prefixKey contextKey = "prefix"
 
-	prefixHeader string = "X-Forwarded-Prefix"
+	PrefixHeader string = "X-Forwarded-Prefix"
 )
 
 type Middleware func(r *http.Request)
@@ -36,7 +36,6 @@ func MiddlewareSetUpstream(upstream *url.URL) Middleware {
 		r.URL.Scheme = upstream.Scheme
 		r.URL.Host = upstream.Host
 		r.URL.Path = path.Join(upstream.Path, r.URL.Path)
-		// fmt.Printf("@@@ ecs after MiddlewareSetUpstream anon middleware, r.URL=%#v\n", r.URL)
 	}
 }
 
@@ -48,11 +47,11 @@ func MiddlewareSetPrefixHeader() Middleware {
 		}
 
 		// Do not override the prefix header if it is already set.
-		if r.Header.Get(prefixHeader) != "" {
+		if r.Header.Get(PrefixHeader) != "" {
 			return
 		}
 
-		r.Header.Set(prefixHeader, prefix)
+		r.Header.Set(PrefixHeader, prefix)
 	}
 }
 

--- a/test/e2e/interactive_test.go
+++ b/test/e2e/interactive_test.go
@@ -1,3 +1,4 @@
+//go:build interactive
 // +build interactive
 
 package e2e
@@ -23,7 +24,7 @@ func TestInteractiveSetup(t *testing.T) {
 	readEndpoint, writeEndpoint, readExtEndpoint := startServicesForMetrics(t, e)
 	logsEndpoint, logsExtEndpoint := startServicesForLogs(t, e)
 	rulesEndpoint := startServicesForRules(t, e)
-	internalOtlpEndpoint, httpQueryEndpoint := startServicesForTraces(t, e)
+	internalOtlpEndpoint, httpExternalQueryEndpoint, httpInternalQueryEndpoint := startServicesForTraces(t, e)
 
 	api, err := newObservatoriumAPIService(
 		e,
@@ -33,6 +34,7 @@ func TestInteractiveSetup(t *testing.T) {
 		withRateLimiter(rateLimiterAddr),
 		withGRPCListenEndpoint(":8317"),
 		withOtelTraceEndpoint(internalOtlpEndpoint),
+		withJaegerEndpoint("http://"+httpInternalQueryEndpoint),
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(api))
@@ -57,7 +59,7 @@ func TestInteractiveSetup(t *testing.T) {
 	fmt.Printf("Thanos Query on host machine: 			%s \n", readExtEndpoint)
 	fmt.Printf("Loki on host machine: 				%s \n", logsExtEndpoint)
 	fmt.Printf("Observatorium gRPC API on host machine:           %s\n", api.Endpoint("grpc"))
-	fmt.Printf("Jaeger Query on host machine (HTTP):              %s\n", httpQueryEndpoint)
+	fmt.Printf("Jaeger Query on host machine (HTTP):              %s\n", httpExternalQueryEndpoint)
 
 	fmt.Printf("API Token: 					%s \n\n", token)
 

--- a/test/e2e/interactive_test.go
+++ b/test/e2e/interactive_test.go
@@ -1,4 +1,3 @@
-//go:build interactive
 // +build interactive
 
 package e2e

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -1,4 +1,3 @@
-//go:build integration || interactive
 // +build integration interactive
 
 package e2e

--- a/test/e2e/traces_test.go
+++ b/test/e2e/traces_test.go
@@ -1,4 +1,3 @@
-//go:build integration
 // +build integration
 
 package e2e


### PR DESCRIPTION
This PR adds proxying of the Jaeger V2 HTTP query API and the Jaeger UI assets.

With this change, the Jaeger UI is available at http://localhost:8080/api/traces/v1/test-oidc/search/

Note that the first time logging in, it redirects away from traces.  Not sure if that is correct or not.

Note that there are currently no multi-tenant backends for Jaeger, so the UI currently sees all traces.  The work to divide the tenants will be done in Jaeger itself or another front-end, probably not in observatorium/api.