### PR TITLE
Add flags for setting maximum TLS version and client authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Usage of ./observatorium-api:
     	Path to the tenants file. (default "tenants.yaml")
   -tls.cipher-suites string
     	Comma-separated list of cipher suites for the server. Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants). If omitted, the default Go cipher suites will be used. Note that TLS 1.3 ciphersuites are not configurable.
+  -tls.client-auth-type string
+    	Policy for TLS client-side authentication. Values are from ClientAuthType constants in https://pkg.go.dev/crypto/tls#ClientAuthType (default "RequestClientCert")
   -tls.healthchecks.server-ca-file string
     	File containing the TLS CA against which to verify servers. If no server CA is specified, the client will use the system certificates.
   -tls.healthchecks.server-name string
@@ -135,6 +137,8 @@ Usage of ./observatorium-api:
     	File containing the default x509 Certificate for internal HTTPS. Leave blank to disable TLS.
   -tls.internal.server.key-file string
     	File containing the default x509 private key matching --tls.internal.server.cert-file. Leave blank to disable TLS.
+  -tls.max-version string
+    	Maximum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. (default "VersionTLS13")
   -tls.min-version string
     	Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants. (default "VersionTLS13")
   -tls.reload-interval duration

--- a/main.go
+++ b/main.go
@@ -105,7 +105,9 @@ type serverConfig struct {
 
 type tlsConfig struct {
 	minVersion     string
+	maxVersion     string
 	cipherSuites   []string
+	clientAuthType string
 	reloadInterval time.Duration
 
 	serverCertFile string
@@ -665,6 +667,8 @@ func main() {
 			cfg.tls.serverCertFile,
 			cfg.tls.serverKeyFile,
 			cfg.tls.minVersion,
+			cfg.tls.maxVersion,
+			cfg.tls.clientAuthType,
 			cfg.tls.cipherSuites,
 		)
 		if err != nil {
@@ -761,6 +765,8 @@ func main() {
 			cfg.tls.internalServerCertFile,
 			cfg.tls.internalServerKeyFile,
 			cfg.tls.minVersion,
+			cfg.tls.maxVersion,
+			cfg.tls.clientAuthType,
 			cfg.tls.cipherSuites,
 		)
 		if err != nil {
@@ -940,11 +946,15 @@ func parseFlags() (config, error) {
 			" If no server name is specified, the server name will be inferred from the healthcheck URL.")
 	flag.StringVar(&cfg.tls.minVersion, "tls.min-version", "VersionTLS13",
 		"Minimum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.")
+	flag.StringVar(&cfg.tls.maxVersion, "tls.max-version", "VersionTLS13",
+		"Maximum TLS version supported. Value must match version names from https://golang.org/pkg/crypto/tls/#pkg-constants.")
 	flag.StringVar(&rawTLSCipherSuites, "tls.cipher-suites", "",
 		"Comma-separated list of cipher suites for the server."+
 			" Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants)."+
 			" If omitted, the default Go cipher suites will be used."+
 			" Note that TLS 1.3 ciphersuites are not configurable.")
+	flag.StringVar(&cfg.tls.clientAuthType, "tls.client-auth-type", "RequestClientCert",
+		"Policy for TLS client-side authentication. Values are from ClientAuthType constants in https://pkg.go.dev/crypto/tls#ClientAuthType")
 	flag.DurationVar(&cfg.tls.reloadInterval, "tls.reload-interval", time.Minute,
 		"The interval at which to watch for TLS certificate changes.")
 	flag.StringVar(&cfg.middleware.rateLimiterAddress, "middleware.rate-limiter.grpc-address", "",

--- a/tls/config.go
+++ b/tls/config.go
@@ -10,7 +10,7 @@ import (
 )
 
 // NewServerConfig provides new server TLS configuration.
-func NewServerConfig(logger log.Logger, certFile, keyFile, minVersion string, cipherSuites []string) (*tls.Config, error) {
+func NewServerConfig(logger log.Logger, certFile, keyFile, minVersion, maxVersion, clientAuthType string, cipherSuites []string) (*tls.Config, error) {
 	if certFile == "" && keyFile == "" {
 		level.Info(logger).Log("msg", "TLS disabled; key and cert must be set to enable")
 
@@ -24,14 +24,28 @@ func NewServerConfig(logger log.Logger, certFile, keyFile, minVersion string, ci
 		return nil, fmt.Errorf("server credentials: %w", err)
 	}
 
-	version, err := flag.TLSVersion(minVersion)
+	tlsMinVersion, err := flag.TLSVersion(minVersion)
 	if err != nil {
 		return nil, fmt.Errorf("TLS version invalid: %w", err)
+	}
+
+	tlsMaxVersion, err := flag.TLSVersion(maxVersion)
+	if err != nil {
+		return nil, fmt.Errorf("TLS version invalid: %w", err)
+	}
+
+	if tlsMinVersion > tlsMaxVersion {
+		return nil, fmt.Errorf("TLS minimum version can not be greater than maximum version: %v > %v", tlsMinVersion, tlsMaxVersion)
 	}
 
 	cipherSuiteIDs, err := flag.TLSCipherSuites(cipherSuites)
 	if err != nil {
 		return nil, fmt.Errorf("TLS cipher suite name to ID conversion: %v", err)
+	}
+
+	tlsClientAuthType, err := parseClientAuthType(clientAuthType)
+	if err != nil {
+		return nil, fmt.Errorf("can not parse TLS Client authentication policy: %w", err)
 	}
 
 	tlsCfg := &tls.Config{
@@ -40,9 +54,27 @@ func NewServerConfig(logger log.Logger, certFile, keyFile, minVersion string, ci
 		// If CipherSuites is nil, a default list of secure cipher suites is used.
 		// Note that TLS 1.3 ciphersuites are not configurable.
 		CipherSuites: cipherSuiteIDs,
-		ClientAuth:   tls.RequestClientCert,
-		MinVersion:   version,
+		ClientAuth:   tlsClientAuthType,
+		MinVersion:   tlsMinVersion,
+		MaxVersion:   tlsMaxVersion,
 	}
 
 	return tlsCfg, nil
+}
+
+func parseClientAuthType(rawAuthType string) (tls.ClientAuthType, error) {
+	switch rawAuthType {
+	case "NoClientCert":
+		return tls.NoClientCert, nil
+	case "RequestClientCert":
+		return tls.RequestClientCert, nil
+	case "RequireAnyClientCert":
+		return tls.RequireAnyClientCert, nil
+	case "VerifyClientCertIfGiven":
+		return tls.VerifyClientCertIfGiven, nil
+	case "RequireAndVerifyClientCert":
+		return tls.RequireAndVerifyClientCert, nil
+	default:
+		return 0, fmt.Errorf("unknown ClientAuthType: %s", rawAuthType)
+	}
 }


### PR DESCRIPTION
We currently encounter an issue where the health-check of HAProxy causes a periodic error message to be printed by this service:

```
2022/07/06 16:26:52 http: TLS handshake error from haproxy-ip:43002: write tcp service-ip:8080->haproxy-ip:43002: write: connection reset by peer
```

This is because observability-api tries to request a client-certificate from all connections by default, which fails in this case because HAProxy does not do any TLS exchange, but immediately closes the connection again.

I have also added the `max-version` setting because it was helpful during debugging this case and looked useful for the future.

This PR replaces #316 .

Refs: https://issues.redhat.com/browse/LOG-2750