### PR TITLE
*: Bump go.mod to 1.18 to fix dependabot issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ build: $(BIN_NAME)
 
 .PHONY: deps
 deps: go.mod go.sum
-	go mod tidy -compat=1.17
+	go mod tidy
 	go mod download
 	go mod verify
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/observatorium/api
 
-go 1.17
+go 1.18
 
 require (
 	github.com/brancz/kube-rbac-proxy v0.11.0


### PR DESCRIPTION
Signed-off-by: Matej Gera <matejgera@gmail.com>

Follow up to https://github.com/observatorium/api/pull/409.

The issue is that dependabot uses `go mod tidy` without the parameter to ensure compatibility with 1.17 module graph pruning (`-compat=1.17`). One example of affected PR: https://github.com/observatorium/api/pull/408.

Since it's not possible customize dependabot command, next best solution is to bump `go.mod` to 1.18 even though we don't strictly require it. This sidesteps the issue as with 1.18 it's not necessary to use the `-compat` parameter (see last paragraph in https://go.dev/ref/mod#graph-pruning).