### PR TITLE
Add optional series matcher in spec

### DIFF
--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -24,7 +24,7 @@ import (
 // GetLabelValuesParams defines parameters for GetLabelValues.
 type GetLabelValuesParams struct {
 	// Repeated series selector argument
-	Match externalRef1.SeriesMatcher `json:"match[]"`
+	Match *externalRef1.OptionalSeriesMatcher `json:"match[],omitempty"`
 
 	// Start timestamp
 	Start *externalRef1.StartTS `json:"start,omitempty"`
@@ -36,7 +36,7 @@ type GetLabelValuesParams struct {
 // GetLabelsParams defines parameters for GetLabels.
 type GetLabelsParams struct {
 	// Repeated series selector argument
-	Match externalRef1.SeriesMatcher `json:"match[]"`
+	Match *externalRef1.OptionalSeriesMatcher `json:"match[],omitempty"`
 
 	// Start timestamp
 	Start *externalRef1.StartTS `json:"start,omitempty"`
@@ -325,16 +325,20 @@ func NewGetLabelValuesRequest(server string, tenant externalRef1.Tenant, labelNa
 
 	queryValues := queryURL.Query()
 
-	if queryFrag, err := runtime.StyleParamWithLocation("form", true, "match[]", runtime.ParamLocationQuery, params.Match); err != nil {
-		return nil, err
-	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-		return nil, err
-	} else {
-		for k, v := range parsed {
-			for _, v2 := range v {
-				queryValues.Add(k, v2)
+	if params.Match != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "match[]", runtime.ParamLocationQuery, *params.Match); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
 			}
 		}
+
 	}
 
 	if params.Start != nil {
@@ -407,16 +411,20 @@ func NewGetLabelsRequest(server string, tenant externalRef1.Tenant, params *GetL
 
 	queryValues := queryURL.Query()
 
-	if queryFrag, err := runtime.StyleParamWithLocation("form", true, "match[]", runtime.ParamLocationQuery, params.Match); err != nil {
-		return nil, err
-	} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
-		return nil, err
-	} else {
-		for k, v := range parsed {
-			for _, v2 := range v {
-				queryValues.Add(k, v2)
+	if params.Match != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "match[]", runtime.ParamLocationQuery, *params.Match); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
 			}
 		}
+
 	}
 
 	if params.Start != nil {

--- a/client/parameters/parameters.gen.go
+++ b/client/parameters/parameters.gen.go
@@ -6,6 +6,9 @@ package parameters
 // EndTS defines model for endTS.
 type EndTS string
 
+// OptionalSeriesMatcher defines model for optionalSeriesMatcher.
+type OptionalSeriesMatcher []string
+
 // Query defines model for query.
 type Query string
 

--- a/client/parameters/parameters.yaml
+++ b/client/parameters/parameters.yaml
@@ -16,6 +16,14 @@ components:
         type: array
         items:
           type: string
+    optionalSeriesMatcher:
+      in: query
+      name: match[]
+      description: Repeated series selector argument
+      schema:
+        type: array
+        items:
+          type: string
     startTS:
       in: query
       name: start

--- a/client/spec.yaml
+++ b/client/spec.yaml
@@ -95,7 +95,7 @@ paths:
   /api/metrics/v1/{tenant}/api/v1/labels:
     parameters:
       - $ref: ./parameters/parameters.yaml#/components/parameters/tenant
-      - $ref: ./parameters/parameters.yaml#/components/parameters/seriesMatcher
+      - $ref: ./parameters/parameters.yaml#/components/parameters/optionalSeriesMatcher
       - $ref: ./parameters/parameters.yaml#/components/parameters/startTS
       - $ref: ./parameters/parameters.yaml#/components/parameters/endTS
     get:
@@ -125,7 +125,7 @@ paths:
         required: true
         schema:
           type: string
-      - $ref: ./parameters/parameters.yaml#/components/parameters/seriesMatcher
+      - $ref: ./parameters/parameters.yaml#/components/parameters/optionalSeriesMatcher
       - $ref: ./parameters/parameters.yaml#/components/parameters/startTS
       - $ref: ./parameters/parameters.yaml#/components/parameters/endTS
     get:


### PR DESCRIPTION
This PR adds `optionalSeriesMatcher` parameter in the oapi spec to use in endpoints like /api/v1/labels and /api/v1/label/{name}/values.