### PR TITLE
Fix grpc port name by making it lowercase

### DIFF
--- a/examples/manifests/deployment-with-tls.yaml
+++ b/examples/manifests/deployment-with-tls.yaml
@@ -56,12 +56,12 @@ spec:
           periodSeconds: 30
         name: observatorium-api
         ports:
+        - containerPort: 8090
+          name: grpc-public
         - containerPort: 8081
           name: internal
         - containerPort: 8080
           name: public
-        - containerPort: 8090
-          name: publicGrpc
         readinessProbe:
           failureThreshold: 12
           httpGet:

--- a/examples/manifests/deployment.yaml
+++ b/examples/manifests/deployment.yaml
@@ -50,12 +50,12 @@ spec:
           periodSeconds: 30
         name: observatorium-api
         ports:
+        - containerPort: 8090
+          name: grpc-public
         - containerPort: 8081
           name: internal
         - containerPort: 8080
           name: public
-        - containerPort: 8090
-          name: publicGrpc
         readinessProbe:
           failureThreshold: 12
           httpGet:

--- a/examples/manifests/service-with-tls.yaml
+++ b/examples/manifests/service-with-tls.yaml
@@ -10,15 +10,15 @@ metadata:
   namespace: observatorium
 spec:
   ports:
+  - name: grpc-public
+    port: 8090
+    targetPort: 8090
   - name: internal
     port: 8081
     targetPort: 8081
   - name: public
     port: 8080
     targetPort: 8080
-  - name: publicGrpc
-    port: 8090
-    targetPort: 8090
   selector:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api

--- a/examples/manifests/service.yaml
+++ b/examples/manifests/service.yaml
@@ -10,15 +10,15 @@ metadata:
   namespace: observatorium
 spec:
   ports:
+  - name: grpc-public
+    port: 8090
+    targetPort: 8090
   - name: internal
     port: 8081
     targetPort: 8081
   - name: public
     port: 8080
     targetPort: 8080
-  - name: publicGrpc
-    port: 8090
-    targetPort: 8090
   selector:
     app.kubernetes.io/component: api
     app.kubernetes.io/instance: observatorium-api

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -12,7 +12,7 @@ local defaults = {
   ports: {
     public: 8080,
     internal: 8081,
-    publicGrpc: 8090,
+    'grpc-public': 8090,
   },
   resources: {},
   serviceMonitor: false,
@@ -133,7 +133,7 @@ function(params) {
                 if api.config.traces != {} then
                   [
                     '--traces.write.endpoint=' + api.config.traces.writeEndpoint,
-                    '--grpc.listen=' + api.config.ports.publicGrpc,
+                    '--grpc.listen=' + api.config.ports['grpc-public'],
                   ] else []
               ) + (
                 if api.config.rbac != {} then ['--rbac.config=/etc/observatorium/rbac.yaml'] else []


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>


The port name cannot be upper case:

```
Error from server (Invalid): error when creating "manifests/api-deployment.yaml": Deployment.apps "observatorium-xyz-observatorium-api" is invalid: spec.template.spec.containers[0].ports[2].name: Invalid value: "publicGrpc": must contain only alpha-numeric characters (a-z, 0-9), and hyphens (-)
Error from server (Invalid): error when creating "manifests/api-service.yaml": Service "observatorium-xyz-observatorium-api" is invalid: spec.ports[2].name: Invalid value: "publicGrpc": a lowercase RFC 1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')

```