### PR TITLE
Return errors in Prometheus HTTP API format

### DIFF
--- a/api/logs/v1/labels_enforcer.go
+++ b/api/logs/v1/labels_enforcer.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/observatorium/api/authorization"
 	logqlv2 "github.com/observatorium/api/logql/v2"
+	"github.com/observatorium/api/utils"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
@@ -18,7 +19,7 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			data, ok := authorization.GetData(r.Context())
 			if !ok {
-				http.Error(w, "error finding authorization label matcher", http.StatusInternalServerError)
+				utils.PrometheusAPIError(w, "error finding authorization label matcher", http.StatusInternalServerError)
 
 				return
 			}
@@ -33,14 +34,14 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 
 			var lm []*labels.Matcher
 			if err := json.Unmarshal([]byte(data), &lm); err != nil {
-				http.Error(w, "error parsing authorization label matchers", http.StatusInternalServerError)
+				utils.PrometheusAPIError(w, "error parsing authorization label matchers", http.StatusInternalServerError)
 
 				return
 			}
 
 			q, err := enforceValues(lm, r.URL.Query())
 			if err != nil {
-				http.Error(w, fmt.Sprintf("could not enforce authorization label matchers: %v", err), http.StatusInternalServerError)
+				utils.PrometheusAPIError(w, fmt.Sprintf("could not enforce authorization label matchers: %v", err), http.StatusInternalServerError)
 
 				return
 			}

--- a/api/logs/v1/labels_enforcer.go
+++ b/api/logs/v1/labels_enforcer.go
@@ -7,8 +7,8 @@ import (
 	"net/url"
 
 	"github.com/observatorium/api/authorization"
+	"github.com/observatorium/api/httperr"
 	logqlv2 "github.com/observatorium/api/logql/v2"
-	"github.com/observatorium/api/utils"
 	"github.com/prometheus/prometheus/pkg/labels"
 )
 
@@ -19,7 +19,7 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			data, ok := authorization.GetData(r.Context())
 			if !ok {
-				utils.PrometheusAPIError(w, "error finding authorization label matcher", http.StatusInternalServerError)
+				httperr.PrometheusAPIError(w, "error finding authorization label matcher", http.StatusInternalServerError)
 
 				return
 			}
@@ -34,14 +34,14 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 
 			var lm []*labels.Matcher
 			if err := json.Unmarshal([]byte(data), &lm); err != nil {
-				utils.PrometheusAPIError(w, "error parsing authorization label matchers", http.StatusInternalServerError)
+				httperr.PrometheusAPIError(w, "error parsing authorization label matchers", http.StatusInternalServerError)
 
 				return
 			}
 
 			q, err := enforceValues(lm, r.URL.Query())
 			if err != nil {
-				utils.PrometheusAPIError(w, fmt.Sprintf("could not enforce authorization label matchers: %v", err), http.StatusInternalServerError)
+				httperr.PrometheusAPIError(w, fmt.Sprintf("could not enforce authorization label matchers: %v", err), http.StatusInternalServerError)
 
 				return
 			}

--- a/api/metrics/v1/labels_enforcer.go
+++ b/api/metrics/v1/labels_enforcer.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/observatorium/api/authentication"
 	"github.com/observatorium/api/authorization"
-	"github.com/observatorium/api/utils"
+	"github.com/observatorium/api/httperr"
 	"github.com/prometheus-community/prom-label-proxy/injectproxy"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -29,7 +29,7 @@ func WithEnforceTenancyOnQuery(label string) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id, ok := authentication.GetTenantID(r.Context())
 			if !ok {
-				utils.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
+				httperr.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
 
 				return
 			}
@@ -60,7 +60,7 @@ func WithEnforceTenancyOnMatchers(label string) func(http.Handler) http.Handler 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id, ok := authentication.GetTenantID(r.Context())
 			if !ok {
-				utils.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
+				httperr.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
 
 				return
 			}
@@ -101,7 +101,7 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			data, ok := authorization.GetData(r.Context())
 			if !ok {
-				utils.PrometheusAPIError(w, "error finding authorization label matcher", http.StatusInternalServerError)
+				httperr.PrometheusAPIError(w, "error finding authorization label matcher", http.StatusInternalServerError)
 
 				return
 			}
@@ -116,7 +116,7 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 
 			var lm []*labels.Matcher
 			if err := json.Unmarshal([]byte(data), &lm); err != nil {
-				utils.PrometheusAPIError(w, "error parsing authorization label matcher", http.StatusInternalServerError)
+				httperr.PrometheusAPIError(w, "error parsing authorization label matcher", http.StatusInternalServerError)
 
 				return
 			}
