### PR TITLE
authentication: clean up naming

### DIFF
--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -69,38 +69,38 @@ func NewProviderManager(l log.Logger, registrationRetryCount *prometheus.Counter
 
 // InitializeProvider initializes an authenticator provider and register the created
 // authentication middleware and handler.
-func (ah *ProviderManager) InitializeProvider(config map[string]interface{},
+func (pm *ProviderManager) InitializeProvider(config map[string]interface{},
 	tenant string, authenticatorType string, registrationRetryCount *prometheus.CounterVec, logger log.Logger) chan Provider {
 	authCh := make(chan Provider)
 
 	go func() {
 		providerFactory, err := getProviderFactory(authenticatorType)
 		if err != nil {
-			level.Error(ah.logger).Log("msg", err, "tenant", tenant, "authenticator", authenticatorType)
+			level.Error(pm.logger).Log("msg", err, "tenant", tenant, "authenticator", authenticatorType)
 			authCh <- nil
 			return
 		}
 
 		provider, err := providerFactory(config, tenant, registrationRetryCount, logger)
 		if err != nil {
-			level.Error(ah.logger).Log("msg", err, "tenant", tenant, "authenticator", authenticatorType)
+			level.Error(pm.logger).Log("msg", err, "tenant", tenant, "authenticator", authenticatorType)
 			authCh <- nil
 			return
 		}
 
-		ah.mtx.Lock()
-		ah.middlewares[tenant] = provider.Middleware()
-		ah.gRPCInterceptors[tenant] = provider.GRPCMiddleware()
+		pm.mtx.Lock()
+		pm.middlewares[tenant] = provider.Middleware()
+		pm.gRPCInterceptors[tenant] = provider.GRPCMiddleware()
 		pattern, handler := provider.Handler()
 		if pattern != "" && handler != nil {
-			if ah.patternHandlers[pattern] == nil {
-				ah.patternHandlers[pattern] = make(tenantHandlers)
+			if pm.patternHandlers[pattern] == nil {
+				pm.patternHandlers[pattern] = make(tenantHandlers)
 			}
-			ah.patternHandlers[pattern][tenant] = handler
+			pm.patternHandlers[pattern][tenant] = handler
 		}
-		ah.mtx.Unlock()
+		pm.mtx.Unlock()
 
-		level.Debug(ah.logger).Log("msg", "successfully initialized authentication provider", "tenant", tenant, "authenticator", authenticatorType)
+		level.Debug(pm.logger).Log("msg", "successfully initialized authentication provider", "tenant", tenant, "authenticator", authenticatorType)
 		authCh <- provider
 	}()
 
@@ -108,39 +108,39 @@ func (ah *ProviderManager) InitializeProvider(config map[string]interface{},
 }
 
 // Middleware returns an authentication middleware for a tenant.
-func (ah *ProviderManager) Middlewares(tenant string) (Middleware, bool) {
-	ah.mtx.RLock()
-	mw, ok := ah.middlewares[tenant]
-	ah.mtx.RUnlock()
+func (pm *ProviderManager) Middlewares(tenant string) (Middleware, bool) {
+	pm.mtx.RLock()
+	mw, ok := pm.middlewares[tenant]
+	pm.mtx.RUnlock()
 
 	return mw, ok
 }
 
 // GRPCMiddlewares returns an authentication interceptor for a tenant.
-func (ah *ProviderManager) GRPCMiddlewares(tenant string) (grpc.StreamServerInterceptor, bool) {
-	ah.mtx.RLock()
-	mw, ok := ah.gRPCInterceptors[tenant]
-	ah.mtx.RUnlock()
+func (pm *ProviderManager) GRPCMiddlewares(tenant string) (grpc.StreamServerInterceptor, bool) {
+	pm.mtx.RLock()
+	mw, ok := pm.gRPCInterceptors[tenant]
+	pm.mtx.RUnlock()
 
 	return mw, ok
 }
 
 // PatternHandler return an http.HandlerFunc for a corresponding pattern.
-func (ah *ProviderManager) PatternHandler(pattern string) http.HandlerFunc {
+func (pm *ProviderManager) PatternHandler(pattern string) http.HandlerFunc {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		tenant, ok := GetTenant(r.Context())
 		const msg = "error finding tenant"
 		if !ok {
-			level.Warn(ah.logger).Log("msg", msg, "tenant", tenant)
+			level.Warn(pm.logger).Log("msg", msg, "tenant", tenant)
 			http.Error(w, msg, http.StatusInternalServerError)
 			return
 		}
 
-		ah.mtx.RLock()
-		h, ok := ah.patternHandlers[pattern][tenant]
-		ah.mtx.RUnlock()
+		pm.mtx.RLock()
+		h, ok := pm.patternHandlers[pattern][tenant]
+		pm.mtx.RUnlock()
 		if !ok {
-			level.Debug(ah.logger).Log("msg", msg, "tenant", tenant)
+			level.Debug(pm.logger).Log("msg", msg, "tenant", tenant)
 			http.Error(w, msg, http.StatusUnauthorized)
 			return
 		}

--- a/authentication/authentication.go
+++ b/authentication/authentication.go
@@ -74,14 +74,14 @@ func (ah *ProviderManager) InitializeProvider(config map[string]interface{},
 	authCh := make(chan Provider)
 
 	go func() {
-		ProviderFactory, err := getProviderFactory(authenticatorType)
+		providerFactory, err := getProviderFactory(authenticatorType)
 		if err != nil {
 			level.Error(ah.logger).Log("msg", err, "tenant", tenant, "authenticator", authenticatorType)
 			authCh <- nil
 			return
 		}
 
-		authenticator, err := ProviderFactory(config, tenant, registrationRetryCount, logger)
+		authenticator, err := providerFactory(config, tenant, registrationRetryCount, logger)
 		if err != nil {
 			level.Error(ah.logger).Log("msg", err, "tenant", tenant, "authenticator", authenticatorType)
 			authCh <- nil
@@ -152,10 +152,10 @@ func getProviderFactory(authType string) (ProviderFactory, error) {
 	providersMtx.RLock()
 	defer providersMtx.RUnlock()
 
-	ProviderFactory, ok := providerFactories[authType]
+	providerFactory, ok := providerFactories[authType]
 	if !ok {
 		return nil, fmt.Errorf("authenticator type %s is not supported", authType)
 	}
 
-	return ProviderFactory, nil
+	return providerFactory, nil
 }

--- a/authentication/authentication_test.go
+++ b/authentication/authentication_test.go
@@ -73,7 +73,7 @@ func TestNewAuthentication(t *testing.T) {
 
 	reg := prometheus.NewRegistry()
 	registrationFailingMetric := RegisterTenantsFailingMetric(reg)
-	ah := NewProviderManager(l, registrationFailingMetric)
+	pm := NewProviderManager(l, registrationFailingMetric)
 
 	t.Run("Getting an authenticator factory", func(t *testing.T) {
 		_, err := getProviderFactory(authenticatorTypeName)
@@ -87,23 +87,23 @@ func TestNewAuthentication(t *testing.T) {
 	})
 
 	t.Run("initialize authenticators", func(t *testing.T) {
-		initializedAuthenticator := <-ah.InitializeProvider(dummyConfig, tenant, authenticatorTypeName, registrationFailingMetric, l)
-		if initializedAuthenticator == nil {
+		initializedProvider := <-pm.InitializeProvider(dummyConfig, tenant, authenticatorTypeName, registrationFailingMetric, l)
+		if initializedProvider == nil {
 			t.Fatalf("initialized authenticator should not be nil")
 		}
 
-		_, ok := ah.Middlewares(tenant)
+		_, ok := pm.Middlewares(tenant)
 		if !ok {
 			t.Fatalf("middleware of the dummy authenticator has not been found")
 		}
 
-		_, handler := initializedAuthenticator.Handler()
+		_, handler := initializedProvider.Handler()
 		if handler != nil {
 			t.Fatalf("getting undefined handler should be nil")
 		}
 
-		nonExistAuthenticator := <-ah.InitializeProvider(dummyConfig, tenant, "not-exist", registrationFailingMetric, l)
-		if nonExistAuthenticator != nil {
+		nonExistantProvider := <-pm.InitializeProvider(dummyConfig, tenant, "not-exist", registrationFailingMetric, l)
+		if nonExistantProvider != nil {
 			t.Fatalf("intializing a non-exist authenticator should return a nil authenticator")
 		}
 	})


### PR DESCRIPTION
This PR includes two commits aimed at cleaning up the naming in the authentication/authentication.go file:
- authentication: clarify naming
This commit makes the naming within the `InitializeProvider` func follow go conventions of naming to clarify the intent of the named identifier.
- authentication: use consistent naming
This commit tries to standardize the naming of the `authenticator` variable and renames it internally within the `authentication` package as a `provider`.
