### PR TITLE
Login endpoint at /api/traces/v1/{tenent}/login

### DIFF
--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -46,6 +46,10 @@ func (a dummyAuthenticator) Handler() (string, http.Handler) {
 	return "", nil
 }
 
+func (a dummyAuthenticator) LoginPath(tenant string) string {
+	return ""
+}
+
 func newdummyAuthenticator(c map[string]interface{}, tenant string, registrationRetryCount *prometheus.CounterVec, logger log.Logger) (Provider, error) {
 	var config dummyAuthenticatorConfig
 

--- a/authentication/mtls.go
+++ b/authentication/mtls.go
@@ -156,3 +156,7 @@ func (a MTLSAuthenticator) GRPCMiddleware() grpc.StreamServerInterceptor {
 func (a MTLSAuthenticator) Handler() (string, http.Handler) {
 	return "", nil
 }
+
+func (a MTLSAuthenticator) LoginPath(tenant string) string {
+	return ""
+}

--- a/authentication/oidc.go
+++ b/authentication/oidc.go
@@ -434,3 +434,7 @@ func (a oidcAuthenticator) checkAuth(ctx context.Context, token string) (context
 
 	return ctx, "", http.StatusOK, codes.OK
 }
+
+func (a oidcAuthenticator) LoginPath(tenant string) string {
+	return strings.ReplaceAll("/oidc/{tenant}/login", "{tenant}", tenant)
+}

--- a/authentication/openshift.go
+++ b/authentication/openshift.go
@@ -507,3 +507,7 @@ func (a OpenShiftAuthenticator) GRPCMiddleware() grpc.StreamServerInterceptor {
 func (a OpenShiftAuthenticator) Handler() (string, http.Handler) {
 	return "/openshift/{tenant}", a.handler
 }
+
+func (a OpenShiftAuthenticator) LoginPath(tenant string) string {
+	return strings.ReplaceAll("/openshift/{tenant}/login", "{tenant}", tenant)
+}


### PR DESCRIPTION
Resolves https://github.com/observatorium/api/issues/266

This creates the endpoint /api/traces/v1/{tenent}/login which redirects to that tenant's provider-specific login endpoint.

This allows the trace UI to log out using a relative path, e.g. `./logout`, rather than requiring knowledge of the authentication provider specified in _tenants.yaml_.

Currently only exposed for tracing, but all the plumbing is there other UIs.

PR is created as a **draft** so please comment on the direction/idea.  If the approach is good I will begin work on tests.