### PR TITLE
Proposal: Fix HTTP instrumentation for metricsv1 handler

### DIFF
--- a/server/http_instrumentation.go
+++ b/server/http_instrumentation.go
@@ -1,13 +1,15 @@
 package server
 
 import (
+	"context"
+	"net/http"
+	"strconv"
+	"time"
+
 	"github.com/go-chi/chi/middleware"
 	"github.com/observatorium/api/authentication"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"net/http"
-	"strconv"
-	"time"
 )
 
 // httpMetricsCollector is responsible for collecting HTTP metrics with extra tenant labels.
@@ -19,20 +21,20 @@ type httpMetricsCollector struct {
 }
 
 // newHTTPMetricsCollector creates a new httpMetricsCollector.
-func newHTTPMetricsCollector(reg *prometheus.Registry, hardcodedLabels []string) httpMetricsCollector {
+func newHTTPMetricsCollector(reg *prometheus.Registry) httpMetricsCollector {
 	m := httpMetricsCollector{
 		requestCounter: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "http_requests_total",
 			Help: "Counter of HTTP requests.",
 		},
-			append(hardcodedLabels, "code", "method", "tenant"),
+			[]string{"group", "handler", "code", "method", "tenant"},
 		),
 		requestSize: promauto.With(reg).NewSummaryVec(
 			prometheus.SummaryOpts{
 				Name: "http_request_size_bytes",
 				Help: "Size of HTTP requests.",
 			},
-			append(hardcodedLabels, "code", "method", "tenant"),
+			[]string{"group", "handler", "code", "method", "tenant"},
 		),
 		requestDuration: promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -40,7 +42,7 @@ func newHTTPMetricsCollector(reg *prometheus.Registry, hardcodedLabels []string)
 				Help:    "Histogram of latencies for HTTP requests.",
 				Buckets: []float64{.1, .2, .4, 1, 2.5, 5, 8, 20, 60, 120},
 			},
-			append(hardcodedLabels, "code", "method", "tenant"),
+			[]string{"group", "handler", "code", "method", "tenant"},
 		),
 		responseSize: promauto.With(reg).NewHistogramVec(
 			prometheus.HistogramOpts{
@@ -48,7 +50,7 @@ func newHTTPMetricsCollector(reg *prometheus.Registry, hardcodedLabels []string)
 				Help:    "Histogram of response size for HTTP requests.",
 				Buckets: prometheus.ExponentialBuckets(100, 10, 8),
 			},
-			append(hardcodedLabels, "code", "method", "tenant"),
+			[]string{"group", "handler", "code", "method", "tenant"},
 		),
 	}
 	return m
@@ -60,8 +62,18 @@ type instrumentedHandlerFactory struct {
 }
 
 // NewHandler creates a new instrumented HTTP handler with the given extra labels and calling the "next" handlers.
+// If the extraLabels are nil, they will be fetched from the context. To store them in the context see the functions
+// WithHandlerLabel and WithGroupLabel.
 func (m instrumentedHandlerFactory) NewHandler(extraLabels prometheus.Labels, next http.Handler) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		if len(extraLabels) == 0 {
+			if labels := r.Context().Value(extraHandlerLabelsCtxKey); labels != nil {
+				ctxLabels, ok := labels.(prometheus.Labels)
+				if ok {
+					extraLabels = ctxLabels
+				}
+			}
+		}
 		rw := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 		now := time.Now()
 		next.ServeHTTP(rw, r)
@@ -91,9 +103,9 @@ func (m instrumentedHandlerFactory) NewHandler(extraLabels prometheus.Labels, ne
 }
 
 // NewInstrumentedHandlerFactory creates a new instrumentedHandlerFactory.
-func NewInstrumentedHandlerFactory(req *prometheus.Registry, hardcodedLabels []string) instrumentedHandlerFactory {
+func NewInstrumentedHandlerFactory(req *prometheus.Registry) instrumentedHandlerFactory {
 	return instrumentedHandlerFactory{
-		metricsCollector: newHTTPMetricsCollector(req, hardcodedLabels),
+		metricsCollector: newHTTPMetricsCollector(req),
 	}
 }
 
@@ -120,4 +132,42 @@ func computeApproximateRequestSize(r *http.Request) int {
 		s += int(r.ContentLength)
 	}
 	return s
+}
+
+var extraHandlerLabelsCtxKey = struct{}{}
+
+func extraHandlerLabelFromContext(ctx context.Context) prometheus.Labels {
+	labels, ok := ctx.Value(extraHandlerLabelsCtxKey).(prometheus.Labels)
+	if !ok {
+		return nil
+	}
+	return labels
+}
+
+// WithHandlerLabel stores desired value for the "handler" label in the context. It will later be
+// picked up by the HTTP instrumentation middleware and used in its metrics.
+func WithHandlerLabel(value string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return extraHandlerLabel("handler", value, next)
+	}
+}
+
+// WithGroupLabel stores desired value for the "group" label in the context. It will later be
+// picked up by the HTTP instrumentation middleware and used in its metrics.
+func WithGroupLabel(value string) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return extraHandlerLabel("group", value, next)
+	}
+}
+
+func extraHandlerLabel(name, value string, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		labels := extraHandlerLabelFromContext(r.Context())
+		if labels != nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+		labels[name] = value
+		next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), extraHandlerLabelsCtxKey, labels)))
+	})
 }


### PR DESCRIPTION
Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>

## Motivation

This is an idea of how to separate the work from #430 into smaller parts.

## Problem

Currently the instrumentation middleware is not catching all requests. There are plenty of middlewares being set up before instrumentation (i.e. the timeout middleware, rate limit middleware) that can finish a request early.

## Changes

- HTTP instrumentation middleware moved to as high as possible on the middlestack, before anything that could finish the request early before it's instrumented.
  - Changed the hardcoded labels per handler mechanism to accomodate this. Note This was never meant to be a flexible mechanism to add arbitrary labels to the HTTP instrumentation metrics, as such labels have to be defined in the metrics first.
  - Created two small middlewares to add the "group" and "handler" labels
    - Used them everywhere in the "metricsv1" group as an example.