### PR TITLE
Seggregate read and write access to logs rules routes based on flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Usage of ./observatorium-api:
     	The endpoint against which to make read requests for logs.
   -logs.rules.endpoint string
     	The endpoint against which to make rules requests for logs.
+  -logs.rules.read-only
+    	Allow only read-only rule requests for logs.
   -logs.tail.endpoint string
     	The endpoint against which to make tail read requests for logs.
   -logs.tenant-header string

--- a/main.go
+++ b/main.go
@@ -141,6 +141,9 @@ type logsConfig struct {
 	upstreamCertFile string
 	upstreamKeyFile  string
 	tenantHeader     string
+
+	// Allow only read-only access on rules
+	rulesReaOnly bool
 	// enable logs at least one {read,write,tail}Endpoint} is provided.
 	enabled bool
 }
@@ -654,6 +657,7 @@ func main() {
 								cfg.logs.tailEndpoint,
 								cfg.logs.writeEndpoint,
 								cfg.logs.rulesEndpoint,
+								cfg.logs.rulesReaOnly,
 								logsUpstreamCACert,
 								logsUpstreamClientCert,
 								logsv1.Logger(logger),
@@ -957,6 +961,8 @@ func parseFlags() (config, error) {
 		"The endpoint against which to make read requests for logs.")
 	flag.StringVar(&rawLogsRulesEndpoint, "logs.rules.endpoint", "",
 		"The endpoint against which to make rules requests for logs.")
+	flag.BoolVar(&cfg.logs.rulesReaOnly, "logs.rules.read-only", false,
+		"Allow only read-only rule requests for logs.")
 	flag.StringVar(&cfg.logs.upstreamCAFile, "logs.tls.ca-file", "",
 		"File containing the TLS CA against which to upstream logs servers. Leave blank to disable TLS.")
 	flag.StringVar(&cfg.logs.upstreamCertFile, "logs.tls.cert-file", "",


### PR DESCRIPTION
The following PR is a spin-off from the discussion on observatorium/api#380 and observatorium/rules-objstore#11 to support Loki rules management via the observatorium-api. In particular it simplifies the original design by removing the need to run the `rules-objstore` as a middle-man for Loki rules. In addition it continues to support kubernetes-native rules management via custom resources by adding the option to have a read-only access to Loki rules via the observatorium-api. In detail:

### RHOBS Rules Management

For managing Loki Rules the observatorium-api allows to proxy read and write requests to the Loki Ruler endpoints (i.e. `--logs.rules.endpont=http://loki-ruler:3100` and `--logs.rules.read-only=false`). The Loki Ruler is managing all CRUD operations on a shared object storage bucket on a distinct path, e.g. `/logs/rules`. The bucket is shared with the `rules-objstore` that manages exclusively the metrics rules on separate path, e.g. `/metrics/rules`.

### Kubernetes native Rules Management

The read and write access to Loki Rules is separated here between the observatorium-api and the kubernetes operator that provides custom resources for alerting and recording rules (See Loki Operator). The observatorium-api enables only a read access to the rules. On the other hand the custom resources for alerting and recording rules are translated into Loki Rules YAML stored in a ConfigMap.  Thus the cli flags look like `--logs.rules.endpont=http://loki-ruler.ns.svc:3100` and `--logs.rules.read-only=true`