@@ -139,7 +139,7 @@ func enforceRequestQueryLabels(e *injectproxy.Enforcer, w http.ResponseWriter, r
 	// enforce in both places.
 	q, found1, err := enforceQueryValues(e, r.URL.Query())
 	if err != nil {
-		utils.PrometheusAPIError(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusBadRequest)
+		httperr.PrometheusAPIError(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusBadRequest)
 
 		return false
 	}
@@ -151,14 +151,14 @@ func enforceRequestQueryLabels(e *injectproxy.Enforcer, w http.ResponseWriter, r
 	if r.Method == http.MethodPost {
 		if err := r.ParseForm(); err != nil {
 			// We're returning server error here because we cannot ensure this is a bad request.
-			utils.PrometheusAPIError(w, fmt.Sprintf("could not parse form: %v", err), http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, fmt.Sprintf("could not parse form: %v", err), http.StatusInternalServerError)
 
 			return false
 		}
 
 		q, found2, err = enforceQueryValues(e, r.PostForm)
 		if err != nil {
-			utils.PrometheusAPIError(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusBadRequest)
+			httperr.PrometheusAPIError(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusBadRequest)
 
 			return false
 		}
@@ -170,7 +170,7 @@ func enforceRequestQueryLabels(e *injectproxy.Enforcer, w http.ResponseWriter, r
 
 	// If no query was found, return early.
 	if !found1 && !found2 {
-		utils.PrometheusAPIError(w, "no query found", http.StatusBadRequest)
+		httperr.PrometheusAPIError(w, "no query found", http.StatusBadRequest)
 
 		return false
 	}

--- a/api/metrics/v1/labels_enforcer.go
+++ b/api/metrics/v1/labels_enforcer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/observatorium/api/authentication"
 	"github.com/observatorium/api/authorization"
+	"github.com/observatorium/api/utils"
 	"github.com/prometheus-community/prom-label-proxy/injectproxy"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -28,7 +29,7 @@ func WithEnforceTenancyOnQuery(label string) func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id, ok := authentication.GetTenantID(r.Context())
 			if !ok {
-				http.Error(w, "error finding tenant ID", http.StatusInternalServerError)
+				utils.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
 
 				return
 			}
@@ -59,7 +60,7 @@ func WithEnforceTenancyOnMatchers(label string) func(http.Handler) http.Handler 
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id, ok := authentication.GetTenantID(r.Context())
 			if !ok {
-				http.Error(w, "error finding tenant ID", http.StatusInternalServerError)
+				utils.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
 
 				return
 			}
@@ -100,7 +101,7 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			data, ok := authorization.GetData(r.Context())
 			if !ok {
-				http.Error(w, "error finding authorization label matcher", http.StatusInternalServerError)
+				utils.PrometheusAPIError(w, "error finding authorization label matcher", http.StatusInternalServerError)
 
 				return
 			}
@@ -115,7 +116,7 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 
 			var lm []*labels.Matcher
 			if err := json.Unmarshal([]byte(data), &lm); err != nil {
-				http.Error(w, "error parsing authorization label matcher", http.StatusInternalServerError)
+				utils.PrometheusAPIError(w, "error parsing authorization label matcher", http.StatusInternalServerError)
 
 				return
 			}
@@ -138,7 +139,7 @@ func enforceRequestQueryLabels(e *injectproxy.Enforcer, w http.ResponseWriter, r
 	// enforce in both places.
 	q, found1, err := enforceQueryValues(e, r.URL.Query())
 	if err != nil {
-		http.Error(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusBadRequest)
+		utils.PrometheusAPIError(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusBadRequest)
 
 		return false
 	}
@@ -150,14 +151,14 @@ func enforceRequestQueryLabels(e *injectproxy.Enforcer, w http.ResponseWriter, r
 	if r.Method == http.MethodPost {
 		if err := r.ParseForm(); err != nil {
 			// We're returning server error here because we cannot ensure this is a bad request.
-			http.Error(w, fmt.Sprintf("could not parse form: %v", err), http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, fmt.Sprintf("could not parse form: %v", err), http.StatusInternalServerError)
 
 			return false
 		}
 
 		q, found2, err = enforceQueryValues(e, r.PostForm)
 		if err != nil {
-			http.Error(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusBadRequest)
+			utils.PrometheusAPIError(w, fmt.Sprintf("could not enforce labels: %v", err), http.StatusBadRequest)
 
 			return false
 		}
@@ -169,7 +170,7 @@ func enforceRequestQueryLabels(e *injectproxy.Enforcer, w http.ResponseWriter, r
 
 	// If no query was found, return early.
 	if !found1 && !found2 {
-		http.Error(w, "no query found", http.StatusBadRequest)
+		utils.PrometheusAPIError(w, "no query found", http.StatusBadRequest)
 
 		return false
 	}

--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/observatorium/api/authentication"
 	"github.com/observatorium/api/rules"
+	"github.com/observatorium/api/utils"
 	"github.com/prometheus-community/prom-label-proxy/injectproxy"
 	"github.com/prometheus/prometheus/pkg/labels"
 	"github.com/prometheus/prometheus/promql/parser"
@@ -99,13 +100,13 @@ type rulesHandler struct {
 func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 	tenant, ok := authentication.GetTenant(r.Context())
 	if !ok {
-		http.Error(w, "error finding tenant", http.StatusUnauthorized)
+		utils.PrometheusAPIError(w, "error finding tenant", http.StatusUnauthorized)
 		return
 	}
 
 	id, ok := authentication.GetTenantID(r.Context())
 	if !ok {
-		http.Error(w, "error finding tenant ID", http.StatusUnauthorized)
+		utils.PrometheusAPIError(w, "error finding tenant ID", http.StatusUnauthorized)
 		return
 	}
 
@@ -118,7 +119,7 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 			sc = resp.StatusCode
 		}
 
-		http.Error(w, "error listing rules", sc)
+		utils.PrometheusAPIError(w, "error listing rules", sc)
 
 		return
 	}
@@ -128,9 +129,9 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 	if resp.StatusCode/100 != 2 {
 		switch resp.StatusCode {
 		case http.StatusNotFound:
-			http.Error(w, "no rules found", resp.StatusCode)
+			utils.PrometheusAPIError(w, "no rules found", resp.StatusCode)
 		default:
-			http.Error(w, "error listing rules", resp.StatusCode)
+			utils.PrometheusAPIError(w, "error listing rules", resp.StatusCode)
 		}
 
 		return
@@ -139,7 +140,7 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 	rawRules, err := unmarshalRules(resp.Body)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not unmarshal rules", "err", err.Error())
-		http.Error(w, "error unmarshaling rules", http.StatusInternalServerError)
+		utils.PrometheusAPIError(w, "error unmarshaling rules", http.StatusInternalServerError)
 
 		return
 	}
@@ -147,7 +148,7 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 	err = enforceLabelsInRules(rawRules, rh.tenantLabel, id)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not enforce labels in rules", "err", err.Error())
-		http.Error(w, "failed to process rules", http.StatusInternalServerError)
+		utils.PrometheusAPIError(w, "failed to process rules", http.StatusInternalServerError)
 
 		return
 	}
@@ -155,7 +156,7 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 	body, err := yaml.Marshal(rawRules)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not marshal rules YAML", "err", err.Error())
-		http.Error(w, "error marshaling rules YAML", http.StatusInternalServerError)
+		utils.PrometheusAPIError(w, "error marshaling rules YAML", http.StatusInternalServerError)
 
 		return
 	}
@@ -169,19 +170,19 @@ func (rh *rulesHandler) get(w http.ResponseWriter, r *http.Request) {
 func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 	tenant, ok := authentication.GetTenant(r.Context())
 	if !ok {
-		http.Error(w, "error finding tenant", http.StatusUnauthorized)
+		utils.PrometheusAPIError(w, "error finding tenant", http.StatusUnauthorized)
 	}
 
 	id, ok := authentication.GetTenantID(r.Context())
 	if !ok {
-		http.Error(w, "error finding tenant ID", http.StatusUnauthorized)
+		utils.PrometheusAPIError(w, "error finding tenant ID", http.StatusUnauthorized)
 		return
 	}
 
 	rawRules, err := unmarshalRules(r.Body)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not unmarshal rules", "err", err.Error())
-		http.Error(w, "error unmarshaling rules", http.StatusInternalServerError)
+		utils.PrometheusAPIError(w, "error unmarshaling rules", http.StatusInternalServerError)
 
 		return
 	}
@@ -189,7 +190,7 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 	err = enforceLabelsInRules(rawRules, rh.tenantLabel, id)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not enforce labels in rules", "err", err.Error())
-		http.Error(w, "failed to process rules", http.StatusInternalServerError)
+		utils.PrometheusAPIError(w, "failed to process rules", http.StatusInternalServerError)
 
 		return
 	}
@@ -197,7 +198,7 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 	body, err := yaml.Marshal(rawRules)
 	if err != nil {
 		level.Error(rh.logger).Log("msg", "could not marshal rules YAML", "err", err.Error())
-		http.Error(w, "error marshaling rules YAML", http.StatusInternalServerError)
+		utils.PrometheusAPIError(w, "error marshaling rules YAML", http.StatusInternalServerError)
 
 		return
 	}
@@ -210,7 +211,7 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 		}
 
 		level.Error(rh.logger).Log("msg", "could not set rules", "err", err.Error())
-		http.Error(w, "error creating rules", sc)
+		utils.PrometheusAPIError(w, "error creating rules", sc)
 
 		return
 	}
@@ -220,7 +221,7 @@ func (rh *rulesHandler) put(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(resp.StatusCode)
 
 	if _, err := io.Copy(w, resp.Body); err != nil {
-		http.Error(w, "error writing rules response", http.StatusInternalServerError)
+		utils.PrometheusAPIError(w, "error writing rules response", http.StatusInternalServerError)
 		return
 	}
 }

--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/observatorium/api/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 )
@@ -132,7 +133,7 @@ func (pm *ProviderManager) PatternHandler(pattern string) http.HandlerFunc {
 		const msg = "error finding tenant"
 		if !ok {
 			level.Warn(pm.logger).Log("msg", msg, "tenant", tenant)
-			http.Error(w, msg, http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -141,7 +142,7 @@ func (pm *ProviderManager) PatternHandler(pattern string) http.HandlerFunc {
 		pm.mtx.RUnlock()
 		if !ok {
 			level.Debug(pm.logger).Log("msg", msg, "tenant", tenant)
-			http.Error(w, msg, http.StatusUnauthorized)
+			utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 			return
 		}
 		h.ServeHTTP(w, r)

--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/observatorium/api/utils"
+	"github.com/observatorium/api/httperr"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 )
@@ -133,7 +133,7 @@ func (pm *ProviderManager) PatternHandler(pattern string) http.HandlerFunc {
 		const msg = "error finding tenant"
 		if !ok {
 			level.Warn(pm.logger).Log("msg", msg, "tenant", tenant)
-			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -142,7 +142,7 @@ func (pm *ProviderManager) PatternHandler(pattern string) http.HandlerFunc {
 		pm.mtx.RUnlock()
 		if !ok {
 			level.Debug(pm.logger).Log("msg", msg, "tenant", tenant)
-			utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
+			httperr.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 			return
 		}
 		h.ServeHTTP(w, r)

--- a/authentication/http.go
+++ b/authentication/http.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi"
+	"github.com/observatorium/api/utils"
 )
 
 // contextKey to use when setting context values in the HTTP package.
@@ -143,7 +144,7 @@ func WithTenantMiddlewares(mwFns ...MiddlewareFunc) Middleware {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			tenant, ok := GetTenant(r.Context())
 			if !ok {
-				http.Error(w, "error finding tenant", http.StatusBadRequest)
+				utils.PrometheusAPIError(w, "error finding tenant", http.StatusBadRequest)
 				return
 			}
 
@@ -154,7 +155,7 @@ func WithTenantMiddlewares(mwFns ...MiddlewareFunc) Middleware {
 				}
 			}
 
-			http.Error(w, "tenant not found, have you registered it?", http.StatusUnauthorized)
+			utils.PrometheusAPIError(w, "tenant not found, have you registered it?", http.StatusUnauthorized)
 		})
 	}
 }
@@ -182,7 +183,7 @@ func EnforceAccessTokenPresentOnSignalWrite(oidcTenants map[string]struct{}) fun
 
 			rawToken := r.Header.Get("Authorization")
 			if rawToken == "" {
-				http.Error(w, "couldn't find the authorization header", http.StatusBadRequest)
+				utils.PrometheusAPIError(w, "couldn't find the authorization header", http.StatusBadRequest)
 				return
 			}
 

--- a/authentication/http.go
+++ b/authentication/http.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-chi/chi"
-	"github.com/observatorium/api/utils"
+	"github.com/observatorium/api/httperr"
 )
 
 // contextKey to use when setting context values in the HTTP package.
@@ -144,7 +144,7 @@ func WithTenantMiddlewares(mwFns ...MiddlewareFunc) Middleware {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			tenant, ok := GetTenant(r.Context())
 			if !ok {
-				utils.PrometheusAPIError(w, "error finding tenant", http.StatusBadRequest)
+				httperr.PrometheusAPIError(w, "error finding tenant", http.StatusBadRequest)
 				return
 			}
 
@@ -155,7 +155,7 @@ func WithTenantMiddlewares(mwFns ...MiddlewareFunc) Middleware {
 				}
 			}
 
-			utils.PrometheusAPIError(w, "tenant not found, have you registered it?", http.StatusUnauthorized)
+			httperr.PrometheusAPIError(w, "tenant not found, have you registered it?", http.StatusUnauthorized)
 		})
 	}
 }
