### PR TITLE
Add mTLS support for upstream servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ Usage of ./observatorium-api:
     	The name of the HTTP header containing the tenant ID to forward to the logs upstream. (default "X-Scope-OrgID")
   -logs.tls.ca-file string
     	File containing the TLS CA against which to upstream logs servers. Leave blank to disable TLS.
+  -logs.tls.cert-file string
+    	File containing the TLS client certificates to authenticate against upstream logs servers. Leave blank to disable mTLS.
+  -logs.tls.key-file string
+    	File containing the TLS client key to authenticate against upstream logs servers. Leave blank to disable mTLS.
   -logs.write.endpoint string
     	The endpoint against which to make write requests for logs.
   -metrics.read.endpoint string
@@ -111,6 +115,10 @@ Usage of ./observatorium-api:
     	The name of the PromQL label that should hold the tenant ID in metrics upstreams. (default "tenant_id")
   -metrics.tls.ca-file string
     	File containing the TLS CA against which to upstream metrics servers. Leave blank to disable TLS.
+  -metrics.tls.cert-file string
+    	File containing the TLS client certificates to authenticate against upstream logs servers. Leave blank to disable mTLS.
+  -metrics.tls.key-file string
+    	File containing the TLS client key to authenticate against upstream metrics servers. Leave blank to disable mTLS.
   -metrics.write.endpoint string
     	The endpoint against which to make write requests for metrics.
   -middleware.backlog-duration-concurrent-requests duration
@@ -151,6 +159,12 @@ Usage of ./observatorium-api:
     	The endpoint against which to make HTTP read requests for traces.
   -traces.tenant-header string
     	The name of the HTTP header containing the tenant ID to forward to upstream OpenTelemetry collector. (default "X-Tenant")
+  -traces.tls.ca-file string
+    	File containing the TLS CA against which to upstream traces servers. Leave blank to disable TLS.
+  -traces.tls.cert-file string
+    	File containing the TLS client certificates to authenticate against upstream logs servers. Leave blank to disable mTLS.
+  -traces.tls.key-file string
+    	File containing the TLS client key to authenticate against upstream traces servers. Leave blank to disable mTLS.
   -traces.write.endpoint string
     	The endpoint against which to make gRPC write requests for traces.
   -web.healthchecks.url string

--- a/tls/config.go
+++ b/tls/config.go
@@ -2,12 +2,31 @@ package tls
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"k8s.io/component-base/cli/flag"
 )
+
+// NewClientConfig returns a tls config for the reverse proxy handling if an upstream CA is given.
+func NewClientConfig(upstreamCA []byte, upstreamCert *tls.Certificate) *tls.Config {
+	if len(upstreamCA) == 0 {
+		return nil
+	}
+
+	cfg := &tls.Config{
+		RootCAs: x509.NewCertPool(),
+	}
+	cfg.RootCAs.AppendCertsFromPEM(upstreamCA)
+
+	if upstreamCert != nil {
+		cfg.Certificates = append(cfg.Certificates, *upstreamCert)
+	}
+
+	return cfg
+}
 
 // NewServerConfig provides new server TLS configuration.
 func NewServerConfig(logger log.Logger, certFile, keyFile, minVersion, maxVersion, clientAuthType string, cipherSuites []string) (*tls.Config, error) {


### PR DESCRIPTION
The following PR adds support to reverse proxy calls to metrics/logs/traces endpoints using mTLS. The purpose for this to support for example a Loki cluster that is secured via mTLS on an isolated environment. In detail, Loki does not support any native authentication methods on the HTTP layer.