### PR TITLE
Fix rate limiter window duration

### DIFF
--- a/ratelimit/http.go
+++ b/ratelimit/http.go
@@ -65,7 +65,7 @@ func WithSharedRateLimiter(logger log.Logger, client SharedRateLimiter, configs 
 				name:     requestName,
 				key:      fmt.Sprintf("%s:%s", c.Tenant, c.Matcher.String()),
 				limit:    int64(c.Limit),
-				duration: c.Window.Microseconds(),
+				duration: c.Window.Milliseconds(),
 			}}.Handler})
 	}
 


### PR DESCRIPTION
Gubernator's duration parameter should be in milliseconds, according to their own documentation: https://github.com/mailgun/gubernator/blob/v1.0.1-rc.1/README.md?plain=1#L41.

Unfortunately I cannot add an e2e test for this right now because:

* This is is kind of urgent. 
* The e2e tests aren't (yet) arm64 friendly and I work on arm64. 
* To make them arm64 friendly we need to upgrade github.com/efficientgo dependencies (there are breaking changes) and potentially create multi-arch images for other projects in this org. I created #423 to track this.

I found the problem and solution by spinning up Gubernator and manually calling the gRPC service.