### PR TITLE
Add logo within spec for API docs

### DIFF
--- a/client/spec.yaml
+++ b/client/spec.yaml
@@ -6,6 +6,9 @@ info:
   license:
     name: Apache 2.0
     url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+  x-logo:
+    url: 'https://observatorium.io/observatorium.png'
+    altText: 'Observatorium logo'
 tags:
   - name: observatoriumv1
     description: Calls related to Observatorium


### PR DESCRIPTION
This PR adds a logo in the spec, which would appear in API docs here: https://github.com/observatorium/observatorium/pull/483.