### PR TITLE
Move setting up middleware before authN route mounting

### DIFF
--- a/authentication/http.go
+++ b/authentication/http.go
@@ -187,7 +187,6 @@ func EnforceAccessTokenPresentOnSignalWrite(oidcTenants map[string]struct{}) fun
 			}
 
 			next.ServeHTTP(w, r)
-			return
 		})
 	}
 }

--- a/main.go
+++ b/main.go
@@ -460,17 +460,30 @@ func main() {
 		hardcodedLabels := []string{"group", "handler"}
 		instrumenter := server.NewInstrumentedHandlerFactory(reg, hardcodedLabels)
 
-		tenantIDs := map[string]string{}
-		authorizers := map[string]rbac.Authorizer{}
-		var rateLimits []ratelimit.Config
-		oidcTenants := map[string]struct{}{}
-		// registrationRetryCount used by authenticator providers to count
-		// registration failures per tenant.
-		registerTenantsFailingMetric := authentication.RegisterTenantsFailingMetric(reg)
-		pm := authentication.NewProviderManager(logger, registerTenantsFailingMetric)
+		var (
+			tenantIDs   = map[string]string{}
+			authorizers = map[string]rbac.Authorizer{}
+			oidcTenants = map[string]struct{}{}
+
+			rateLimits []ratelimit.Config
+			// registrationRetryCount used by authenticator providers to count
+			// registration failures per tenant.
+			registerTenantsFailingMetric = authentication.RegisterTenantsFailingMetric(reg)
+			pm                           = authentication.NewProviderManager(logger, registerTenantsFailingMetric)
+		)
 
 		r.Group(func(r chi.Router) {
-			// registeredAuthNRoutes is used to avoid double register the same pattern.
+			// Set up common middleware before mounting authN routes.
+			for _, t := range tenantsCfg.Tenants {
+				tenantIDs[t.Name] = t.ID
+			}
+
+			r.Use(authentication.WithTenant)
+			r.Use(authentication.WithTenantID(tenantIDs))
+			r.Use(authentication.WithAccessToken())
+			r.MethodNotAllowed(blockNonDefinedMethods())
+
+			// registeredAuthNRoutes is used to avoid double registration of the same pattern.
 			var regMtx sync.RWMutex
 			registeredAuthNRoutes := make(map[string]struct{})
 			for _, t := range tenantsCfg.Tenants {
@@ -478,7 +491,6 @@ func main() {
 					continue
 				}
 				level.Info(logger).Log("msg", "adding a tenant", "tenant", t.Name)
-				tenantIDs[t.Name] = t.ID
 				if t.RateLimits != nil {
 					for _, rl := range t.RateLimits {
 						matcher, err := regexp.Compile(rl.Endpoint)
@@ -521,11 +533,6 @@ func main() {
 					authorizers[t.Name] = authorizer
 				}
 			}
-
-			r.Use(authentication.WithTenant)
-			r.Use(authentication.WithTenantID(tenantIDs))
-			r.Use(authentication.WithAccessToken())
-			r.MethodNotAllowed(blockNonDefinedMethods())
 
 			writePathRedirectProtection := authentication.EnforceAccessTokenPresentOnSignalWrite(oidcTenants)
 


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

I started to nice [some E2E test](https://app.circleci.com/pipelines/github/observatorium/api/740/workflows/7481ee6b-6ae4-4bb0-8e40-d9f78e7c5eaa/jobs/3687) runs failing with this in the output:
```
12:27:49 observatorium_api: level=info name=observatorium ts=2022-06-20T12:27:49.093915144Z caller=panic.go:1038 msg=exiting
12:27:49 observatorium_api: panic: chi: all middlewares must be defined before routes on a mux
12:27:49 observatorium_api: goroutine 1 [running]:
12:27:49 observatorium_api: github.com/go-chi/chi.(*Mux).Use(0x194ba80, {0xc0002237e8, 0xc0002060e5, 0x9})
12:27:49 observatorium_api: /home/circleci/.go_workspace/pkg/mod/github.com/go-chi/chi@v4.1.2+incompatible/mux.go:98 +0x126
12:27:49 observatorium_api: main.main.func4({0x1e9ce90, 0xc0006838c0})
12:27:49 observatorium_api: /home/circleci/project/main.go:525 +0x777
12:27:49 observatorium_api: github.com/go-chi/chi.(*Mux).Group(0x1ba14dc, 0xc00037fa78)
12:27:49 observatorium_api: /home/circleci/.go_workspace/pkg/mod/github.com/go-chi/chi@v4.1.2+incompatible/mux.go:255 +0x4b
12:27:49 observatorium_api: main.main()
12:27:49 observatorium_api: /home/circleci/project/main.go:472 +0x309
```

Looking at the code, chi requires us to first set up middleware and only then allows us to specify routes on the router. Doing this the other way around [results in a panic](https://github.com/go-chi/chi/blob/b75b525e1d50900a814c222113c415b81648e45c/mux.go#L102).

Although it's not apparent from the output (since it captures only when the panic happens, but it does not tell us which routes were mounted), I'm assuming this comes from mounting authN routes here:
https://github.com/observatorium/api/blob/e79e6a1b0325fed6d988bd79c308b6e7be547b17/main.go#L513

Since we're doing this in a separate goroutine, I'm assuming in some rare cases the goroutine to mount can finish before we specify the middleware in the main goroutine.

This PR propose a simple fix by reorganizing the code a bit - first we do a first pass and collect all tenant IDs and setup common middlewares. Then we start doing second pass through tenant configs and start setting up the authN routes.