### PR TITLE
Add trace recieving to TestInteractive

### DIFF
--- a/test/e2e/interactive_test.go
+++ b/test/e2e/interactive_test.go
@@ -23,6 +23,7 @@ func TestInteractiveSetup(t *testing.T) {
 	readEndpoint, writeEndpoint, readExtEndpoint := startServicesForMetrics(t, e)
 	logsEndpoint, logsExtEndpoint := startServicesForLogs(t, e)
 	rulesEndpoint := startServicesForRules(t, e)
+	internalOtlpEndpoint, httpQueryEndpoint := startServicesForTraces(t, e)
 
 	api, err := newObservatoriumAPIService(
 		e,
@@ -30,6 +31,8 @@ func TestInteractiveSetup(t *testing.T) {
 		withLogsEndpoints("http://"+logsEndpoint),
 		withRulesEndpoint("http://"+rulesEndpoint),
 		withRateLimiter(rateLimiterAddr),
+		withGRPCListenEndpoint(":8317"),
+		withOtelTraceEndpoint(internalOtlpEndpoint),
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(api))
@@ -53,6 +56,9 @@ func TestInteractiveSetup(t *testing.T) {
 	fmt.Printf("Observatorium internal server on host machine: 	%s \n", api.Endpoint("http-internal"))
 	fmt.Printf("Thanos Query on host machine: 			%s \n", readExtEndpoint)
 	fmt.Printf("Loki on host machine: 				%s \n", logsExtEndpoint)
+	fmt.Printf("Observatorium gRPC API on host machine:           %s\n", api.Endpoint("grpc"))
+	fmt.Printf("Jaeger Query on host machine (HTTP):              %s\n", httpQueryEndpoint)
+
 	fmt.Printf("API Token: 					%s \n\n", token)
 
 	testutil.Ok(t, e2einteractive.RunUntilEndpointHit())


### PR DESCRIPTION
This PR adds trace receiving to TestInteractive.

This starts an Open Telemetry collector that forwards to a Jaeger with memory-only storage.
This enables Observatorium to listen for GRPC, and to forward to that OTel collector.

Note that this configuration is merely for testing; the memory-only Jaeger does not support tenancy or persist traces.

To actually run the test you'll need to check out https://github.com/open-telemetry/opentelemetry-proto because neither Observatorium nor OTel support gRPC reflection.

To run the test first `go test -v --tags=interactive -test.timeout=9999m -run TestInteractiveSetup ./test/e2e/.`.  (The `-v` is important, otherwise you don't see the ports and logs.)

(The test outputs important ports and an OIDC token.  It then outputs logs continuously -- you may want to control-s your terminal!)

Next, in another window, 

```
API_TOKEN=<the value output by the test>
OBSERVATORIUM_GRPC_PORT=<the value output by the test>
JAEGER_PORT=<the value output by the test>
OTEL_DIR=<the location of the OTel proto org> # typically ~/go/src/opentelemetry.io/

# Create a trace with ID dbafe6c78cad6907da57ceeea8aa1c64
cat > /tmp/one-trace-with-service.json <<EOM
{"resourceSpans":[
  {
    "resource": {
      "attributes": {"key": "service.name", "value": { "string_value": "another-service"}}
    },
    "instrumentationLibrarySpans":[{"spans":[
    {
      "trace_id":"26/mx4ytaQfaV87uqKocZA==",
      "span_id": "wPE19XLMS30=",
      "name": "test",
      "start_time_unix_nano": $(date +%s000000000),
      "endTimeUnixNano": $(date +%s999999999),
      "kind": 3,
      "status": { "code": 1, "message": "sunny" } 
  }
]}]}]}
EOM

# Sent the trace to Observatorium
(cat /tmp/one-trace-with-service.json; sleep 2) | grpcurl --insecure -d @ -import-path "$OTEL_DIR"/opentelemetry-proto/ -proto "$OTEL_DIR"/opentelemetry-proto/opentelemetry/proto/collector/trace/v1/trace_service.proto -H "Authorization: bearer $API_TOKEN" -H "X-Tenant: test-oidc" localhost:"$OBSERVATORIUM_GRPC_PORT" opentelemetry.proto.collector.trace.v1.TraceService/Export

# Read the trace from Jaeger
curl "localhost:$JAEGER_PORT/api/v3/traces/dbafe6c78cad6907da57ceeea8aa1c64"
```

Note that the OTel collector is configured to log traces, so you can see it working with `docker logs`.
Note that once https://github.com/observatorium/api/pull/252 merges Observatorium will be used to retrieve traces, in addition to directly contacting Jaeger

To cause the test to clean up, _curl_ the URL output by the test.