@@ -183,7 +183,7 @@ func EnforceAccessTokenPresentOnSignalWrite(oidcTenants map[string]struct{}) fun
 
 			rawToken := r.Header.Get("Authorization")
 			if rawToken == "" {
-				utils.PrometheusAPIError(w, "couldn't find the authorization header", http.StatusBadRequest)
+				httperr.PrometheusAPIError(w, "couldn't find the authorization header", http.StatusBadRequest)
 				return
 			}
 

--- a/authentication/mtls.go
+++ b/authentication/mtls.go
@@ -12,6 +12,7 @@ import (
 	"github.com/go-kit/log"
 	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/mitchellh/mapstructure"
+	"github.com/observatorium/api/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -98,7 +99,7 @@ func (a MTLSAuthenticator) Middleware() Middleware {
 			}
 
 			if len(r.TLS.PeerCertificates) == 0 {
-				http.Error(w, "no client certificate presented", http.StatusUnauthorized)
+				utils.PrometheusAPIError(w, "no client certificate presented", http.StatusUnauthorized)
 				return
 			}
 
@@ -116,10 +117,10 @@ func (a MTLSAuthenticator) Middleware() Middleware {
 
 			if _, err := r.TLS.PeerCertificates[0].Verify(opts); err != nil {
 				if errors.Is(err, x509.CertificateInvalidError{}) {
-					http.Error(w, err.Error(), http.StatusUnauthorized)
+					utils.PrometheusAPIError(w, err.Error(), http.StatusUnauthorized)
 					return
 				}
-				http.Error(w, err.Error(), http.StatusInternalServerError)
+				utils.PrometheusAPIError(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 
@@ -134,7 +135,7 @@ func (a MTLSAuthenticator) Middleware() Middleware {
 			case len(r.TLS.PeerCertificates[0].IPAddresses) > 0:
 				sub = r.TLS.PeerCertificates[0].IPAddresses[0].String()
 			default:
-				http.Error(w, "could not determine subject", http.StatusBadRequest)
+				utils.PrometheusAPIError(w, "could not determine subject", http.StatusBadRequest)
 				return
 			}
 			ctx := context.WithValue(r.Context(), subjectKey, sub)

--- a/authentication/mtls.go
+++ b/authentication/mtls.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-kit/log"
 	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/mitchellh/mapstructure"
-	"github.com/observatorium/api/utils"
+	"github.com/observatorium/api/httperr"
 	"github.com/prometheus/client_golang/prometheus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -99,7 +99,7 @@ func (a MTLSAuthenticator) Middleware() Middleware {
 			}
 
 			if len(r.TLS.PeerCertificates) == 0 {
-				utils.PrometheusAPIError(w, "no client certificate presented", http.StatusUnauthorized)
+				httperr.PrometheusAPIError(w, "no client certificate presented", http.StatusUnauthorized)
 				return
 			}
 
@@ -117,10 +117,10 @@ func (a MTLSAuthenticator) Middleware() Middleware {
 
 			if _, err := r.TLS.PeerCertificates[0].Verify(opts); err != nil {
 				if errors.Is(err, x509.CertificateInvalidError{}) {
-					utils.PrometheusAPIError(w, err.Error(), http.StatusUnauthorized)
+					httperr.PrometheusAPIError(w, err.Error(), http.StatusUnauthorized)
 					return
 				}
-				utils.PrometheusAPIError(w, err.Error(), http.StatusInternalServerError)
+				httperr.PrometheusAPIError(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 
@@ -135,7 +135,7 @@ func (a MTLSAuthenticator) Middleware() Middleware {
 			case len(r.TLS.PeerCertificates[0].IPAddresses) > 0:
 				sub = r.TLS.PeerCertificates[0].IPAddresses[0].String()
 			default:
-				utils.PrometheusAPIError(w, "could not determine subject", http.StatusBadRequest)
+				httperr.PrometheusAPIError(w, "could not determine subject", http.StatusBadRequest)
 				return
 			}
 			ctx := context.WithValue(r.Context(), subjectKey, sub)

--- a/authentication/oidc.go
+++ b/authentication/oidc.go
@@ -20,7 +20,7 @@ import (
 	"github.com/go-kit/log/level"
 	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/mitchellh/mapstructure"
-	"github.com/observatorium/api/utils"
+	"github.com/observatorium/api/httperr"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/oauth2"
@@ -211,7 +211,7 @@ func (a oidcAuthenticator) oidcCallBackHandler() http.HandlerFunc {
 			desc := r.URL.Query().Get("error_description")
 			msg := fmt.Sprintf("%s: %s", errMsg, desc)
 			level.Debug(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+			httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -219,14 +219,14 @@ func (a oidcAuthenticator) oidcCallBackHandler() http.HandlerFunc {
 		if queryCode == "" {
 			const msg = "no code in request"
 			level.Debug(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+			httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 		queryState := r.URL.Query().Get("state")
 		if queryState != state {
 			const msg = "incorrect state in request"
 			level.Debug(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+			httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -234,7 +234,7 @@ func (a oidcAuthenticator) oidcCallBackHandler() http.HandlerFunc {
 		if err != nil {
 			msg := fmt.Sprintf("failed to get token: %v", err)
 			level.Warn(a.logger).Log("msg", msg, "err", err)
-			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -242,7 +242,7 @@ func (a oidcAuthenticator) oidcCallBackHandler() http.HandlerFunc {
 		if !ok {
 			const msg = "no id_token in token response"
 			level.Warn(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -250,7 +250,7 @@ func (a oidcAuthenticator) oidcCallBackHandler() http.HandlerFunc {
 		if err != nil {
 			msg := fmt.Sprintf("failed to verify ID token: %v", err)
 			level.Warn(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -281,7 +281,7 @@ func (a oidcAuthenticator) Middleware() Middleware {
 				if len(authorization) != 2 {
 					const msg = "invalid Authorization header"
 					level.Debug(a.logger).Log("msg", msg)
-					utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
+					httperr.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 					return
 				}
 
@@ -293,12 +293,12 @@ func (a oidcAuthenticator) Middleware() Middleware {
 					if !ok {
 						const msg = "error finding tenant"
 						level.Warn(a.logger).Log("msg", msg)
-						utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
+						httperr.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 						return
 					}
 					// Redirect users to the OIDC login
 					w.Header().Set("Location", path.Join("/oidc", tenant, "/login"))
-					utils.PrometheusAPIError(w, "failed to find token", http.StatusFound)
+					httperr.PrometheusAPIError(w, "failed to find token", http.StatusFound)
 					return
 				}
 				token = cookie.Value
@@ -306,7 +306,7 @@ func (a oidcAuthenticator) Middleware() Middleware {
 
 			ctx, msg, code, _ := a.checkAuth(r.Context(), token)
 			if code != http.StatusOK {
-				utils.PrometheusAPIError(w, msg, code)
+				httperr.PrometheusAPIError(w, msg, code)
 				return
 			}
 

--- a/authentication/oidc.go
+++ b/authentication/oidc.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-kit/log/level"
 	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/mitchellh/mapstructure"
+	"github.com/observatorium/api/utils"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"golang.org/x/oauth2"
@@ -210,7 +211,7 @@ func (a oidcAuthenticator) oidcCallBackHandler() http.HandlerFunc {
 			desc := r.URL.Query().Get("error_description")
 			msg := fmt.Sprintf("%s: %s", errMsg, desc)
 			level.Debug(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusBadRequest)
+			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -218,14 +219,14 @@ func (a oidcAuthenticator) oidcCallBackHandler() http.HandlerFunc {
 		if queryCode == "" {
 			const msg = "no code in request"
 			level.Debug(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusBadRequest)
+			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 		queryState := r.URL.Query().Get("state")
 		if queryState != state {
 			const msg = "incorrect state in request"
 			level.Debug(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusBadRequest)
+			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -233,7 +234,7 @@ func (a oidcAuthenticator) oidcCallBackHandler() http.HandlerFunc {
 		if err != nil {
 			msg := fmt.Sprintf("failed to get token: %v", err)
 			level.Warn(a.logger).Log("msg", msg, "err", err)
-			http.Error(w, msg, http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -241,7 +242,7 @@ func (a oidcAuthenticator) oidcCallBackHandler() http.HandlerFunc {
 		if !ok {
 			const msg = "no id_token in token response"
 			level.Warn(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -249,7 +250,7 @@ func (a oidcAuthenticator) oidcCallBackHandler() http.HandlerFunc {
 		if err != nil {
 			msg := fmt.Sprintf("failed to verify ID token: %v", err)
 			level.Warn(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -280,7 +281,7 @@ func (a oidcAuthenticator) Middleware() Middleware {
 				if len(authorization) != 2 {
 					const msg = "invalid Authorization header"
 					level.Debug(a.logger).Log("msg", msg)
-					http.Error(w, msg, http.StatusUnauthorized)
+					utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 					return
 				}
 
@@ -292,12 +293,12 @@ func (a oidcAuthenticator) Middleware() Middleware {
 					if !ok {
 						const msg = "error finding tenant"
 						level.Warn(a.logger).Log("msg", msg)
-						http.Error(w, msg, http.StatusInternalServerError)
+						utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 						return
 					}
 					// Redirect users to the OIDC login
 					w.Header().Set("Location", path.Join("/oidc", tenant, "/login"))
-					http.Error(w, "failed to find token", http.StatusFound)
+					utils.PrometheusAPIError(w, "failed to find token", http.StatusFound)
 					return
 				}
 				token = cookie.Value
@@ -305,7 +306,7 @@ func (a oidcAuthenticator) Middleware() Middleware {
 
 			ctx, msg, code, _ := a.checkAuth(r.Context(), token)
 			if code != http.StatusOK {
-				http.Error(w, msg, code)
+				utils.PrometheusAPIError(w, msg, code)
 				return
 			}
 

--- a/authentication/openshift.go
+++ b/authentication/openshift.go
@@ -20,6 +20,7 @@ import (
 	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/mitchellh/mapstructure"
 	"github.com/observatorium/api/authentication/openshift"
+	"github.com/observatorium/api/utils"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -248,7 +249,7 @@ func (a OpenShiftAuthenticator) openshiftLoginHandler() http.HandlerFunc {
 		if err != nil {
 			const msg = "failed to parse authorization endpoint URL"
 			level.Warn(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -256,7 +257,7 @@ func (a OpenShiftAuthenticator) openshiftLoginHandler() http.HandlerFunc {
 		if queryRoute == "" {
 			const msg = "incorrect route in request"
 			level.Debug(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusBadRequest)
+			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -280,7 +281,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 			desc := r.URL.Query().Get("error_description")
 			msg := fmt.Sprintf("%s: %s", errMsg, desc)
 			level.Debug(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusBadRequest)
+			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -288,7 +289,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if queryCode == "" {
 			const msg = "no code in request"
 			level.Debug(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusBadRequest)
+			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -296,7 +297,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if queryState != state {
 			const msg = "incorrect state in request"
 			level.Debug(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusBadRequest)
+			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -304,7 +305,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if queryRoute == "" {
 			const msg = "incorrect route in request"
 			level.Debug(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusBadRequest)
+			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -328,14 +329,14 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if err != nil {
 			msg := fmt.Sprintf("failed to get token: %v", err)
 			level.Warn(a.logger).Log("msg", msg, "err", err)
-			http.Error(w, msg, http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
 		if !token.Valid() {
 			const msg = "invalid token provided"
 			level.Warn(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusUnauthorized)
+			utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 			return
 		}
 
@@ -346,7 +347,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if err != nil {
 			const msg = "invalid request to the apiserver"
 			level.Warn(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -356,14 +357,14 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if err != nil {
 			msg := fmt.Sprintf("failed to authenticate redirect request: %s", err)
 			level.Warn(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusUnauthorized)
+			utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 			return
 		}
 
 		if !ok {
 			const msg = "failed to authenticate redirect request"
 			level.Warn(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusUnauthorized)
+			utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 			return
 		}
 
@@ -373,7 +374,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 			if err != nil {
 				const msg = "failed to encrypt access token"
 				level.Warn(a.logger).Log("msg", msg)
-				http.Error(w, msg, http.StatusInternalServerError)
+				utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 				return
 			}
 		}
@@ -397,7 +398,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if err != nil {
 			msg := fmt.Sprintf("failed to sign jwt token: %s", err)
 			level.Warn(a.logger).Log("msg", msg)
-			http.Error(w, msg, http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -443,12 +444,12 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 				if !ok {
 					const msg = "error finding tenant"
 					level.Warn(a.logger).Log("msg", msg)
-					http.Error(w, msg, http.StatusBadRequest)
+					utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 					return
 				}
 				// Redirect users to the oauth2 login
 				w.Header().Set("Location", path.Join("/openshift", tenant, "/login?route=", r.URL.Path))
-				http.Error(w, "failed to find token", http.StatusFound)
+				utils.PrometheusAPIError(w, "failed to find token", http.StatusFound)
 				return
 			}
 
@@ -458,14 +459,14 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 			if err != nil {
 				msg := errors.Wrap(err, "failed to parse jwt token: %s").Error()
 				level.Warn(a.logger).Log("msg", msg)
-				http.Error(w, msg, http.StatusBadRequest)
+				utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 				return
 			}
 
 			if !jwtToken.Valid {
 				const msg = "failed to authenticate"
 				level.Warn(a.logger).Log("msg", msg)
-				http.Error(w, msg, http.StatusUnauthorized)
+				utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 				return
 			}
 
@@ -473,7 +474,7 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 			if !ok {
 				const msg = "failed to read claims"
 				level.Warn(a.logger).Log("msg", msg)
-				http.Error(w, msg, http.StatusBadRequest)
+				utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 				return
 			}
 
@@ -486,7 +487,7 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 				if err != nil {
 					msg := errors.Wrap(err, "failed to decrypt acess token").Error()
 					level.Warn(a.logger).Log("msg", msg)
-					http.Error(w, msg, http.StatusBadRequest)
+					utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
 					return
 				}
 

--- a/authentication/openshift.go
+++ b/authentication/openshift.go
@@ -20,7 +20,7 @@ import (
 	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/mitchellh/mapstructure"
 	"github.com/observatorium/api/authentication/openshift"
-	"github.com/observatorium/api/utils"
+	"github.com/observatorium/api/httperr"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
@@ -249,7 +249,7 @@ func (a OpenShiftAuthenticator) openshiftLoginHandler() http.HandlerFunc {
 		if err != nil {
 			const msg = "failed to parse authorization endpoint URL"
 			level.Warn(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -257,7 +257,7 @@ func (a OpenShiftAuthenticator) openshiftLoginHandler() http.HandlerFunc {
 		if queryRoute == "" {
 			const msg = "incorrect route in request"
 			level.Debug(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+			httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -281,7 +281,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 			desc := r.URL.Query().Get("error_description")
 			msg := fmt.Sprintf("%s: %s", errMsg, desc)
 			level.Debug(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+			httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -289,7 +289,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if queryCode == "" {
 			const msg = "no code in request"
 			level.Debug(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+			httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -297,7 +297,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if queryState != state {
 			const msg = "incorrect state in request"
 			level.Debug(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+			httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -305,7 +305,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if queryRoute == "" {
 			const msg = "incorrect route in request"
 			level.Debug(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+			httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 			return
 		}
 
@@ -329,14 +329,14 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if err != nil {
 			msg := fmt.Sprintf("failed to get token: %v", err)
 			level.Warn(a.logger).Log("msg", msg, "err", err)
-			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
 		if !token.Valid() {
 			const msg = "invalid token provided"
 			level.Warn(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
+			httperr.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 			return
 		}
 
@@ -347,7 +347,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if err != nil {
 			const msg = "invalid request to the apiserver"
 			level.Warn(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -357,14 +357,14 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if err != nil {
 			msg := fmt.Sprintf("failed to authenticate redirect request: %s", err)
 			level.Warn(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
+			httperr.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 			return
 		}
 
 		if !ok {
 			const msg = "failed to authenticate redirect request"
 			level.Warn(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
+			httperr.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 			return
 		}
 
@@ -374,7 +374,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 			if err != nil {
 				const msg = "failed to encrypt access token"
 				level.Warn(a.logger).Log("msg", msg)
-				utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
+				httperr.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 				return
 			}
 		}
@@ -398,7 +398,7 @@ func (a OpenShiftAuthenticator) openshiftCallbackHandler() http.HandlerFunc {
 		if err != nil {
 			msg := fmt.Sprintf("failed to sign jwt token: %s", err)
 			level.Warn(a.logger).Log("msg", msg)
-			utils.PrometheusAPIError(w, msg, http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, msg, http.StatusInternalServerError)
 			return
 		}
 
@@ -444,12 +444,12 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 				if !ok {
 					const msg = "error finding tenant"
 					level.Warn(a.logger).Log("msg", msg)
-					utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+					httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 					return
 				}
 				// Redirect users to the oauth2 login
 				w.Header().Set("Location", path.Join("/openshift", tenant, "/login?route=", r.URL.Path))
-				utils.PrometheusAPIError(w, "failed to find token", http.StatusFound)
+				httperr.PrometheusAPIError(w, "failed to find token", http.StatusFound)
 				return
 			}
 
@@ -459,14 +459,14 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 			if err != nil {
 				msg := errors.Wrap(err, "failed to parse jwt token: %s").Error()
 				level.Warn(a.logger).Log("msg", msg)
-				utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+				httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 				return
 			}
 
 			if !jwtToken.Valid {
 				const msg = "failed to authenticate"
 				level.Warn(a.logger).Log("msg", msg)
-				utils.PrometheusAPIError(w, msg, http.StatusUnauthorized)
+				httperr.PrometheusAPIError(w, msg, http.StatusUnauthorized)
 				return
 			}
 
@@ -474,7 +474,7 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 			if !ok {
 				const msg = "failed to read claims"
 				level.Warn(a.logger).Log("msg", msg)
-				utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+				httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 				return
 			}
 
@@ -487,7 +487,7 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 				if err != nil {
 					msg := errors.Wrap(err, "failed to decrypt acess token").Error()
 					level.Warn(a.logger).Log("msg", msg)
-					utils.PrometheusAPIError(w, msg, http.StatusBadRequest)
+					httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
 					return
 				}
 

--- a/authorization/http.go
+++ b/authorization/http.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/observatorium/api/authentication"
 	"github.com/observatorium/api/rbac"
+	"github.com/observatorium/api/utils"
 )
 
 // contextKey to use when setting context values in the HTTP package.
@@ -38,13 +39,13 @@ func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Per
 			ctx := r.Context()
 			tenant, ok := authentication.GetTenant(ctx)
 			if !ok {
-				http.Error(w, "error finding tenant", http.StatusInternalServerError)
+				utils.PrometheusAPIError(w, "error finding tenant", http.StatusInternalServerError)
 
 				return
 			}
 			subject, ok := authentication.GetSubject(ctx)
 			if !ok {
-				http.Error(w, "unknown subject", http.StatusUnauthorized)
+				utils.PrometheusAPIError(w, "unknown subject", http.StatusUnauthorized)
 
 				return
 			}
@@ -54,21 +55,21 @@ func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Per
 			}
 			a, ok := authorizers[tenant]
 			if !ok {
-				http.Error(w, "error finding tenant", http.StatusUnauthorized)
+				utils.PrometheusAPIError(w, "error finding tenant", http.StatusUnauthorized)
 
 				return
 			}
 
 			token, ok := authentication.GetAccessToken(r.Context())
 			if !ok {
-				http.Error(w, "error finding access token", http.StatusUnauthorized)
+				utils.PrometheusAPIError(w, "error finding access token", http.StatusUnauthorized)
 
 				return
 			}
 
 			tenantID, ok := authentication.GetTenantID(r.Context())
 			if !ok {
-				http.Error(w, "error finding tenant id", http.StatusUnauthorized)
+				utils.PrometheusAPIError(w, "error finding tenant id", http.StatusUnauthorized)
 
 				return
 			}

--- a/authorization/http.go
+++ b/authorization/http.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 
 	"github.com/observatorium/api/authentication"
+	"github.com/observatorium/api/httperr"
 	"github.com/observatorium/api/rbac"
-	"github.com/observatorium/api/utils"
 )
 
 // contextKey to use when setting context values in the HTTP package.
@@ -39,13 +39,13 @@ func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Per
 			ctx := r.Context()
 			tenant, ok := authentication.GetTenant(ctx)
 			if !ok {
-				utils.PrometheusAPIError(w, "error finding tenant", http.StatusInternalServerError)
+				httperr.PrometheusAPIError(w, "error finding tenant", http.StatusInternalServerError)
 
 				return
 			}
 			subject, ok := authentication.GetSubject(ctx)
 			if !ok {
-				utils.PrometheusAPIError(w, "unknown subject", http.StatusUnauthorized)
+				httperr.PrometheusAPIError(w, "unknown subject", http.StatusUnauthorized)
 
 				return
 			}
@@ -55,21 +55,21 @@ func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Per
 			}
 			a, ok := authorizers[tenant]
 			if !ok {
-				utils.PrometheusAPIError(w, "error finding tenant", http.StatusUnauthorized)
+				httperr.PrometheusAPIError(w, "error finding tenant", http.StatusUnauthorized)
 
 				return
 			}
 
 			token, ok := authentication.GetAccessToken(r.Context())
 			if !ok {
-				utils.PrometheusAPIError(w, "error finding access token", http.StatusUnauthorized)
+				httperr.PrometheusAPIError(w, "error finding access token", http.StatusUnauthorized)
 
 				return
 			}
 
 			tenantID, ok := authentication.GetTenantID(r.Context())
 			if !ok {
-				utils.PrometheusAPIError(w, "error finding tenant id", http.StatusUnauthorized)
+				httperr.PrometheusAPIError(w, "error finding tenant id", http.StatusUnauthorized)
 
 				return
 			}

--- a/httperr/httperr.go
+++ b/httperr/httperr.go
@@ -1,4 +1,4 @@
-package utils
+package httperr
 
 import (
 	"encoding/json"
@@ -11,6 +11,7 @@ func PrometheusAPIError(w http.ResponseWriter, errorMessage string, code int) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
 
+	// As per Prometheus HTTP API format: https://prometheus.io/docs/prometheus/latest/querying/api/#format-overview
 	res := map[string]string{"status": "error", "errorType": "observatorium-api", "error": errorMessage}
 
 	if err := json.NewEncoder(w).Encode(res); err != nil {

--- a/main.go
+++ b/main.go
@@ -54,6 +54,7 @@ import (
 	"github.com/observatorium/api/authentication"
 
 	"github.com/observatorium/api/authorization"
+	"github.com/observatorium/api/httperr"
 	"github.com/observatorium/api/logger"
 	"github.com/observatorium/api/opa"
 	"github.com/observatorium/api/proxy"
@@ -62,7 +63,6 @@ import (
 	"github.com/observatorium/api/server"
 	"github.com/observatorium/api/tls"
 	"github.com/observatorium/api/tracing"
-	"github.com/observatorium/api/utils"
 )
 
 const (
@@ -1088,7 +1088,7 @@ func stripTenantPrefix(prefix string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tenant, ok := authentication.GetTenant(r.Context())
 		if !ok {
-			utils.PrometheusAPIError(w, "tenant not found", http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, "tenant not found", http.StatusInternalServerError)
 			return
 		}
 

--- a/main.go
+++ b/main.go
@@ -62,6 +62,7 @@ import (
 	"github.com/observatorium/api/server"
 	"github.com/observatorium/api/tls"
 	"github.com/observatorium/api/tracing"
+	"github.com/observatorium/api/utils"
 )
 
 const (
@@ -1087,7 +1088,7 @@ func stripTenantPrefix(prefix string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tenant, ok := authentication.GetTenant(r.Context())
 		if !ok {
-			http.Error(w, "tenant not found", http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, "tenant not found", http.StatusInternalServerError)
 			return
 		}
 

--- a/ratelimit/http.go
+++ b/ratelimit/http.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-kit/log/level"
 
 	"github.com/observatorium/api/authentication"
+	"github.com/observatorium/api/utils"
 )
 
 const (
@@ -77,7 +78,7 @@ func combine(middlewares map[string][]middleware) func(next http.Handler) http.H
 			tenant, ok := authentication.GetTenant(r.Context())
 			if !ok {
 				// This shouldn't have happened.
-				http.Error(w, "error finding tenant", http.StatusUnauthorized)
+				utils.PrometheusAPIError(w, "error finding tenant", http.StatusUnauthorized)
 				return
 			}
 
@@ -119,11 +120,11 @@ func (l rateLimiter) Handler(next http.Handler) http.Handler {
 
 		if err != nil {
 			if err == errOverLimit {
-				http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+				utils.PrometheusAPIError(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
 				return
 			}
 			level.Warn(l.logger).Log("msg", "API failed", "err", err)
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			utils.PrometheusAPIError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 

--- a/ratelimit/http.go
+++ b/ratelimit/http.go
@@ -13,7 +13,7 @@ import (
 	"github.com/go-kit/log/level"
 
 	"github.com/observatorium/api/authentication"
-	"github.com/observatorium/api/utils"
+	"github.com/observatorium/api/httperr"
 )
 
 const (
@@ -78,7 +78,7 @@ func combine(middlewares map[string][]middleware) func(next http.Handler) http.H
 			tenant, ok := authentication.GetTenant(r.Context())
 			if !ok {
 				// This shouldn't have happened.
-				utils.PrometheusAPIError(w, "error finding tenant", http.StatusUnauthorized)
+				httperr.PrometheusAPIError(w, "error finding tenant", http.StatusUnauthorized)
 				return
 			}
 
@@ -120,11 +120,11 @@ func (l rateLimiter) Handler(next http.Handler) http.Handler {
 
 		if err != nil {
 			if err == errOverLimit {
-				utils.PrometheusAPIError(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+				httperr.PrometheusAPIError(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
 				return
 			}
 			level.Warn(l.logger).Log("msg", "API failed", "err", err)
-			utils.PrometheusAPIError(w, err.Error(), http.StatusInternalServerError)
+			httperr.PrometheusAPIError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// Adapted from https://github.com/prometheus-community/prom-label-proxy/blob/02d43edb82b7d139f4a4e41912ad903bff46d5c4/injectproxy/utils.go#L22
+func PrometheusAPIError(w http.ResponseWriter, errorMessage string, code int) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(code)
+
+	res := map[string]string{"status": "error", "errorType": "observatorium-api", "error": errorMessage}
+
+	if err := json.NewEncoder(w).Encode(res); err != nil {
+		log.Printf("failed to encode json: %v", err)
+	}
+}


### PR DESCRIPTION
This PR addresses #319 and ensures that all `4xx`/`5xx` responses from Observatorium API are sent in Prometheus API JSON format instead of plaintext, by taking inspiration from https://github.com/prometheus-community/prom-label-proxy/pull/108. This makes debugging via downstream UI/clients much easier.

Thus for a faulty query,

Response before, 
```
could not enforce labels: parse expr error: 1:12: parse error: unterminated quoted string
```
Response after,
```json
{"error":"could not enforce labels: parse expr error: 1:12: parse error: unterminated quoted string","errorType":"observatorium-api","status":"error"}
```

Loki is also [compatible](https://grafana.com/docs/loki/latest/api/) with Prometheus API result format, so we can use the same `PrometheusAPIError` method in `api/logs/v1/labels_enforcer.go` too. :)