### PR TITLE
[WIP] Add support for storing Loki rules via rules-objstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Usage of ./observatorium-api:
     	The endpoint against which to make read requests for logs.
   -logs.rules.endpoint string
     	The endpoint against which to make rules requests for logs.
+  -logs.rules.native
+    	Enable proxying logs rules requests to Loki Ruler directly.
+  -logs.rules.read-only
+    	Enable only read-only logs rules requests to endpoint.
   -logs.tail.endpoint string
     	The endpoint against which to make tail read requests for logs.
   -logs.tenant-header string

--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
 	"github.com/observatorium/api/proxy"
+	"github.com/observatorium/api/rbac"
 	"github.com/observatorium/api/rules"
 	"github.com/observatorium/api/tls"
 )
@@ -25,6 +26,7 @@ const (
 )
 
 const (
+	// Routes to Thanos
 	uiRoute          = "/"
 	queryRoute       = "/api/v1/query"
 	queryRangeRoute  = "/api/v1/query_range"
@@ -33,7 +35,9 @@ const (
 	labelValuesRoute = "/api/v1/label/{label_name}/values"
 	receiveRoute     = "/api/v1/receive"
 	rulesRoute       = "/api/v1/rules"
-	rulesRawRoute    = "/api/v1/rules/raw"
+
+	// Routes to rules-objstore
+	rulesRawRoute = "/api/v1/rules/raw"
 )
 
 type handlerConfiguration struct {
@@ -292,7 +296,7 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 			return r
 		}
 
-		rh := rulesHandler{client: client, logger: c.logger, tenantLabel: c.tenantLabel}
+		rh := rulesHandler{client: client, logger: c.logger, tenantLabel: c.tenantLabel, source: string(rbac.Metrics)}
 
 		r.Group(func(r chi.Router) {
 			r.Use(c.uiMiddlewares...)

--- a/authorization/grpc.go
+++ b/authorization/grpc.go
@@ -67,7 +67,7 @@ func WithGRPCAuthorizers(authorizers map[string]rbac.Authorizer, methReq GRPCRBa
 			return ctx, status.Error(codes.Unauthenticated, "error finding tenant id")
 		}
 
-		_, ok, data := a.Authorize(subject, groups, accessReq.Permission, accessReq.Resource, tenant, tenantID, token)
+		_, ok, data := a.Authorize(subject, groups, accessReq.Permission, rbac.Resource(accessReq.Resource), tenant, tenantID, token)
 		if !ok {
 			level.Debug(logger).Log("msg", "gRPC Authorizer: insufficient auth", "subject", subject, "tenant", tenant)
 			return ctx, status.Error(codes.PermissionDenied, "forbidden")

--- a/authorization/http.go
+++ b/authorization/http.go
@@ -33,7 +33,7 @@ func WithData(ctx context.Context, data string) context.Context {
 
 // WithAuthorizers returns a middleware that authorizes subjects taken from a request context
 // for the given permission on the given resource for a tenant taken from a request context.
-func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Permission, resource string) func(http.Handler) http.Handler {
+func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Permission, resource rbac.Resource) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368
 	google.golang.org/grpc v1.49.0
 	google.golang.org/protobuf v1.28.1
+	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/apimachinery v0.24.4
 	k8s.io/apiserver v0.21.1
 	k8s.io/client-go v0.24.4
@@ -174,7 +175,6 @@ require (
 	gopkg.in/cheggaaa/pb.v1 v1.0.28 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/square/go-jose.v2 v2.4.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.24.4 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect

--- a/opa/opa.go
+++ b/opa/opa.go
@@ -101,12 +101,12 @@ func (a *restAuthorizer) Authorize(
 	subject string,
 	groups []string,
 	permission rbac.Permission,
-	resource, tenant, tenantID, token string,
+	resource rbac.Resource, tenant, tenantID, token string,
 ) (int, bool, string) {
 	var i interface{} = Input{
 		Groups:     groups,
 		Permission: permission,
-		Resource:   resource,
+		Resource:   string(resource),
 		Subject:    subject,
 		Tenant:     tenant,
 		TenantID:   tenantID,
@@ -249,12 +249,12 @@ func (a *inProcessAuthorizer) Authorize(
 	subject string,
 	groups []string,
 	permission rbac.Permission,
-	resource, tenant, tenantID, token string,
+	resource rbac.Resource, tenant, tenantID, token string,
 ) (int, bool, string) {
 	var i interface{} = Input{
 		Groups:     groups,
 		Permission: permission,
-		Resource:   resource,
+		Resource:   string(resource),
 		Subject:    subject,
 		Tenant:     tenant,
 		TenantID:   tenantID,

--- a/rbac/rbac.go
+++ b/rbac/rbac.go
@@ -16,6 +16,9 @@ type Permission string
 // SubjectKind is a kind of Observatorium RBAC subject.
 type SubjectKind string
 
+// Resource is a kind of Observatorium RBAC resource.
+type Resource string
+
 const (
 	// Write gives access to write data to a tenant.
 	Write Permission = "write"
@@ -26,6 +29,13 @@ const (
 	User SubjectKind = "user"
 	// Group represents a subject that is a group.
 	Group SubjectKind = "group"
+
+	// Logs resprsents a resource that is a log endpoint.
+	Logs Resource = "logs"
+	// Metrics resprsents a resource that is a metrics endpoint.
+	Metrics Resource = "metrics"
+	// Traces resprsents a resource that is a traces endpoint.
+	Traces Resource = "Traces"
 )
 
 // Role describes a set of permissions to interact with a tenant.
@@ -52,7 +62,7 @@ type RoleBinding struct {
 // Authorizer can authorize a subject's permission for a tenant's resource.
 type Authorizer interface {
 	// Authorize answers the question: can subject S in groups G perform permission P on resource R for Tenant T?
-	Authorize(subject string, groups []string, permission Permission, resource, tenant, tenantID, token string) (int, bool, string)
+	Authorize(subject string, groups []string, permission Permission, resource Resource, tenant, tenantID, token string) (int, bool, string)
 }
 
 // tenant represents the read and write permissions of many subjects on a single tenant.
@@ -71,9 +81,10 @@ type resources struct {
 }
 
 // Authorize implements the Authorizer interface.
-func (rs resources) Authorize(subject string, groups []string, permission Permission, resource, tenant,
+func (rs resources) Authorize(subject string, groups []string, permission Permission, resource Resource, tenant,
 	tenantID, token string) (int, bool, string) {
-	ts, ok := rs.tenants[resource]
+	resourceStr := string(resource)
+	ts, ok := rs.tenants[resourceStr]
 	if !ok {
 		level.Debug(rs.logger).Log("msg",
 			fmt.Sprintf("authorization: resource %q unknown; valid resources are %v", resource, rs))

--- a/rbac/rbac_test.go
+++ b/rbac/rbac_test.go
@@ -13,7 +13,7 @@ func TestNewAuthorizer(t *testing.T) {
 		subject    string
 		groups     []string
 		permission Permission
-		resource   string
+		resource   Resource
 		tenant     string
 		tenantID   string
 		output     bool

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -295,17 +295,17 @@ func WithRequestEditorFn(fn RequestEditorFn) ClientOption {
 // The interface specification for the client above.
 type ClientInterface interface {
 	// ListAllRules request
-	ListAllRules(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListAllRules(ctx context.Context, source string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// ListRules request
-	ListRules(ctx context.Context, tenant string, reqEditors ...RequestEditorFn) (*http.Response, error)
+	ListRules(ctx context.Context, source string, tenant string, reqEditors ...RequestEditorFn) (*http.Response, error)
 
 	// SetRules request with any body
-	SetRulesWithBody(ctx context.Context, tenant string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
+	SetRulesWithBody(ctx context.Context, source string, tenant string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error)
 }
 
-func (c *Client) ListAllRules(ctx context.Context, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListAllRulesRequest(c.Server)
+func (c *Client) ListAllRules(ctx context.Context, source string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListAllRulesRequest(c.Server, source)
 	if err != nil {
 		return nil, err
 	}
@@ -316,8 +316,8 @@ func (c *Client) ListAllRules(ctx context.Context, reqEditors ...RequestEditorFn
 	return c.Client.Do(req)
 }
 
-func (c *Client) ListRules(ctx context.Context, tenant string, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewListRulesRequest(c.Server, tenant)
+func (c *Client) ListRules(ctx context.Context, source string, tenant string, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewListRulesRequest(c.Server, source, tenant)
 	if err != nil {
 		return nil, err
 	}
@@ -328,8 +328,8 @@ func (c *Client) ListRules(ctx context.Context, tenant string, reqEditors ...Req
 	return c.Client.Do(req)
 }
 
-func (c *Client) SetRulesWithBody(ctx context.Context, tenant string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
-	req, err := NewSetRulesRequestWithBody(c.Server, tenant, contentType, body)
+func (c *Client) SetRulesWithBody(ctx context.Context, source string, tenant string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*http.Response, error) {
+	req, err := NewSetRulesRequestWithBody(c.Server, source, tenant, contentType, body)
 	if err != nil {
 		return nil, err
 	}
@@ -341,15 +341,22 @@ func (c *Client) SetRulesWithBody(ctx context.Context, tenant string, contentTyp
 }
 
 // NewListAllRulesRequest generates requests for ListAllRules
-func NewListAllRulesRequest(server string) (*http.Request, error) {
+func NewListAllRulesRequest(server string, source string) (*http.Request, error) {
 	var err error
+
+	var pathParam0 string
+
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "source", runtime.ParamLocationPath, source)
+	if err != nil {
+		return nil, err
+	}
 
 	serverURL, err := url.Parse(server)
 	if err != nil {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/rules")
+	operationPath := fmt.Sprintf("/api/v1/rules/%s", pathParam0)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -368,12 +375,19 @@ func NewListAllRulesRequest(server string) (*http.Request, error) {
 }
 
 // NewListRulesRequest generates requests for ListRules
-func NewListRulesRequest(server string, tenant string) (*http.Request, error) {
+func NewListRulesRequest(server string, source string, tenant string) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "tenant", runtime.ParamLocationPath, tenant)
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "source", runtime.ParamLocationPath, source)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "tenant", runtime.ParamLocationPath, tenant)
 	if err != nil {
 		return nil, err
 	}
@@ -383,7 +397,7 @@ func NewListRulesRequest(server string, tenant string) (*http.Request, error) {
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/rules/%s", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/rules/%s/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -402,12 +416,19 @@ func NewListRulesRequest(server string, tenant string) (*http.Request, error) {
 }
 
 // NewSetRulesRequestWithBody generates requests for SetRules with any type of body
-func NewSetRulesRequestWithBody(server string, tenant string, contentType string, body io.Reader) (*http.Request, error) {
+func NewSetRulesRequestWithBody(server string, source string, tenant string, contentType string, body io.Reader) (*http.Request, error) {
 	var err error
 
 	var pathParam0 string
 
-	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "tenant", runtime.ParamLocationPath, tenant)
+	pathParam0, err = runtime.StyleParamWithLocation("simple", false, "source", runtime.ParamLocationPath, source)
+	if err != nil {
+		return nil, err
+	}
+
+	var pathParam1 string
+
+	pathParam1, err = runtime.StyleParamWithLocation("simple", false, "tenant", runtime.ParamLocationPath, tenant)
 	if err != nil {
 		return nil, err
 	}
@@ -417,7 +438,7 @@ func NewSetRulesRequestWithBody(server string, tenant string, contentType string
 		return nil, err
 	}
 
-	operationPath := fmt.Sprintf("/api/v1/rules/%s", pathParam0)
+	operationPath := fmt.Sprintf("/api/v1/rules/%s/%s", pathParam0, pathParam1)
 	if operationPath[0] == '/' {
 		operationPath = "." + operationPath
 	}
@@ -481,13 +502,13 @@ func WithBaseURL(baseURL string) ClientOption {
 // ClientWithResponsesInterface is the interface specification for the client with responses above.
 type ClientWithResponsesInterface interface {
 	// ListAllRules request
-	ListAllRulesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAllRulesResponse, error)
+	ListAllRulesWithResponse(ctx context.Context, source string, reqEditors ...RequestEditorFn) (*ListAllRulesResponse, error)
 
 	// ListRules request
-	ListRulesWithResponse(ctx context.Context, tenant string, reqEditors ...RequestEditorFn) (*ListRulesResponse, error)
+	ListRulesWithResponse(ctx context.Context, source string, tenant string, reqEditors ...RequestEditorFn) (*ListRulesResponse, error)
 
 	// SetRules request with any body
-	SetRulesWithBodyWithResponse(ctx context.Context, tenant string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetRulesResponse, error)
+	SetRulesWithBodyWithResponse(ctx context.Context, source string, tenant string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetRulesResponse, error)
 }
 
 type ListAllRulesResponse struct {
@@ -556,8 +577,8 @@ func (r SetRulesResponse) StatusCode() int {
 }
 
 // ListAllRulesWithResponse request returning *ListAllRulesResponse
-func (c *ClientWithResponses) ListAllRulesWithResponse(ctx context.Context, reqEditors ...RequestEditorFn) (*ListAllRulesResponse, error) {
-	rsp, err := c.ListAllRules(ctx, reqEditors...)
+func (c *ClientWithResponses) ListAllRulesWithResponse(ctx context.Context, source string, reqEditors ...RequestEditorFn) (*ListAllRulesResponse, error) {
+	rsp, err := c.ListAllRules(ctx, source, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -565,8 +586,8 @@ func (c *ClientWithResponses) ListAllRulesWithResponse(ctx context.Context, reqE
 }
 
 // ListRulesWithResponse request returning *ListRulesResponse
-func (c *ClientWithResponses) ListRulesWithResponse(ctx context.Context, tenant string, reqEditors ...RequestEditorFn) (*ListRulesResponse, error) {
-	rsp, err := c.ListRules(ctx, tenant, reqEditors...)
+func (c *ClientWithResponses) ListRulesWithResponse(ctx context.Context, source string, tenant string, reqEditors ...RequestEditorFn) (*ListRulesResponse, error) {
+	rsp, err := c.ListRules(ctx, source, tenant, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -574,8 +595,8 @@ func (c *ClientWithResponses) ListRulesWithResponse(ctx context.Context, tenant 
 }
 
 // SetRulesWithBodyWithResponse request with arbitrary body returning *SetRulesResponse
-func (c *ClientWithResponses) SetRulesWithBodyWithResponse(ctx context.Context, tenant string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetRulesResponse, error) {
-	rsp, err := c.SetRulesWithBody(ctx, tenant, contentType, body, reqEditors...)
+func (c *ClientWithResponses) SetRulesWithBodyWithResponse(ctx context.Context, source string, tenant string, contentType string, body io.Reader, reqEditors ...RequestEditorFn) (*SetRulesResponse, error) {
+	rsp, err := c.SetRulesWithBody(ctx, source, tenant, contentType, body, reqEditors...)
 	if err != nil {
 		return nil, err
 	}
@@ -653,14 +674,14 @@ func ParseSetRulesResponse(rsp *http.Response) (*SetRulesResponse, error) {
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
 	// lists all rules for all tenants
-	// (GET /api/v1/rules)
-	ListAllRules(w http.ResponseWriter, r *http.Request)
+	// (GET /api/v1/rules/{source})
+	ListAllRules(w http.ResponseWriter, r *http.Request, source string)
 	// lists all rules for a tenant
-	// (GET /api/v1/rules/{tenant})
-	ListRules(w http.ResponseWriter, r *http.Request, tenant string)
+	// (GET /api/v1/rules/{source}/{tenant})
+	ListRules(w http.ResponseWriter, r *http.Request, source string, tenant string)
 	// set/overwrite the rules for the tenant
-	// (PUT /api/v1/rules/{tenant})
-	SetRules(w http.ResponseWriter, r *http.Request, tenant string)
+	// (PUT /api/v1/rules/{source}/{tenant})
+	SetRules(w http.ResponseWriter, r *http.Request, source string, tenant string)
 }
 
 // ServerInterfaceWrapper converts contexts to parameters.
@@ -676,8 +697,19 @@ type MiddlewareFunc func(http.HandlerFunc) http.HandlerFunc
 func (siw *ServerInterfaceWrapper) ListAllRules(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
+	var err error
+
+	// ------------- Path parameter "source" -------------
+	var source string
+
+	err = runtime.BindStyledParameter("simple", false, "source", chi.URLParam(r, "source"), &source)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "source", Err: err})
+		return
+	}
+
 	var handler = func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.ListAllRules(w, r)
+		siw.Handler.ListAllRules(w, r, source)
 	}
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -693,6 +725,15 @@ func (siw *ServerInterfaceWrapper) ListRules(w http.ResponseWriter, r *http.Requ
 
 	var err error
 
+	// ------------- Path parameter "source" -------------
+	var source string
+
+	err = runtime.BindStyledParameter("simple", false, "source", chi.URLParam(r, "source"), &source)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "source", Err: err})
+		return
+	}
+
 	// ------------- Path parameter "tenant" -------------
 	var tenant string
 
@@ -703,7 +744,7 @@ func (siw *ServerInterfaceWrapper) ListRules(w http.ResponseWriter, r *http.Requ
 	}
 
 	var handler = func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.ListRules(w, r, tenant)
+		siw.Handler.ListRules(w, r, source, tenant)
 	}
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -719,6 +760,15 @@ func (siw *ServerInterfaceWrapper) SetRules(w http.ResponseWriter, r *http.Reque
 
 	var err error
 
+	// ------------- Path parameter "source" -------------
+	var source string
+
+	err = runtime.BindStyledParameter("simple", false, "source", chi.URLParam(r, "source"), &source)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "source", Err: err})
+		return
+	}
+
 	// ------------- Path parameter "tenant" -------------
 	var tenant string
 
@@ -729,7 +779,7 @@ func (siw *ServerInterfaceWrapper) SetRules(w http.ResponseWriter, r *http.Reque
 	}
 
 	var handler = func(w http.ResponseWriter, r *http.Request) {
-		siw.Handler.SetRules(w, r, tenant)
+		siw.Handler.SetRules(w, r, source, tenant)
 	}
 
 	for _, middleware := range siw.HandlerMiddlewares {
@@ -853,13 +903,13 @@ func HandlerWithOptions(si ServerInterface, options ChiServerOptions) http.Handl
 	}
 
 	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/api/v1/rules", wrapper.ListAllRules)
+		r.Get(options.BaseURL+"/api/v1/rules/{source}", wrapper.ListAllRules)
 	})
 	r.Group(func(r chi.Router) {
-		r.Get(options.BaseURL+"/api/v1/rules/{tenant}", wrapper.ListRules)
+		r.Get(options.BaseURL+"/api/v1/rules/{source}/{tenant}", wrapper.ListRules)
 	})
 	r.Group(func(r chi.Router) {
-		r.Put(options.BaseURL+"/api/v1/rules/{tenant}", wrapper.SetRules)
+		r.Put(options.BaseURL+"/api/v1/rules/{source}/{tenant}", wrapper.SetRules)
 	})
 
 	return r

--- a/rules/spec.yaml
+++ b/rules/spec.yaml
@@ -10,8 +10,14 @@ tags:
   - name: rulesv1
     description: Calls related to rules
 paths:
-  /api/v1/rules/{tenant}:
+  /api/v1/rules/{source}/{tenant}:
     parameters:
+      - in: path
+        name: source
+        description: name of the observability signal source
+        required: true
+        schema:
+          type: string
       - in: path
         name: tenant
         description: name of the tenant
@@ -51,7 +57,14 @@ paths:
             schema:
               $ref: '#/components/schemas/Rules'
         description: Rules to set
-  /api/v1/rules:
+  /api/v1/rules/{source}:
+    parameters:
+      - in: path
+        name: source
+        description: name of the observability signal source
+        required: true
+        schema:
+          type: string
     get:
       tags:
         - rulesv1


### PR DESCRIPTION
## Summary

The following PR adds support for serving Loki rules via the [observatorium/rules-objstore](/bservatorium/rules-objstore) service. The underlying design supports two mutual exclusive use cases with this addition:

### Main Case: RHOBS Unified Rules management

Use the Loki Ruler API **only** for read-only access on rules. Provide the `/api/v1/rules/raw` API to create/update rules through the  [observatorium/rules-objstore](/bservatorium/rules-objstore). 

#### Required Further work

To support a unified rules management on RHOBS, the [observatorium/rules-objstore](/bservatorium/rules-objstore) requires to store per tenant and per signal source.

### Secondary Case: Kubernetes-Native Rules Management

Use the Loki Ruler API for fetching/creating/updating rules for native usage (See cli flags `logs.rules.native`). This case applies to using the observatorium-api in the Loki-Operator combined with the CLI flag `logs.rules.read-only` where rules are managed via [AlertingRule](https://loki-operator.dev/docs/api.md/#alertingrule) and/or [RecordingRule](https://loki-operator.dev/docs/api.md/#recordingrule) custom resources.

#### Required Further Work

For example for any kubernetes-native application (e.g. the Loki Operator), it is required to pass the appropriate CLI flags to the observatorium-api, i.e. `--logs.rules.native=loki-ruler.example.com` and `--logs.rules.read-only=true`. For example:

* grafana/loki#7254
