### PR TITLE
Pseudo-tenancy for trace queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ Usage of ./observatorium-api:
     	The percentage of mutex contention events that are reported in the mutex profile. (default 10)
   -debug.name string
     	A name to add as a prefix to log lines. (default "observatorium")
+  -experimental.traces.read.endpoint-template string
+    	A template replacing --read.traces.endpoint, such as http://jaeger-{tenant}-query:16686
   -grpc.listen string
     	The address on which the public gRPC server listens.
   -internal.tracing.endpoint string

--- a/api/traces/v1/api.go
+++ b/api/traces/v1/api.go
@@ -11,7 +11,7 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 )
 
-// TraceRoute represents the fully-qualified gRPC method name for exporting a trace
+// TraceRoute represents the fully-qualified gRPC method name for exporting a trace.
 const TraceRoute = "/opentelemetry.proto.collector.trace.v1.TraceService/Export"
 
 type connOptions struct {

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"path"
 	"strings"
 	"time"
 
@@ -20,6 +21,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
+	"github.com/observatorium/api/authentication"
 	"github.com/observatorium/api/proxy"
 )
 
@@ -95,8 +97,8 @@ func (n nopInstrumentHandler) NewHandler(labels prometheus.Labels, handler http.
 // The web UI handler is able to rewrite
 // HTML to change the <base> attribute so that it works with the Observatorium-style
 // "/api/v1/traces/{tenant}/" URLs.
-func NewV2Handler(read *url.URL, opts ...HandlerOption) http.Handler {
-	if read == nil {
+func NewV2Handler(read string, opts ...HandlerOption) http.Handler {
+	if read == "" {
 		panic("missing Jaeger read url")
 	}
 
@@ -116,7 +118,7 @@ func NewV2Handler(read *url.URL, opts ...HandlerOption) http.Handler {
 	{
 		level.Debug(c.logger).Log("msg", "Configuring upstream Jaeger", "queryv2", read)
 		middlewares := proxy.Middlewares(
-			proxy.MiddlewareSetUpstream(read),
+			middlewareSetTemplatedUpstream(c.logger, read),
 			proxy.MiddlewareSetPrefixHeader(),
 			proxy.MiddlewareLogger(c.logger),
 			proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "tracesv1-read"}),
@@ -161,6 +163,55 @@ func NewV2Handler(read *url.URL, opts ...HandlerOption) http.Handler {
 	})
 
 	return r
+}
+
+// Parse a URL; if the URL includes `{tenant}` that portion will be replaced by the tenant
+func ExpandTemplatedUpstream(templateUpstream, tenant string) (*url.URL, error) {
+	rawTracesReadEndpoint := strings.Replace(templateUpstream, "{tenant}", tenant, 1)
+	return url.ParseRequestURI(rawTracesReadEndpoint)
+}
+
+// middlewareSetTemplatedUpstream is a variation of proxy.MiddlewareSetUpstream()
+// with additional processing if the upstream includes "{tenant}"
+func middlewareSetTemplatedUpstream(logger log.Logger, upstreamTemplate string) proxy.Middleware {
+	// If the upstream is a URL, parse it once
+	upstream, err := url.ParseRequestURI(upstreamTemplate)
+	if err == nil {
+		return func(r *http.Request) {
+			r.URL.Scheme = upstream.Scheme
+			r.URL.Host = upstream.Host
+			r.URL.Path = path.Join(upstream.Path, r.URL.Path)
+		}
+	}
+
+	// The upstream is not a URL.  We checked at startup that `-traces.read.endpoint`
+	// was either a URL or a templated URL, so we must have a templated URL.
+
+	// Cache upstream URLs to avoid re-parse on every read
+	templateToURL := map[string]*url.URL{}
+
+	return func(r *http.Request) {
+		tenant, ok := authentication.GetTenant(r.Context())
+		if !ok {
+			// At this point another middleware must have put the tenant into the context
+			level.Debug(logger).Log("msg", "Internal error; expected tenant in request context")
+		}
+
+		upstream, ok := templateToURL[tenant]
+		if !ok {
+			upstream, err = ExpandTemplatedUpstream(upstreamTemplate, tenant)
+			if err != nil {
+				// Log if the tenant label includes characters that can't appear in a hostname (such as punctuation)
+				level.Debug(logger).Log("msg", "Internal error; tenant contains characters that cannot appear in hostname")
+			}
+
+			templateToURL[tenant] = upstream
+		}
+
+		r.URL.Scheme = upstream.Scheme
+		r.URL.Host = upstream.Host
+		r.URL.Path = path.Join(upstream.Path, r.URL.Path)
+	}
 }
 
 func jaegerUIResponseModifier(response *http.Response) error {

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -190,7 +190,8 @@ func middlewareSetUpstream(logger log.Logger, read *url.URL, readTemplate string
 
 		upstream, ok := templateToURL[tenant]
 		if !ok {
-			upstream, err := ExpandTemplatedUpstream(readTemplate, tenant)
+			var err error
+			upstream, err = ExpandTemplatedUpstream(readTemplate, tenant)
 			if err != nil {
 				// Log if the tenant label includes characters that can't appear in a hostname (such as punctuation)
 				level.Debug(logger).Log("msg", "Internal error; tenant contains characters that cannot appear in hostname")

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -134,7 +134,10 @@ function(params) {
                   [
                     '--traces.write.endpoint=' + api.config.traces.writeEndpoint,
                     '--grpc.listen=0.0.0.0:' + api.config.ports['grpc-public'],
-                  ] else []
+                  ] + (if std.objectHas(api.config.traces, 'readEndpoint') then [
+                         '--traces.read.endpoint=' + api.config.traces.readEndpoint,
+                       ] else [])
+                else []
               ) + (
                 if api.config.rbac != {} then ['--rbac.config=/etc/observatorium/rbac.yaml'] else []
               ) + (

--- a/jsonnet/lib/observatorium-api.libsonnet
+++ b/jsonnet/lib/observatorium-api.libsonnet
@@ -137,6 +137,9 @@ function(params) {
                   ] + (if std.objectHas(api.config.traces, 'readEndpoint') then [
                          '--traces.read.endpoint=' + api.config.traces.readEndpoint,
                        ] else [])
+                  + (if std.objectHas(api.config.traces, 'templateEndpoint') then [
+                       '--experimental.traces.read.endpoint-template=' + api.config.traces.templateEndpoint,
+                     ] else [])
                 else []
               ) + (
                 if api.config.rbac != {} then ['--rbac.config=/etc/observatorium/rbac.yaml'] else []

--- a/main.go
+++ b/main.go
@@ -140,13 +140,13 @@ type logsConfig struct {
 }
 
 type tracesConfig struct {
-	// readTemplateEndpoint is of the form "http://jaeger-{tenant}:16686"
-	// or "http://jaeger:16686"
+	// readTemplateEndpoint is of the form "http://jaeger-{tenant}-query:16686"
 	readTemplateEndpoint string
 
+	readEndpoint  *url.URL
 	writeEndpoint string
 	tenantHeader  string
-	// enable traces if readTemplateEndpoint or writeEndpoint is provided.
+	// enable traces if readTemplateEndpoint, readEndpoint, or writeEndpoint is provided.
 	enabled bool
 }
 
@@ -610,7 +610,7 @@ func main() {
 			}
 
 			// Traces.
-			if cfg.traces.enabled && cfg.traces.readTemplateEndpoint != "" {
+			if cfg.traces.enabled && (cfg.traces.readEndpoint != nil || cfg.traces.readTemplateEndpoint != "") {
 				r.Group(func(r chi.Router) {
 					r.Use(authentication.WithTenantMiddlewares(pm.Middlewares))
 					r.Use(authentication.WithTenantHeader(cfg.traces.tenantHeader, tenantIDs))
@@ -631,6 +631,7 @@ func main() {
 					r.Mount("/api/traces/v1/{tenant}",
 						stripTenantPrefix("/api/traces/v1",
 							tracesv1.NewV2Handler(
+								cfg.traces.readEndpoint,
 								cfg.traces.readTemplateEndpoint,
 								tracesv1.Logger(logger),
 								tracesv1.WithRegistry(reg),
@@ -904,6 +905,8 @@ func parseFlags() (config, error) {
 		"The name of the PromQL label that should hold the tenant ID in metrics upstreams.")
 	flag.StringVar(&rawTracesReadEndpoint, "traces.read.endpoint", "",
 		"The endpoint against which to make HTTP read requests for traces.")
+	flag.StringVar(&cfg.traces.readTemplateEndpoint, "experimental.traces.read.endpoint-template", "",
+		"A template replacing --read.traces.endpoint, such as http://jaeger-{tenant}-query:16686")
 	flag.StringVar(&rawTracesWriteEndpoint, "traces.write.endpoint", "",
 		"The endpoint against which to make gRPC write requests for traces.")
 	flag.StringVar(&cfg.traces.tenantHeader, "traces.tenant-header", "X-Tenant",
@@ -1012,15 +1015,12 @@ func parseFlags() (config, error) {
 	if rawTracesReadEndpoint != "" {
 		cfg.traces.enabled = true
 
-		_, err := url.ParseRequestURI(rawTracesReadEndpoint)
+		tracesReadEndpoint, err := url.ParseRequestURI(rawTracesReadEndpoint)
 		if err != nil {
-			_, err2 := tracesv1.ExpandTemplatedUpstream(rawTracesReadEndpoint, "dummy")
-			if err2 != nil {
-				return cfg, fmt.Errorf("--traces.read.endpoint %q is invalid: %w", rawTracesReadEndpoint, err)
-			}
+			return cfg, fmt.Errorf("--traces.read.endpoint %q is invalid: %w", rawTracesReadEndpoint, err)
 		}
 
-		cfg.traces.readTemplateEndpoint = rawTracesReadEndpoint
+		cfg.traces.readEndpoint = tracesReadEndpoint
 	}
 
 	if rawTracesWriteEndpoint != "" {
@@ -1032,6 +1032,20 @@ func parseFlags() (config, error) {
 		}
 
 		cfg.traces.writeEndpoint = rawTracesWriteEndpoint
+	}
+
+	if cfg.traces.readTemplateEndpoint != "" {
+		if cfg.traces.readEndpoint != nil {
+			return cfg, fmt.Errorf("only one of --traces.read.endpoint and --experimental.traces.read.endpoint-template allowed")
+		}
+
+		// After the template is expanded, will it yield a valid URL?
+		_, err := tracesv1.ExpandTemplatedUpstream(cfg.traces.readTemplateEndpoint, "dummy")
+		if err != nil {
+			return cfg, fmt.Errorf("--experimental.traces.read.endpoint-template %q is invalid: %w", rawTracesReadEndpoint, err)
+		}
+
+		cfg.traces.enabled = true
 	}
 
 	if cfg.traces.enabled && cfg.server.grpcListen == "" {

--- a/main.go
+++ b/main.go
@@ -1039,6 +1039,12 @@ func parseFlags() (config, error) {
 			return cfg, fmt.Errorf("only one of --traces.read.endpoint and --experimental.traces.read.endpoint-template allowed")
 		}
 
+		if !strings.Contains(cfg.traces.readTemplateEndpoint, "{tenant}") {
+			fmt.Fprintf(os.Stderr,
+				"--experimental.traces.read.endpoint-template does not contain '{tenant}', all tenants will use %q\n",
+				cfg.traces.readTemplateEndpoint)
+		}
+
 		// After the template is expanded, will it yield a valid URL?
 		_, err := tracesv1.ExpandTemplatedUpstream(cfg.traces.readTemplateEndpoint, "dummy")
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ type logsConfig struct {
 }
 
 type tracesConfig struct {
-	// readTemplateEndpoint is of the form "http://jaeger-{tenant}-query:16686"
+	// readTemplateEndpoint is of the form "http://jaeger-{tenant}-query:16686".
 	readTemplateEndpoint string
 
 	readEndpoint  *url.URL

--- a/main.go
+++ b/main.go
@@ -365,11 +365,7 @@ func main() {
 	// Running in container with limits but with empty/wrong value of GOMAXPROCS env var could lead to throttling by cpu
 	// maxprocs will automate adjustment by using cgroups info about cpu limit if it set as value for runtime.GOMAXPROCS
 	undo, err := maxprocs.Set(maxprocs.Logger(func(template string, args ...interface{}) {
-		if len(args) == 0 {
-			level.Debug(logger).Log("msg", template)
-		} else {
-			level.Debug(logger).Log("msg", fmt.Sprintf(template, args))
-		}
+		level.Debug(logger).Log("msg", fmt.Sprintf(template, args))
 	}))
 	if err != nil {
 		level.Error(logger).Log("msg", "failed to set GOMAXPROCS:", "err", err)

--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -22,6 +22,7 @@ const (
 	rules       testType = "rules"
 	logs        testType = "logs"
 	traces      testType = "traces"
+	tracetempls testType = "tracetempls"
 	tenants     testType = "tenants"
 	interactive testType = "interactive"
 
@@ -36,6 +37,7 @@ const (
 	envRulesAPIName = "e2e_rules_api"
 	envLogsName     = "e2e_logs_read_write_tail"
 	envTracesName   = "e2e_traces_read_export"
+	envTTemplsName  = "e2e_traces2_templ_query"
 	envTenantsName  = "e2e_tenants"
 	envInteractive  = "e2e_interactive"
 

--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -18,13 +18,13 @@ import (
 type testType string
 
 const (
-	metrics     testType = "metrics"
-	rules       testType = "rules"
-	logs        testType = "logs"
-	traces      testType = "traces"
-	tracetempls testType = "tracetempls"
-	tenants     testType = "tenants"
-	interactive testType = "interactive"
+	metrics        testType = "metrics"
+	rules          testType = "rules"
+	logs           testType = "logs"
+	traces         testType = "traces"
+	tracesTemplate testType = "tracesTemplate"
+	tenants        testType = "tenants"
+	interactive    testType = "interactive"
 
 	dockerLocalSharedDir = "/shared"
 	certsSharedDir       = "certs"
@@ -33,13 +33,13 @@ const (
 	certsContainerPath   = dockerLocalSharedDir + "/" + certsSharedDir
 	configsContainerPath = dockerLocalSharedDir + "/" + configSharedDir
 
-	envMetricsName  = "e2e_metrics_read_write"
-	envRulesAPIName = "e2e_rules_api"
-	envLogsName     = "e2e_logs_read_write_tail"
-	envTracesName   = "e2e_traces_read_export"
-	envTTemplsName  = "e2e_traces2_templ_query"
-	envTenantsName  = "e2e_tenants"
-	envInteractive  = "e2e_interactive"
+	envMetricsName        = "e2e_metrics_read_write"
+	envRulesAPIName       = "e2e_rules_api"
+	envLogsName           = "e2e_logs_read_write_tail"
+	envTracesName         = "e2e_traces_read_export"
+	envTracesTemplateName = "e2e_traces_template_query"
+	envTenantsName        = "e2e_tenants"
+	envInteractive        = "e2e_interactive"
 
 	defaultTenantID = "1610b0c3-c509-4592-a256-a1871353dbfa"
 	mtlsTenantID    = "845cdfd9-f936-443c-979c-2ee7dc91f646"
@@ -235,7 +235,7 @@ service:
             exporters: [logging,jaeger]
 `
 
-// createOtelCollectorConfigYAML() creates YAML for an Open Telemetry collector inside the Observatorium API boundary
+// createOtelCollectorConfigYAML() creates YAML for an Open Telemetry collector inside the Observatorium API boundary.
 func createOtelCollectorConfigYAML(
 	t *testing.T,
 	e e2e.Environment,

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -95,8 +95,8 @@ func getContainerName(t *testing.T, tt testType, serviceName string) string {
 		return envInteractive + "-" + serviceName
 	case traces:
 		return envTracesName + "-" + serviceName
-	case tracetempls:
-		return envTTemplsName + "-" + serviceName
+	case tracesTemplate:
+		return envTracesTemplateName + "-" + serviceName
 	default:
 		t.Fatal("invalid test type provided")
 		return ""

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -95,6 +95,8 @@ func getContainerName(t *testing.T, tt testType, serviceName string) string {
 		return envInteractive + "-" + serviceName
 	case traces:
 		return envTracesName + "-" + serviceName
+	case tracetempls:
+		return envTTemplsName + "-" + serviceName
 	default:
 		t.Fatal("invalid test type provided")
 		return ""

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -314,7 +314,7 @@ type apiOptions struct {
 	gRPCListenEndpoint   string
 	jaegerQueryEndpoint  string
 
-	// "experimental.traces.read.endpoint-template" value
+	// "experimental.traces.read.endpoint-template" value.
 	tracesExperimentalTemplateReadEndpoint string
 }
 

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -313,6 +313,9 @@ type apiOptions struct {
 	tracesWriteEndpoint  string
 	gRPCListenEndpoint   string
 	jaegerQueryEndpoint  string
+
+	// "experimental.traces.read.endpoint-template" value
+	tracesExperimentalTemplateReadEndpoint string
 }
 
 type apiOption func(*apiOptions)
@@ -345,6 +348,12 @@ func withGRPCListenEndpoint(listenEndpoint string) apiOption {
 func withJaegerEndpoint(jaegerQueryEndpoint string) apiOption {
 	return func(o *apiOptions) {
 		o.jaegerQueryEndpoint = jaegerQueryEndpoint
+	}
+}
+
+func withExperimentalJaegerTemplateEndpoint(jaegerQueryEndpointTemplate string) apiOption {
+	return func(o *apiOptions) {
+		o.tracesExperimentalTemplateReadEndpoint = jaegerQueryEndpointTemplate
 	}
 }
 
@@ -407,6 +416,10 @@ func newObservatoriumAPIService(
 
 	if opts.tracesWriteEndpoint != "" {
 		args = append(args, "--traces.write.endpoint="+opts.tracesWriteEndpoint)
+	}
+
+	if opts.tracesExperimentalTemplateReadEndpoint != "" {
+		args = append(args, "--experimental.traces.read.endpoint-template="+opts.tracesExperimentalTemplateReadEndpoint)
 	}
 
 	if opts.jaegerQueryEndpoint != "" {

--- a/test/e2e/traces_test.go
+++ b/test/e2e/traces_test.go
@@ -1,4 +1,3 @@
-//go:build integration
 // +build integration
 
 package e2e

--- a/test/e2e/traces_test.go
+++ b/test/e2e/traces_test.go
@@ -55,17 +55,17 @@ const (
 }`
 
 	//nolint:lll
-	// queriedV3Trace is traceJSON returned through Jaeger's V3 API
+	// queriedV3Trace is traceJSON returned through Jaeger's V3 API.
 	queriedV3Trace = `{"result":{"resourceSpans":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"testHost"}}]},"instrumentationLibrarySpans":[{"instrumentationLibrary":{},"spans":[{"traceId":"W47/95gDgQPSabYzgT/GDA==","spanId":"7uGbfsPBsXM=","parentSpanId":"AAAAAAAAAAA=","name":"testSpan","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1544712660000000000","endTimeUnixNano":"1544712661000000000","attributes":[{"key":"attr1","value":{"intValue":"55"}},{"key":"internal.span.format","value":{"stringValue":"proto"}}]}]}]}]}}`
 
 	//nolint:lll
-	// queriedV2Trace is traceJSON returned through Jaeger's V2 API
+	// queriedV2Trace is traceJSON returned through Jaeger's V2 API.
 	queriedV2Trace = `{"data":[{"traceID":"5b8efff798038103d269b633813fc60c","spans":[{"traceID":"5b8efff798038103d269b633813fc60c","spanID":"eee19b7ec3c1b173","operationName":"testSpan","references":[],"startTime":1544712660000000,"duration":1000000,"tags":[{"key":"attr1","type":"int64","value":55},{"key":"internal.span.format","type":"string","value":"proto"}],"logs":[],"processID":"p1","warnings":null}],"processes":{"p1":{"serviceName":"","tags":[{"key":"host.name","type":"string","value":"testHost"}]}},"warnings":null}],"total":0,"limit":0,"offset":0,"errors":null}`
 
-	// queriedV2Trace is service description JSON returned through Jaeger's V2 API
+	// queriedV2Trace is service description JSON returned through Jaeger's V2 API.
 	queriedV2Services = `{"data":[""],"total":1,"limit":0,"offset":0,"errors":null}`
 
-	// queriedV2Dependencies is dependencies JSON returned through Jaeger's V2 API
+	// queriedV2Dependencies is dependencies JSON returned through Jaeger's V2 API.
 	queriedV2Dependencies = `{"data":[],"total":0,"limit":0,"offset":0,"errors":null}`
 )
 
@@ -87,7 +87,7 @@ func TestTracesExport(t *testing.T) {
 		withJaegerEndpoint("http://"+httpInternalQueryEndpoint),
 
 		// This test doesn't actually write logs, but we need
-		// this because Observatorium currently MUST see a logs or metrics endpoints
+		// this because Observatorium currently MUST see a logs or metrics endpoints.
 		withLogsEndpoints("http://localhost:8080"),
 	)
 	testutil.Ok(t, err)
@@ -99,7 +99,7 @@ func TestTracesExport(t *testing.T) {
 			api.InternalEndpoint("grpc"),
 			token)
 
-		otel := e.Runnable("otel-fwd-coll").
+		otel := e.Runnable("otel-fwd-collector").
 			WithPorts(
 				map[string]int{
 					"http": 4318,
@@ -119,7 +119,7 @@ func TestTracesExport(t *testing.T) {
 		testutil.Ok(t, e2e.StartAndWaitReady(otel))
 
 		// Send trace insecurly to forwarding OTel collector for forwarding through Observatorium
-		// (This code could be refactored to observatorium/up, the test client)
+		// (This code could be refactored to observatorium/up, the test client).
 
 		client := &http.Client{}
 		request, err := http.NewRequest(
@@ -152,7 +152,7 @@ func TestTracesExport(t *testing.T) {
 		httpObservatoriumQueryEndpoint := fmt.Sprintf("https://%s/api/traces/v1/test-oidc/api", api.Endpoint("https"))
 		httpObservatoriumQueryTraceEndpoint := fmt.Sprintf("%s/traces", httpObservatoriumQueryEndpoint)
 		// We skip TLS verification because Observatorium will present a cert for "e2e_traces_read_export-api",
-		// but we contact it using "localhost"
+		// but we contact it using "localhost".
 		returnedTrace, _ = queryForTraceV2(t, "valid Observatorium trace v2 query",
 			httpObservatoriumQueryTraceEndpoint, "5B8EFFF798038103D269B633813FC60C",
 			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
@@ -258,38 +258,37 @@ func requestWithRetry(t *testing.T, testLabel string, client *http.Client, reque
 	return "", -1
 }
 
-func TestTraceTemplateQuery(t *testing.T) {
+func TestTracesTemplateQuery(t *testing.T) {
 	t.Parallel()
 
-	e, err := e2e.NewDockerEnvironment(envTTemplsName)
+	e, err := e2e.NewDockerEnvironment(envTracesTemplateName)
 	testutil.Ok(t, err)
 	t.Cleanup(e.Close)
 
-	prepareConfigsAndCerts(t, tracetempls, e)
-	_, token, _ := startBaseServices(t, e, tracetempls)
+	prepareConfigsAndCerts(t, tracesTemplate, e)
+	_, token, _ := startBaseServices(t, e, tracesTemplate)
 	internalOtlpEndpoint, httpExternalQueryEndpoint, httpInternalQueryEndpoint := startServicesForTraces(t, e)
 
 	api, err := newObservatoriumAPIService(
 		e,
 		withGRPCListenEndpoint(":8317"),
-		// Note that we don't include `{tenant}`, because we can't easily do this with DNS on Docker
+		// Note that we don't include `{tenant}`, because we can't easily do this with DNS on Docker.
 		withOtelTraceEndpoint(internalOtlpEndpoint),
 		withExperimentalJaegerTemplateEndpoint("http://"+httpInternalQueryEndpoint),
 
 		// This test doesn't actually write logs, but we need
-		// this because Observatorium currently MUST see a logs or metrics endpoints
+		// this because Observatorium currently MUST see a logs or metrics endpoints.
 		withLogsEndpoints("http://localhost:8080"),
 	)
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(api))
 
-	t.Run("write-then-query-single-trace", func(t *testing.T) {
-
+	t.Run("write-then-template-query-single-trace", func(t *testing.T) {
 		createOtelForwardingCollectorConfigYAML(t, e,
 			api.InternalEndpoint("grpc"),
 			token)
 
-		otel := e.Runnable("otel-fwd-coll").
+		otel := e.Runnable("otel-fwd-collector").
 			WithPorts(
 				map[string]int{
 					"http": 4318,
@@ -309,7 +308,7 @@ func TestTraceTemplateQuery(t *testing.T) {
 		testutil.Ok(t, e2e.StartAndWaitReady(otel))
 
 		// Send trace insecurly to forwarding OTel collector for forwarding through Observatorium
-		// (This code could be refactored to observatorium/up, the test client)
+		// (This code could be refactored to observatorium/up, the test client).
 
 		client := &http.Client{}
 		request, err := http.NewRequest(
@@ -342,7 +341,7 @@ func TestTraceTemplateQuery(t *testing.T) {
 		httpObservatoriumQueryEndpoint := fmt.Sprintf("https://%s/api/traces/v1/test-oidc/api", api.Endpoint("https"))
 		httpObservatoriumQueryTraceEndpoint := fmt.Sprintf("%s/traces", httpObservatoriumQueryEndpoint)
 		// We skip TLS verification because Observatorium will present a cert for "e2e_traces_read_export-api",
-		// but we contact it using "localhost"
+		// but we contact it using "localhost".
 		returnedTrace, _ = queryForTraceV2(t, "valid Observatorium trace v2 query",
 			httpObservatoriumQueryTraceEndpoint, "5B8EFFF798038103D269B633813FC60C",
 			true, fmt.Sprintf("bearer %s", token), http.StatusOK)

--- a/test/e2e/traces_test.go
+++ b/test/e2e/traces_test.go
@@ -261,12 +261,12 @@ func requestWithRetry(t *testing.T, testLabel string, client *http.Client, reque
 func TestTraceTemplateQuery(t *testing.T) {
 	t.Parallel()
 
-	e, err := e2e.NewDockerEnvironment(envTracesName)
+	e, err := e2e.NewDockerEnvironment(envTTemplsName)
 	testutil.Ok(t, err)
 	t.Cleanup(e.Close)
 
-	prepareConfigsAndCerts(t, traces, e)
-	_, token, _ := startBaseServices(t, e, traces)
+	prepareConfigsAndCerts(t, tracetempls, e)
+	_, token, _ := startBaseServices(t, e, tracetempls)
 	internalOtlpEndpoint, httpExternalQueryEndpoint, httpInternalQueryEndpoint := startServicesForTraces(t, e)
 
 	api, err := newObservatoriumAPIService(

--- a/test/e2e/traces_test.go
+++ b/test/e2e/traces_test.go
@@ -257,3 +257,115 @@ func requestWithRetry(t *testing.T, testLabel string, client *http.Client, reque
 	testutil.Assert(t, false, fmt.Sprintf("%s: HTTP %d response not received within time limit", testLabel, expectedResponse))
 	return "", -1
 }
+
+func TestTraceTemplateQuery(t *testing.T) {
+	t.Parallel()
+
+	e, err := e2e.NewDockerEnvironment(envTracesName)
+	testutil.Ok(t, err)
+	t.Cleanup(e.Close)
+
+	prepareConfigsAndCerts(t, traces, e)
+	_, token, _ := startBaseServices(t, e, traces)
+	internalOtlpEndpoint, httpExternalQueryEndpoint, httpInternalQueryEndpoint := startServicesForTraces(t, e)
+
+	api, err := newObservatoriumAPIService(
+		e,
+		withGRPCListenEndpoint(":8317"),
+		// Note that we don't include `{tenant}`, because we can't easily do this with DNS on Docker
+		withOtelTraceEndpoint(internalOtlpEndpoint),
+		withExperimentalJaegerTemplateEndpoint("http://"+httpInternalQueryEndpoint),
+
+		// This test doesn't actually write logs, but we need
+		// this because Observatorium currently MUST see a logs or metrics endpoints
+		withLogsEndpoints("http://localhost:8080"),
+	)
+	testutil.Ok(t, err)
+	testutil.Ok(t, e2e.StartAndWaitReady(api))
+
+	t.Run("write-then-query-single-trace", func(t *testing.T) {
+
+		createOtelForwardingCollectorConfigYAML(t, e,
+			api.InternalEndpoint("grpc"),
+			token)
+
+		otel := e.Runnable("otel-fwd-coll").
+			WithPorts(
+				map[string]int{
+					"http": 4318,
+					"grpc": 4317,
+				}).
+			Init(e2e.StartOptions{
+				Image: otelFwdCollectorImage,
+				Volumes: []string{
+					fmt.Sprintf("%s:/conf/forwarding-collector.yaml",
+						filepath.Join(filepath.Join(e.SharedDir(), configSharedDir, "forwarding-collector.yaml"))),
+				},
+				Command: e2e.Command{
+					Args: []string{"--config=/conf/forwarding-collector.yaml"},
+				},
+			})
+
+		testutil.Ok(t, e2e.StartAndWaitReady(otel))
+
+		// Send trace insecurly to forwarding OTel collector for forwarding through Observatorium
+		// (This code could be refactored to observatorium/up, the test client)
+
+		client := &http.Client{}
+		request, err := http.NewRequest(
+			"POST",
+			fmt.Sprintf("http://%s/v1/traces", otel.Endpoint("http")),
+			bytes.NewBuffer([]byte(traceJSON)))
+		testutil.Ok(t, err)
+		request.Header.Set("Content-Type", "application/json")
+		response, err := client.Do(request)
+		testutil.Ok(t, err)
+		defer response.Body.Close()
+
+		body, err := ioutil.ReadAll(response.Body)
+		testutil.Ok(t, err)
+
+		bodyStr := string(body)
+		assertResponse(t, bodyStr, "{}")
+
+		testutil.Equals(t, http.StatusOK, response.StatusCode)
+
+		returnedTrace := queryForTraceDirectV3(t,
+			httpExternalQueryEndpoint, "5B8EFFF798038103D269B633813FC60C")
+		assertResponse(t, returnedTrace, queriedV3Trace)
+
+		returnedTrace, _ = queryForTraceV2(t, "direct Jaeger v2 query",
+			fmt.Sprintf("http://%s/api/traces", httpExternalQueryEndpoint), "5B8EFFF798038103D269B633813FC60C",
+			false, "", http.StatusOK)
+		assertResponse(t, returnedTrace, queriedV2Trace)
+
+		httpObservatoriumQueryEndpoint := fmt.Sprintf("https://%s/api/traces/v1/test-oidc/api", api.Endpoint("https"))
+		httpObservatoriumQueryTraceEndpoint := fmt.Sprintf("%s/traces", httpObservatoriumQueryEndpoint)
+		// We skip TLS verification because Observatorium will present a cert for "e2e_traces_read_export-api",
+		// but we contact it using "localhost"
+		returnedTrace, _ = queryForTraceV2(t, "valid Observatorium trace v2 query",
+			httpObservatoriumQueryTraceEndpoint, "5B8EFFF798038103D269B633813FC60C",
+			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
+		assertResponse(t, returnedTrace, queriedV2Trace)
+
+		_, returnedStatus := queryForTraceV2(t, "invalid Observatorium trace v2 query",
+			httpObservatoriumQueryTraceEndpoint, "5B8EFFF798038103D269B633813FC60C",
+			true, fmt.Sprintf("bearer invalid-token"), 500)
+		testutil.Equals(t, returnedStatus, 500)
+
+		returnedTrace, _ = queryForTraceV2(t, "direct Jaeger v2 query",
+			fmt.Sprintf("http://%s/api/traces", httpExternalQueryEndpoint), "5B8EFFF798038103D269B633813FC60C",
+			false, "", http.StatusOK)
+		assertResponse(t, returnedTrace, queriedV2Trace)
+
+		returnedServices, _ := queryJaeger(t, "Observatorium services v2 query",
+			fmt.Sprintf("%s/services", httpObservatoriumQueryEndpoint),
+			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
+		assertResponse(t, returnedServices, queriedV2Services)
+
+		returnedDependencies, _ := queryJaeger(t, "Observatorium dependencies v2 query",
+			fmt.Sprintf("%s/dependencies", httpObservatoriumQueryEndpoint),
+			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
+		assertResponse(t, returnedDependencies, queriedV2Dependencies)
+	})
+}

--- a/test/e2e/traces_test.go
+++ b/test/e2e/traces_test.go
@@ -1,3 +1,4 @@
+//go:build integration
 // +build integration
 
 package e2e
@@ -61,9 +62,6 @@ const (
 	//nolint:lll
 	// queriedV2Trace is traceJSON returned through Jaeger's V2 API.
 	queriedV2Trace = `{"data":[{"traceID":"5b8efff798038103d269b633813fc60c","spans":[{"traceID":"5b8efff798038103d269b633813fc60c","spanID":"eee19b7ec3c1b173","operationName":"testSpan","references":[],"startTime":1544712660000000,"duration":1000000,"tags":[{"key":"attr1","type":"int64","value":55},{"key":"internal.span.format","type":"string","value":"proto"}],"logs":[],"processID":"p1","warnings":null}],"processes":{"p1":{"serviceName":"","tags":[{"key":"host.name","type":"string","value":"testHost"}]}},"warnings":null}],"total":0,"limit":0,"offset":0,"errors":null}`
-
-	// queriedV2Trace is service description JSON returned through Jaeger's V2 API.
-	queriedV2Services = `{"data":[""],"total":1,"limit":0,"offset":0,"errors":null}`
 
 	// queriedV2Dependencies is dependencies JSON returned through Jaeger's V2 API.
 	queriedV2Dependencies = `{"data":[],"total":0,"limit":0,"offset":0,"errors":null}`
@@ -168,10 +166,12 @@ func TestTracesExport(t *testing.T) {
 			false, "", http.StatusOK)
 		assertResponse(t, returnedTrace, queriedV2Trace)
 
-		returnedServices, _ := queryJaeger(t, "Observatorium services v2 query",
+		_, returnedStatus = queryJaeger(t, "Observatorium services v2 query",
 			fmt.Sprintf("%s/services", httpObservatoriumQueryEndpoint),
 			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
-		assertResponse(t, returnedServices, queriedV2Services)
+		// We don't compare the JSON, as it can differ
+		// slightly depending on timing and retries.
+		testutil.Equals(t, returnedStatus, 200)
 
 		returnedDependencies, _ := queryJaeger(t, "Observatorium dependencies v2 query",
 			fmt.Sprintf("%s/dependencies", httpObservatoriumQueryEndpoint),
@@ -357,10 +357,12 @@ func TestTracesTemplateQuery(t *testing.T) {
 			false, "", http.StatusOK)
 		assertResponse(t, returnedTrace, queriedV2Trace)
 
-		returnedServices, _ := queryJaeger(t, "Observatorium services v2 query",
+		_, returnedStatus = queryJaeger(t, "Observatorium services v2 query",
 			fmt.Sprintf("%s/services", httpObservatoriumQueryEndpoint),
 			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
-		assertResponse(t, returnedServices, queriedV2Services)
+		// We don't compare the JSON, as it can differ
+		// slightly depending on timing and retries.
+		testutil.Equals(t, returnedStatus, 200)
 
 		returnedDependencies, _ := queryJaeger(t, "Observatorium dependencies v2 query",
 			fmt.Sprintf("%s/dependencies", httpObservatoriumQueryEndpoint),


### PR DESCRIPTION
Signed-off-by: Ed Snible <snible@us.ibm.com>

Resolves https://github.com/observatorium/api/issues/267 allowing Jaeger query hosts to be specified in Jsonnet.

Resolves https://github.com/observatorium/api/issues/268 by allowing the `-traces.read.endpoint` to describe multiple single-tenant Jaeger instances.  For example, we can say `-traces.read.endpoint=http://jaeger-{tenant}-query:16686`.  (This uses the same convention we use in the configuration of the OTel processor.)

With this implementation, Observatorium can provide all tenants with their own Jaeger instance.  In the future, when Jaeger itself supports tenancy, we simply change the read endpoint to point to the multi-tenant Jaeger.

cc @pavolloffay 