### PR TITLE
Fix OIDC redirect URL in e2e test

### DIFF
--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -57,7 +57,7 @@ tenants:
       clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
       issuerCAPath: %[1]s
       issuerURL: https://%[2]s
-      redirectURL: https://localhost:8443/oidc/test-oidc/callback
+      redirectURL: https://%[7]s:8443/oidc/test-oidc/callback
       usernameClaim: email
   opa:
     query: data.observatorium.allow
@@ -78,7 +78,7 @@ tenants:
     clientSecret: ZXhhbXBsZS1hcHAtc2VjcmV0
     issuerCAPath: %[1]s
     issuerURL: https://%[2]s
-    redirectURL: https://localhost:8443/oidc/test-attacker/callback
+    redirectURL: https://%[7]s:8443/oidc/test-attacker/callback
     usernameClaim: email
   opa:
     query: data.observatorium.allow
@@ -105,6 +105,7 @@ func createTenantsYAML(
 	e e2e.Environment,
 	issuerURL string,
 	opaURL string,
+	apiServiceHostname string,
 ) {
 	yamlContent := []byte(fmt.Sprintf(
 		tenantsYamlTpl,
@@ -114,6 +115,7 @@ func createTenantsYAML(
 		filepath.Join(configsContainerPath, "rbac.yaml"),
 		filepath.Join(certsContainerPath, "ca.pem"),
 		path.Join(opaURL, "v1/data/observatorium/allow"),
+		apiServiceHostname,
 	))
 
 	err := os.WriteFile(

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -201,7 +201,7 @@ func startBaseServices(t *testing.T, e e2e.Environment, tt testType) (
 	opa := newOPAService(e)
 	testutil.Ok(t, e2e.StartAndWaitReady(dex, gubernator, opa))
 
-	createTenantsYAML(t, e, dex.InternalEndpoint("https"), opa.InternalEndpoint("http"))
+	createTenantsYAML(t, e, dex.InternalEndpoint("https"), opa.InternalEndpoint("http"), getContainerName(t, tt, "observatorium_api"))
 
 	token, err := obtainToken(dex.Endpoint("https"), getTLSClientConfig(t, e))
 	testutil.Ok(t, err)


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <p.loffay@gmail.com>


With  https://github.com/dvddarias/docker-hoster
```
docker run -d \
    -v /var/run/docker.sock:/tmp/docker.sock \
    -v /etc/hosts:/tmp/hosts \
    dvdarias/docker-hoster	
```

I can access `https://e2e_interactive-observatorium_api:8443/api/traces/v1/test-oidc/search` from my host and fully authenticate. The tool just edits `/etc/hosts` which somebody can do manually by using IP addresses from `docker inspect`.