### PR TITLE
Running as non-root in Kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ARG VERSION
 ARG VCS_REF
 ARG DOCKERFILE_PATH
 
+USER 10000:10000
+
 LABEL vendor="Observatorium" \
     name="observatorium/api" \
     description="Observatorium API" \


### PR DESCRIPTION
This PR defines the USER in the Dockerfile as 10000. When running the image as nonroot in Kubernetes, the resulting pod(s) will have a CreateContainerConfigError. This is because the USER in the image is not defined and assumed to be root.

The work around for this in Kubernetes is to define the user to be some non-zero user. However, as the image does not require any elevated privileges, it would be nice to make it work with the non-root user specification. This is relevant to the Kubernetes Pod Security Admission changes, which require a number of changes to be compliant with the `restricted` policy.

ref: https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted