### PR TITLE
Add dedup and partial_response query params to spec

### DIFF
--- a/client/client.gen.go
+++ b/client/client.gen.go
@@ -53,6 +53,12 @@ type GetInstantQueryParams struct {
 	// Evaluation timeout
 	Timeout *externalRef1.QueryTimeout `json:"timeout,omitempty"`
 
+	// Query deduplication (Thanos)
+	Dedup *externalRef1.QueryDedup `json:"dedup,omitempty"`
+
+	// Query partial response (Thanos)
+	PartialResponse *externalRef1.QueryPartialResponse `json:"partial_response,omitempty"`
+
 	// Evaluation timestamp
 	Time *string `json:"time,omitempty"`
 }
@@ -70,6 +76,12 @@ type GetRangeQueryParams struct {
 
 	// Evaluation timeout
 	Timeout *externalRef1.QueryTimeout `json:"timeout,omitempty"`
+
+	// Query deduplication (Thanos)
+	Dedup *externalRef1.QueryDedup `json:"dedup,omitempty"`
+
+	// Query partial response (Thanos)
+	PartialResponse *externalRef1.QueryPartialResponse `json:"partial_response,omitempty"`
 
 	// Query resolution step width
 	Step *string `json:"step,omitempty"`
@@ -529,6 +541,38 @@ func NewGetInstantQueryRequest(server string, tenant externalRef1.Tenant, params
 
 	}
 
+	if params.Dedup != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "dedup", runtime.ParamLocationQuery, *params.Dedup); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.PartialResponse != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "partial_response", runtime.ParamLocationQuery, *params.PartialResponse); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
 	if params.Time != nil {
 
 		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "time", runtime.ParamLocationQuery, *params.Time); err != nil {
@@ -634,6 +678,38 @@ func NewGetRangeQueryRequest(server string, tenant externalRef1.Tenant, params *
 	if params.Timeout != nil {
 
 		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "timeout", runtime.ParamLocationQuery, *params.Timeout); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.Dedup != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "dedup", runtime.ParamLocationQuery, *params.Dedup); err != nil {
+			return nil, err
+		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
+			return nil, err
+		} else {
+			for k, v := range parsed {
+				for _, v2 := range v {
+					queryValues.Add(k, v2)
+				}
+			}
+		}
+
+	}
+
+	if params.PartialResponse != nil {
+
+		if queryFrag, err := runtime.StyleParamWithLocation("form", true, "partial_response", runtime.ParamLocationQuery, *params.PartialResponse); err != nil {
 			return nil, err
 		} else if parsed, err := url.ParseQuery(queryFrag); err != nil {
 			return nil, err

--- a/client/parameters/parameters.gen.go
+++ b/client/parameters/parameters.gen.go
@@ -12,6 +12,12 @@ type OptionalSeriesMatcher []string
 // Query defines model for query.
 type Query string
 
+// QueryDedup defines model for queryDedup.
+type QueryDedup bool
+
+// QueryPartialResponse defines model for queryPartialResponse.
+type QueryPartialResponse bool
+
 // QueryTimeout defines model for queryTimeout.
 type QueryTimeout string
 

--- a/client/parameters/parameters.yaml
+++ b/client/parameters/parameters.yaml
@@ -50,3 +50,15 @@ components:
       description: Evaluation timeout
       schema:
         type: string
+    queryDedup:
+      in: query
+      name: dedup
+      description: Query deduplication (Thanos)
+      schema:
+        type: boolean
+    queryPartialResponse:
+      in: query
+      name: partial_response
+      description: Query partial response (Thanos)
+      schema:
+        type: boolean

--- a/client/spec.yaml
+++ b/client/spec.yaml
@@ -154,6 +154,8 @@ paths:
       - $ref: ./parameters/parameters.yaml#/components/parameters/tenant
       - $ref: ./parameters/parameters.yaml#/components/parameters/query
       - $ref: ./parameters/parameters.yaml#/components/parameters/queryTimeout
+      - $ref: ./parameters/parameters.yaml#/components/parameters/queryDedup
+      - $ref: ./parameters/parameters.yaml#/components/parameters/queryPartialResponse
       - in: query
         name: time
         description: Evaluation timestamp
@@ -185,6 +187,8 @@ paths:
       - $ref: ./parameters/parameters.yaml#/components/parameters/startTS
       - $ref: ./parameters/parameters.yaml#/components/parameters/endTS
       - $ref: ./parameters/parameters.yaml#/components/parameters/queryTimeout
+      - $ref: ./parameters/parameters.yaml#/components/parameters/queryDedup
+      - $ref: ./parameters/parameters.yaml#/components/parameters/queryPartialResponse
       - in: query
         name: step
         description: Query resolution step width


### PR DESCRIPTION
This PR adds `dedup` and `partial_response` to Query API spec.