### PR TITLE
Overwrite tenant id header

### DIFF
--- a/authentication/http.go
+++ b/authentication/http.go
@@ -84,7 +84,7 @@ func WithTenantHeader(header string, tenantIDs map[string]string) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			tenant := chi.URLParam(r, "tenant")
-			r.Header.Add(header, tenantIDs[tenant])
+			r.Header.Set(header, tenantIDs[tenant])
 			next.ServeHTTP(w, r)
 		})
 	}


### PR DESCRIPTION
The `Add` function adds another header on top of what is already there,
that means if a client sets that header, it would be picked up by loki.
This commit changes it to Set to make sure we overwrite the header if it
is provided.