### PR TITLE
Label Enforcer: If parsing fails, change HTTP status code to bad request

### DIFF
--- a/api/metrics/v1/labels_enforcer.go
+++ b/api/metrics/v1/labels_enforcer.go
@@ -143,7 +143,8 @@ func enforceRequestQueryLabels(e *injectproxy.Enforcer, w http.ResponseWriter, r
 	// Enforce the query in the POST body if needed.
 	if r.Method == http.MethodPost {
 		if err := r.ParseForm(); err != nil {
-			http.Error(w, fmt.Sprintf("could not parse form: %v", err), http.StatusBadRequest)
+			// We're returning server error here because we cannot ensure this is a bad request.
+			http.Error(w, fmt.Sprintf("could not parse form: %v", err), http.StatusInternalServerError)
 
 			return
 		}

--- a/api/metrics/v1/labels_enforcer.go
+++ b/api/metrics/v1/labels_enforcer.go
@@ -132,7 +132,7 @@ func enforceRequestQueryLabels(e *injectproxy.Enforcer, w http.ResponseWriter, r
 	// enforce in both places.
 	q, found1, err := enforceQueryValues(e, r.URL.Query())
 	if err != nil {
-		http.Error(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusInternalServerError)
+		http.Error(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusBadRequest)
 
 		return
 	}
@@ -143,14 +143,14 @@ func enforceRequestQueryLabels(e *injectproxy.Enforcer, w http.ResponseWriter, r
 	// Enforce the query in the POST body if needed.
 	if r.Method == http.MethodPost {
 		if err := r.ParseForm(); err != nil {
-			http.Error(w, fmt.Sprintf("could not parse form: %v", err), http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("could not parse form: %v", err), http.StatusBadRequest)
 
 			return
 		}
 
 		q, found2, err = enforceQueryValues(e, r.PostForm)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusInternalServerError)
+			http.Error(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusBadRequest)
 
 			return
 		}


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

We have noticed that if a user is providing an invalid query to the API on the read path, this will result in HTTP response `500`. This is due to the fact that when we are enforcing labels and parsing the query, we are considering this to be an server error, which it is not. Since method `enforceQueryValues` can fail only if given invalid input, I'd suggest changing this the response to bad request to indicate to the user the error is on their side.