### PR TITLE
Remove usage of io/ioutil

### DIFF
--- a/api/metrics/v1/labels_enforcer.go
+++ b/api/metrics/v1/labels_enforcer.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -164,7 +164,7 @@ func enforceRequestQueryLabels(e *injectproxy.Enforcer, w http.ResponseWriter, r
 		}
 		// We are replacing request body, close previous one (ParseForm ensures it is read fully and not nil).
 		_ = r.Body.Close()
-		r.Body = ioutil.NopCloser(strings.NewReader(q))
+		r.Body = io.NopCloser(strings.NewReader(q))
 		r.ContentLength = int64(len(q))
 	}
 

--- a/api/metrics/v1/rules.go
+++ b/api/metrics/v1/rules.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/ghodss/yaml"
@@ -78,7 +77,7 @@ func enforceLabelsInExpr(e *injectproxy.Enforcer, expr string) (string, error) {
 }
 
 func unmarshalRules(r io.Reader) (rules.Rules, error) {
-	body, err := ioutil.ReadAll(r)
+	body, err := io.ReadAll(r)
 	if err != nil {
 		return rules.Rules{}, err
 	}

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -6,7 +6,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httputil"
@@ -234,7 +233,7 @@ func jaegerUIResponseModifier(response *http.Response) error {
 			reader = response.Body
 		}
 
-		b, err := ioutil.ReadAll(reader)
+		b, err := io.ReadAll(reader)
 		if err != nil {
 			return err
 		}
@@ -257,7 +256,7 @@ func jaegerUIResponseModifier(response *http.Response) error {
 		response.Header["Content-Encoding"] = []string{}
 		buf := bytes.NewBufferString(strResponse)
 		response.Header["Content-Length"] = []string{fmt.Sprint(buf.Len())}
-		response.Body = ioutil.NopCloser(buf)
+		response.Body = io.NopCloser(buf)
 	}
 
 	return nil

--- a/authentication/mtls.go
+++ b/authentication/mtls.go
@@ -6,8 +6,8 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net/http"
+	"os"
 
 	"github.com/go-kit/log"
 	grpc_middleware_auth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
@@ -48,7 +48,7 @@ func newMTLSAuthenticator(c map[string]interface{}, tenant string, registrationR
 	}
 
 	if config.CAPath != "" {
-		rawCA, err := ioutil.ReadFile(config.CAPath)
+		rawCA, err := os.ReadFile(config.CAPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read mTLS ca file: %s", err.Error())
 		}

--- a/authentication/oidc.go
+++ b/authentication/oidc.go
@@ -6,9 +6,9 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"path"
 	"strings"
 	"time"
@@ -86,7 +86,7 @@ func newOIDCAuthenticator(c map[string]interface{}, tenant string,
 	}
 
 	if config.IssuerCAPath != "" {
-		IssuerRawCA, err := ioutil.ReadFile(config.IssuerCAPath)
+		IssuerRawCA, err := os.ReadFile(config.IssuerCAPath)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read issuer ca file: %s", err.Error())
 		}

--- a/authentication/openshift/discovery.go
+++ b/authentication/openshift/discovery.go
@@ -3,7 +3,7 @@ package openshift
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -23,7 +23,7 @@ const (
 
 // GetServiceAccountCACert returns the PEM-encoded CA certificate currently mounted.
 func GetServiceAccountCACert() ([]byte, error) {
-	rawCA, err := ioutil.ReadFile(ServiceAccountCAPath)
+	rawCA, err := os.ReadFile(ServiceAccountCAPath)
 	if err != nil {
 		return nil, err
 	}
@@ -35,12 +35,12 @@ func GetServiceAccountCACert() ([]byte, error) {
 // serviceaccount name. Returns an error if the reading the auto-mounted files for
 // the namespace and token are not readable.
 func DiscoverCredentials(name string) (string, string, error) {
-	n, err := ioutil.ReadFile(ServiceAccountNamespacePath)
+	n, err := os.ReadFile(ServiceAccountNamespacePath)
 	if err != nil || len(n) == 0 {
 		return "", "", err
 	}
 
-	d, err := ioutil.ReadFile(ServiceAccountTokenPath)
+	d, err := os.ReadFile(ServiceAccountTokenPath)
 	if err != nil || len(d) == 0 {
 		return "", "", err
 	}
@@ -68,7 +68,7 @@ func DiscoverOAuth(client *http.Client) (authURL *url.URL, tokenURL *url.URL, er
 	}
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read response body: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	stdlog "log"
 	"net"
 	"net/http"
@@ -260,7 +259,7 @@ func main() {
 
 	var tenantsCfg tenantsConfig
 	{
-		f, err := ioutil.ReadFile(cfg.tenantsConfigPath)
+		f, err := os.ReadFile(cfg.tenantsConfigPath)
 		if err != nil {
 			stdlog.Fatalf("cannot read tenant configuration file from path %q: %v", cfg.tenantsConfigPath, err)
 		}
@@ -410,7 +409,7 @@ func main() {
 			}
 
 			if cfg.tls.healthchecksServerCAFile != "" {
-				caCert, err := ioutil.ReadFile(cfg.tls.healthchecksServerCAFile)
+				caCert, err := os.ReadFile(cfg.tls.healthchecksServerCAFile)
 				if err != nil {
 					stdlog.Fatalf("failed to initialize healthcheck server TLS CA: %v", err)
 				}
@@ -436,14 +435,14 @@ func main() {
 		)
 
 		if cfg.metrics.upstreamCAFile != "" {
-			metricsUpstreamCACert, err = ioutil.ReadFile(cfg.metrics.upstreamCAFile)
+			metricsUpstreamCACert, err = os.ReadFile(cfg.metrics.upstreamCAFile)
 			if err != nil {
 				stdlog.Fatalf("failed to read upstream metrics TLS CA: %v", err)
 			}
 		}
 
 		if cfg.logs.upstreamCAFile != "" {
-			logsUpstreamCACert, err = ioutil.ReadFile(cfg.logs.upstreamCAFile)
+			logsUpstreamCACert, err = os.ReadFile(cfg.logs.upstreamCAFile)
 			if err != nil {
 				stdlog.Fatalf("failed to read upstream logs TLS CA: %v", err)
 			}

--- a/opa/opa.go
+++ b/opa/opa.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -154,7 +154,7 @@ func (a *restAuthorizer) Authorize(
 	}
 
 	if res.StatusCode/100 != 2 {
-		body, _ := ioutil.ReadAll(res.Body)
+		body, _ := io.ReadAll(res.Body)
 		res.Body.Close()
 		level.Error(a.logger).Log(
 			"msg", "received non-200 status code from OPA endpoint",

--- a/opa/opa_test.go
+++ b/opa/opa_test.go
@@ -1,7 +1,6 @@
 package opa
 
 import (
-	"io/ioutil"
 	"os"
 	"regexp"
 	"testing"
@@ -28,14 +27,10 @@ func dummyCustomRegoFunction(logger log.Logger) func(*rego.Rego) {
 func TestCustomRegoFunctions(t *testing.T) {
 	onboardNewFunction("dummy-rego-function", dummyCustomRegoFunction)
 
-	dir, err := ioutil.TempDir(".", "observatorium-tests")
-	if err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
-
+	dir := t.TempDir()
 	defer os.RemoveAll(dir)
 
-	regoFile, err := ioutil.TempFile(dir, "test.rego")
+	regoFile, err := os.CreateTemp(dir, "test.rego")
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/rbac/rbac.go
+++ b/rbac/rbac.go
@@ -3,7 +3,6 @@ package rbac
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/ghodss/yaml"
@@ -183,7 +182,7 @@ func Parse(r io.Reader, logger log.Logger) (Authorizer, error) {
 		RoleBindings []RoleBinding `json:"roleBindings"`
 	}{}
 
-	raw, err := ioutil.ReadAll(r)
+	raw, err := io.ReadAll(r)
 	if err != nil {
 		return nil, fmt.Errorf("could not read RBAC data: %w", err)
 	}

--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -117,7 +116,7 @@ func createTenantsYAML(
 		path.Join(opaURL, "v1/data/observatorium/allow"),
 	))
 
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		filepath.Join(e.SharedDir(), configSharedDir, "tenants.yaml"),
 		yamlContent,
 		os.FileMode(0755),
@@ -168,7 +167,7 @@ func createDexYAML(
 		redirectURI,
 	))
 
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		filepath.Join(e.SharedDir(), configSharedDir, "dex.yaml"),
 		yamlContent,
 		os.FileMode(0755),
@@ -199,7 +198,7 @@ func createRulesYAML(
 		secretKey,
 	))
 
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		filepath.Join(e.SharedDir(), configSharedDir, "rules-objstore.yaml"),
 		yamlContent,
 		os.FileMode(0755),
@@ -250,7 +249,7 @@ func createOtelCollectorConfigYAML(
 		otelConfigTpl,
 		jaegerGRPCEndpoint))
 
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		filepath.Join(e.SharedDir(), configSharedDir, "collector.yaml"),
 		yamlContent,
 		os.FileMode(0644),
@@ -313,7 +312,7 @@ func createOtelForwardingCollectorConfigYAML(
 		observatoriumGRPCEndpoint,
 		dexToken))
 
-	err := ioutil.WriteFile(
+	err := os.WriteFile(
 		filepath.Join(e.SharedDir(), configSharedDir, "forwarding-collector.yaml"),
 		yamlContent,
 		os.FileMode(0644),

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -7,9 +7,10 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -68,7 +69,7 @@ func obtainToken(endpoint string, tlsConf *tls.Config) (string, error) {
 	}
 	defer res.Body.Close()
 
-	body, err := ioutil.ReadAll(res.Body)
+	body, err := io.ReadAll(res.Body)
 	if err != nil {
 		return "", fmt.Errorf("cannot read body: %v\n", err)
 	}
@@ -104,7 +105,7 @@ func getContainerName(t *testing.T, tt testType, serviceName string) string {
 }
 
 func getTLSClientConfig(t *testing.T, e e2e.Environment) *tls.Config {
-	cert, err := ioutil.ReadFile(filepath.Join(e.SharedDir(), certsSharedDir, "ca.pem"))
+	cert, err := os.ReadFile(filepath.Join(e.SharedDir(), certsSharedDir, "ca.pem"))
 	testutil.Ok(t, err)
 
 	cp := x509.NewCertPool()

--- a/test/e2e/logs_test.go
+++ b/test/e2e/logs_test.go
@@ -3,7 +3,7 @@
 package e2e
 
 import (
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"testing"
@@ -80,7 +80,7 @@ func TestLogsReadWriteAndTail(t *testing.T) {
 		testutil.Ok(t, err)
 		defer res.Body.Close()
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		testutil.Ok(t, err)
 
 		bodyStr := string(body)

--- a/test/e2e/rules_test.go
+++ b/test/e2e/rules_test.go
@@ -4,7 +4,7 @@ package e2e
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"testing"
 
@@ -139,7 +139,7 @@ func TestRulesAPI(t *testing.T) {
 
 		testutil.Equals(t, http.StatusOK, res.StatusCode)
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		bodyStr := string(body)
 
 		assertResponse(t, bodyStr, "subscription_labels{email_domain=\"domain1.com\",tenant_id=\""+defaultTenantID+"\"}")
@@ -179,7 +179,7 @@ func TestRulesAPI(t *testing.T) {
 
 		testutil.Equals(t, http.StatusOK, res.StatusCode)
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		bodyStr := string(body)
 
 		assertResponse(t, bodyStr, "alert: HighRequestLatency")
@@ -215,7 +215,7 @@ func TestRulesAPI(t *testing.T) {
 
 		testutil.Equals(t, http.StatusOK, res.StatusCode)
 
-		body, err := ioutil.ReadAll(res.Body)
+		body, err := io.ReadAll(res.Body)
 		bodyStr := string(body)
 
 		assertResponse(t, bodyStr, "record: job:up:avg")

--- a/test/e2e/traces_test.go
+++ b/test/e2e/traces_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -129,7 +129,7 @@ func TestTracesExport(t *testing.T) {
 		testutil.Ok(t, err)
 		defer response.Body.Close()
 
-		body, err := ioutil.ReadAll(response.Body)
+		body, err := io.ReadAll(response.Body)
 		testutil.Ok(t, err)
 
 		bodyStr := string(body)
@@ -247,7 +247,7 @@ func requestWithRetry(t *testing.T, testLabel string, client *http.Client, reque
 		// We got a 200 response.
 		defer response.Body.Close()
 
-		body, err := ioutil.ReadAll(response.Body)
+		body, err := io.ReadAll(response.Body)
 		testutil.Ok(t, err)
 
 		return string(body), response.StatusCode
@@ -320,7 +320,7 @@ func TestTracesTemplateQuery(t *testing.T) {
 		testutil.Ok(t, err)
 		defer response.Body.Close()
 
-		body, err := ioutil.ReadAll(response.Body)
+		body, err := io.ReadAll(response.Body)
 		testutil.Ok(t, err)
 
 		bodyStr := string(body)

--- a/test/testtls/generate.go
+++ b/test/testtls/generate.go
@@ -2,7 +2,6 @@ package testtls
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -103,7 +102,7 @@ func GenerateCerts(
 			return fmt.Errorf("mkdir %s: %v", path, err)
 		}
 
-		if err := ioutil.WriteFile(filepath.Join(path, file), content, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(path, file), content, 0644); err != nil {
 			return fmt.Errorf("write file %s: %v", file, err)
 		}
 	}


### PR DESCRIPTION
This PR removes the usage of `ioutil` package, which has been deprecated: https://go.dev/doc/go1.16#ioutil.

`ioutil` is still however used in generated files (rules.go, client,go).