### PR TITLE
Remove component-base for manual implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,6 @@ require (
 	k8s.io/apimachinery v0.24.4
 	k8s.io/apiserver v0.21.1
 	k8s.io/client-go v0.24.4
-	k8s.io/component-base v0.24.4
 )
 
 require (
@@ -177,6 +176,7 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.24.4 // indirect
+	k8s.io/component-base v0.24.4 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect

--- a/tls/config.go
+++ b/tls/config.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"k8s.io/component-base/cli/flag"
 )
 
 // NewClientConfig returns a tls config for the reverse proxy handling if an upstream CA is given.
@@ -43,21 +42,21 @@ func NewServerConfig(logger log.Logger, certFile, keyFile, minVersion, maxVersio
 		return nil, fmt.Errorf("server credentials: %w", err)
 	}
 
-	tlsMinVersion, err := flag.TLSVersion(minVersion)
+	tlsMinVersion, err := parseTLSVersion(minVersion)
 	if err != nil {
-		return nil, fmt.Errorf("TLS version invalid: %w", err)
+		return nil, fmt.Errorf("cannot parse TLS Version: %w", err)
 	}
 
-	tlsMaxVersion, err := flag.TLSVersion(maxVersion)
+	tlsMaxVersion, err := parseTLSVersion(maxVersion)
 	if err != nil {
-		return nil, fmt.Errorf("TLS version invalid: %w", err)
+		return nil, fmt.Errorf("cannot parse TLS Version: %w", err)
 	}
 
 	if tlsMinVersion > tlsMaxVersion {
 		return nil, fmt.Errorf("TLS minimum version can not be greater than maximum version: %v > %v", tlsMinVersion, tlsMaxVersion)
 	}
 
-	cipherSuiteIDs, err := flag.TLSCipherSuites(cipherSuites)
+	cipherSuiteIDs, err := mapCipherNamesToIDs(cipherSuites)
 	if err != nil {
 		return nil, fmt.Errorf("TLS cipher suite name to ID conversion: %v", err)
 	}
@@ -79,6 +78,49 @@ func NewServerConfig(logger log.Logger, certFile, keyFile, minVersion, maxVersio
 	}
 
 	return tlsCfg, nil
+}
+
+func tlsCipherSuites() map[string]uint16 {
+	cipherSuites := map[string]uint16{}
+
+	for _, suite := range tls.CipherSuites() {
+		cipherSuites[suite.Name] = suite.ID
+	}
+	for _, suite := range tls.InsecureCipherSuites() {
+		cipherSuites[suite.Name] = suite.ID
+	}
+
+	return cipherSuites
+}
+
+func parseTLSVersion(rawTLSVersion string) (uint16, error) {
+	switch rawTLSVersion {
+	case "VersionTLS10": 
+		return tls.VersionTLS10, nil
+	case "VersionTLS11": 
+		return tls.VersionTLS11, nil
+	case "VersionTLS12": 
+		return tls.VersionTLS12, nil
+	case "VersionTLS13": 
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("unknown TLSVersion: %s", rawTLSVersion)
+	}
+}
+
+func mapCipherNamesToIDs(rawTLSCipherSuites []string) ([]uint16, error) {
+	cipherSuites := []uint16{}
+	allCipherSuites := tlsCipherSuites()
+
+	for _, name := range rawTLSCipherSuites {
+		id, ok := allCipherSuites[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown TLSCipherSuite: %s", name)
+		}
+		cipherSuites = append(cipherSuites, id)
+	}
+
+	return cipherSuites, nil
 }
 
 func parseClientAuthType(rawAuthType string) (tls.ClientAuthType, error) {


### PR DESCRIPTION
This PR removes the `k8s.io/component-base` dependency in favor of a manual lookup for the TLS variables. `component-base` and `apiserver` rely on old versions of `otel`. This causes problems when trying to upgrade the k8s dependencies. Since `component-base` is only required to look up the TLS variables, it makes sense to replace it to reduce the number of dependencies which rely on this old library version.