### PR TITLE
Fix default TLS cipher configuration when none are specified

### DIFF
--- a/tls/config.go
+++ b/tls/config.go
@@ -109,6 +109,10 @@ func parseTLSVersion(rawTLSVersion string) (uint16, error) {
 }
 
 func mapCipherNamesToIDs(rawTLSCipherSuites []string) ([]uint16, error) {
+	if rawTLSCipherSuites == nil {
+		return nil, nil
+	}
+
 	cipherSuites := []uint16{}
 	allCipherSuites := tlsCipherSuites()
 


### PR DESCRIPTION
This is a follow-up patch to #396. When there is no cipher suite set, an empty array would be set in for the `TLSConfig`. Instead, this should be nil so that the default list of cipher suites are used instead.