### PR TITLE
Allow multiple matchers for NetObserv multi-tenancy (NETOBSERV-171)

### DIFF
--- a/api/logs/v1/labels_enforcer.go
+++ b/api/logs/v1/labels_enforcer.go
@@ -14,7 +14,7 @@ import (
 
 type AuthzResponseData struct {
 	Matchers  []*labels.Matcher `json:"matchers,omitempty"`
-	LogicalOp string            `json:"logicalOp,omitempty"`
+	MatcherOp string            `json:"matcherOp,omitempty"`
 }
 
 const logicalOr = "or"
@@ -71,7 +71,7 @@ func enforceValues(mInfo AuthzResponseData, v url.Values) (values string, err er
 		return "", fmt.Errorf("failed parsing LogQL expression: %w", err)
 	}
 
-	switch mInfo.LogicalOp {
+	switch mInfo.MatcherOp {
 	case logicalOr:
 		// Logical "OR" to combine multiple matchers needs to be done via LogQueryExpr > LogPipelineExpr
 		expr.Walk(func(expr interface{}) {

--- a/api/logs/v1/labels_enforcer.go
+++ b/api/logs/v1/labels_enforcer.go
@@ -12,8 +12,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-// TODO: share with OPA?
-type MatchersInfo struct {
+type AuthzResponseData struct {
 	Matchers  []*labels.Matcher `json:"matchers,omitempty"`
 	LogicalOp string            `json:"logicalOp,omitempty"`
 }
@@ -40,7 +39,7 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 				return
 			}
 
-			var matchersInfo MatchersInfo
+			var matchersInfo AuthzResponseData
 			if err := json.Unmarshal([]byte(data), &matchersInfo); err != nil {
 				httperr.PrometheusAPIError(w, "error parsing authorization label matchers", http.StatusInternalServerError)
 
@@ -62,7 +61,7 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 
 const queryParam = "query"
 
-func enforceValues(mInfo MatchersInfo, v url.Values) (values string, err error) {
+func enforceValues(mInfo AuthzResponseData, v url.Values) (values string, err error) {
 	if v.Get(queryParam) == "" {
 		return v.Encode(), nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.39.0
 	github.com/prometheus/prometheus v0.42.0
-	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.39.0
 	go.opentelemetry.io/contrib/propagators/jaeger v1.14.0
 	go.opentelemetry.io/otel v1.13.0
@@ -145,6 +144,7 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/urfave/cli v1.22.7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/common v0.39.0
 	github.com/prometheus/prometheus v0.42.0
+	github.com/stretchr/testify v1.8.1
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.39.0
 	go.opentelemetry.io/contrib/propagators/jaeger v1.14.0
 	go.opentelemetry.io/otel v1.13.0
@@ -144,7 +145,6 @@ require (
 	github.com/soheilhy/cmux v0.1.5 // indirect
 	github.com/spf13/cobra v1.6.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.8.1 // indirect
 	github.com/tchap/go-patricia/v2 v2.3.1 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20201229170055-e5319fda7802 // indirect
 	github.com/urfave/cli v1.22.7 // indirect

--- a/logql/v2/ast.go
+++ b/logql/v2/ast.go
@@ -63,39 +63,32 @@ func (s *StreamMatcherExpr) Walk(fn WalkFn) {
 	fn(s)
 }
 
-func singleStreamString(matchers []*labels.Matcher) string {
+func (s *StreamMatcherExpr) String() string {
 	var sb strings.Builder
 
 	sb.WriteString("{")
-
-	for i, m := range matchers {
-		sb.WriteString(m.String())
-
-		if i+1 != len(matchers) {
-			sb.WriteString(", ")
-		}
-	}
+	sb.WriteString(matchersToString(s.matchers, ", "))
 
 	sb.WriteString("}")
+
+	if len(s.orMatchers) > 0 {
+		sb.WriteString(" | ")
+		sb.WriteString(matchersToString(s.orMatchers, " or "))
+	}
 
 	return sb.String()
 }
 
-func (s *StreamMatcherExpr) String() string {
-	if len(s.orMatchers) == 0 {
-		return singleStreamString(s.matchers)
+func matchersToString(matchers []*labels.Matcher, sep string) string {
+	var sb strings.Builder
+	for i, m := range matchers {
+		sb.WriteString(m.String())
+
+		if i+1 != len(matchers) {
+			sb.WriteString(sep)
+		}
 	}
-	// TODO: this won't work, as "or" operator only works with vectors.
-	// Options:
-	// 1. split into several queries, then merge results
-	// 2. use line filters
-	//   E.g: {app="netobserv-flowcollector"} | SrcK8S_Namespace=~"netobserv|default" or DstK8S_Namespace=~"netobserv|default"
-	// Option 1. is probably more performant as it uses indexed stream selectors; but more complex
-	var parts []string
-	for _, orMatcher := range s.orMatchers {
-		parts = append(parts, singleStreamString(append(s.matchers, orMatcher)))
-	}
-	return strings.Join(parts, " or ")
+	return sb.String()
 }
 
 func newLabelMatcher(t labels.MatchType, n, v string) *labels.Matcher {
@@ -496,7 +489,7 @@ func (l *LogRangeQueryExpr) String() string {
 		sb.WriteString(") ")
 		sb.WriteString(l.rng)
 	} else {
-		sl := strings.ReplaceAll(l.left.String(), "}", fmt.Sprintf("}%s", l.rng))
+		sl := strings.Replace(l.left.String(), "}", fmt.Sprintf("}%s", l.rng), 1)
 		sb.WriteString(sl)
 	}
 

--- a/logql/v2/ast.go
+++ b/logql/v2/ast.go
@@ -107,9 +107,7 @@ func (l *LogFilterExpr) String() string {
 	if l.filterOp != "" {
 		sb.WriteString(l.filterOp)
 		sb.WriteString("(")
-		sb.WriteString(`"`)
-		sb.WriteString(l.value)
-		sb.WriteString(`"`)
+		sb.WriteString(strconv.Quote(l.value))
 		sb.WriteString(")")
 	} else {
 		sb.WriteString(strconv.Quote(l.value))

--- a/logql/v2/ast.go
+++ b/logql/v2/ast.go
@@ -61,7 +61,8 @@ func (s *StreamMatcherExpr) Walk(fn WalkFn) {
 func (s *StreamMatcherExpr) String() string {
 	var sb strings.Builder
 
-	sb.WriteRune('{')
+	sb.WriteString("{")
+
 	for i, m := range s.matchers {
 		sb.WriteString(m.String())
 
@@ -69,7 +70,8 @@ func (s *StreamMatcherExpr) String() string {
 			sb.WriteString(", ")
 		}
 	}
-	sb.WriteRune('}')
+
+	sb.WriteString("}")
 
 	return sb.String()
 }

--- a/logql/v2/ast.go
+++ b/logql/v2/ast.go
@@ -129,9 +129,7 @@ func (l *LogFilterExpr) String() string {
 		sb.WriteString(`"`)
 		sb.WriteString(")")
 	} else {
-		sb.WriteString(`"`)
-		sb.WriteString(l.value)
-		sb.WriteString(`"`)
+		sb.WriteString(strconv.Quote(l.value))
 	}
 
 	return sb.String()

--- a/logql/v2/ast_test.go
+++ b/logql/v2/ast_test.go
@@ -145,14 +145,14 @@ func Test_AstWalker_AppendORMatcher(t *testing.T) {
 
 	l := []*labels.Matcher{
 		{
-			Type:  labels.MatchEqual,
+			Type:  labels.MatchRegexp,
 			Name:  "second",
-			Value: "next",
+			Value: "foo|bar",
 		},
 		{
-			Type:  labels.MatchEqual,
+			Type:  labels.MatchRegexp,
 			Name:  "third",
-			Value: "next",
+			Value: "foo|bar",
 		},
 	}
 
@@ -169,25 +169,24 @@ func Test_AstWalker_AppendORMatcher(t *testing.T) {
 		// log selector expressions
 		{
 			input:  `{first="value"}`,
-			output: `{first="value"} | second="next" or third="next"`,
+			output: `{first="value"} | second=~"foo|bar" or third=~"foo|bar"`,
 		},
 		{
 			input:  `{first="value"} |= "other" |= ip("8.8.8.8")`,
-			output: `{first="value"} | second="next" or third="next" |= "other" |= ip("8.8.8.8")`,
+			output: `{first="value"} | second=~"foo|bar" or third=~"foo|bar" |= "other" |= ip("8.8.8.8")`,
 		},
 		{
 			input:  `{ first = "value" }|logfmt|addr>=ip("1.1.1.1")`,
-			output: `{first="value"} | second="next" or third="next" | logfmt | addr>=ip("1.1.1.1")`,
+			output: `{first="value"} | second=~"foo|bar" or third=~"foo|bar" | logfmt | addr>=ip("1.1.1.1")`,
 		},
 		// log metric expressions
 		{
-			input: `sum(rate({first="value"}[5m]))`,
-			// Check: is that correct??
-			output: `sum(rate({first="value"}[5m] | second="next" or third="next"))`,
+			input:  `sum(rate({first="value"}[5m]))`,
+			output: `sum(rate({first="value"}[5m] | second=~"foo|bar" or third=~"foo|bar"))`,
 		},
 		{
 			input:  `max without (second) (count_over_time({first="value"}[5h]))`,
-			output: `max without(second) (count_over_time({first="value"}[5h] | second="next" or third="next"))`,
+			output: `max without(second) (count_over_time({first="value"}[5h] | second=~"foo|bar" or third=~"foo|bar"))`,
 		},
 	}
 	for _, tc := range tc {

--- a/logql/v2/ast_test.go
+++ b/logql/v2/ast_test.go
@@ -169,25 +169,25 @@ func Test_AstWalker_AppendORMatcher(t *testing.T) {
 		// log selector expressions
 		{
 			input:  `{first="value"}`,
-			output: `{first="value", second="next"} or {first="value", third="next"}`,
+			output: `{first="value"} | second="next" or third="next"`,
 		},
 		{
 			input:  `{first="value"} |= "other" |= ip("8.8.8.8")`,
-			output: `{first="value", second="next"} or {first="value", third="next"} |= "other" |= ip("8.8.8.8")`,
+			output: `{first="value"} | second="next" or third="next" |= "other" |= ip("8.8.8.8")`,
 		},
 		{
 			input:  `{ first = "value" }|logfmt|addr>=ip("1.1.1.1")`,
-			output: `{first="value", second="next"} or {first="value", third="next"} | logfmt | addr>=ip("1.1.1.1")`,
+			output: `{first="value"} | second="next" or third="next" | logfmt | addr>=ip("1.1.1.1")`,
 		},
 		// log metric expressions
 		{
 			input: `sum(rate({first="value"}[5m]))`,
 			// Check: is that correct??
-			output: `sum(rate({first="value", second="next"}[5m] or {first="value", third="next"}[5m]))`,
+			output: `sum(rate({first="value"}[5m] | second="next" or third="next"))`,
 		},
 		{
 			input:  `max without (second) (count_over_time({first="value"}[5h]))`,
-			output: `max without(second) (count_over_time({first="value", second="next"}[5h] or {first="value", third="next"}[5h]))`,
+			output: `max without(second) (count_over_time({first="value"}[5h] | second="next" or third="next"))`,
 		},
 	}
 	for _, tc := range tc {

--- a/logql/v2/ast_test.go
+++ b/logql/v2/ast_test.go
@@ -199,8 +199,8 @@ func Test_AstWalker_AppendORMatcher(t *testing.T) {
 
 		expr.Walk(func(e interface{}) {
 			switch ex := e.(type) { //nolint:gocritic
-			case *StreamMatcherExpr:
-				ex.AppendORMatchers(l)
+			case *LogQueryExpr:
+				ex.AppendPipelineMatchers(l, "or")
 			}
 		})
 

--- a/logql/v2/expr.y
+++ b/logql/v2/expr.y
@@ -88,9 +88,9 @@ expr:
         ;
 
 logQueryExpr:
-                selector                                         { $$ = newStreamMatcherExpr($1)                      }
-        |       selector logPipelineExpr                         { $$ = newLogQueryExpr(newStreamMatcherExpr($1), $2) }
-        |       OPEN_PARENTHESIS logQueryExpr CLOSE_PARENTHESIS  { $$ = $2                                            }
+                selector                                         { $$ = newLogQueryExpr(newStreamMatcherExpr($1), nil) }
+        |       selector logPipelineExpr                         { $$ = newLogQueryExpr(newStreamMatcherExpr($1), $2)  }
+        |       OPEN_PARENTHESIS logQueryExpr CLOSE_PARENTHESIS  { $$ = $2                                             }
         ;
 
 logPipelineExpr:

--- a/logql/v2/expr.y.go
+++ b/logql/v2/expr.y.go
@@ -833,7 +833,7 @@ exprdefault:
 	case 6:
 		exprDollar = exprS[exprpt-1 : exprpt+1]
 		{
-			exprVAL.LogQueryExpr = newStreamMatcherExpr(exprDollar[1].Selector)
+			exprVAL.LogQueryExpr = newLogQueryExpr(newStreamMatcherExpr(exprDollar[1].Selector), nil)
 		}
 	case 7:
 		exprDollar = exprS[exprpt-2 : exprpt+1]

--- a/logql/v2/parser_test.go
+++ b/logql/v2/parser_test.go
@@ -1430,44 +1430,6 @@ func TestParseExpr(t *testing.T) {
 				},
 			},
 		},
-		// OR Log filters
-		{
-			input: `{first="value"} | label1="foo" or label2="foo"`,
-			expr: &LogQueryExpr{
-				filter: LogPipelineExpr{
-					{
-						expr: &LogParserExpr{
-							parser: "json",
-						},
-					},
-					{
-						stages: LogFiltersExpr{
-							{
-								filter:  "|",
-								alias:   "label1",
-								aliasOp: "=",
-								value:   "foo",
-							},
-							{
-								filter:  "or",
-								alias:   "label2",
-								aliasOp: "=",
-								value:   "foo",
-							},
-						},
-					},
-				},
-				left: &StreamMatcherExpr{
-					matchers: []*labels.Matcher{
-						{
-							Type:  labels.MatchEqual,
-							Name:  "first",
-							Value: "value",
-						},
-					},
-				},
-			},
-		},
 	}
 	for _, tc := range tc { //nolint:paralleltest
 		tc := tc

--- a/logql/v2/parser_test.go
+++ b/logql/v2/parser_test.go
@@ -1430,6 +1430,44 @@ func TestParseExpr(t *testing.T) {
 				},
 			},
 		},
+		// OR Log filters
+		{
+			input: `{first="value"} | label1="foo" or label2="foo"`,
+			expr: &LogQueryExpr{
+				filter: LogPipelineExpr{
+					{
+						expr: &LogParserExpr{
+							parser: "json",
+						},
+					},
+					{
+						stages: LogFiltersExpr{
+							{
+								filter:  "|",
+								alias:   "label1",
+								aliasOp: "=",
+								value:   "foo",
+							},
+							{
+								filter:  "or",
+								alias:   "label2",
+								aliasOp: "=",
+								value:   "foo",
+							},
+						},
+					},
+				},
+				left: &StreamMatcherExpr{
+					matchers: []*labels.Matcher{
+						{
+							Type:  labels.MatchEqual,
+							Name:  "first",
+							Value: "value",
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range tc { //nolint:paralleltest
 		tc := tc

--- a/logql/v2/parser_test.go
+++ b/logql/v2/parser_test.go
@@ -24,7 +24,7 @@ func TestParseExpr(t *testing.T) {
 		// log selector expressions
 		{
 			input: `{first="value"}`,
-			expr: &StreamMatcherExpr{
+			expr: &LogQueryExpr{left: &StreamMatcherExpr{
 				matchers: []*labels.Matcher{
 					{
 						Type:  labels.MatchEqual,
@@ -32,11 +32,11 @@ func TestParseExpr(t *testing.T) {
 						Value: "value",
 					},
 				},
-			},
+			}},
 		},
 		{
 			input: `{first="value", value!="other"}`,
-			expr: &StreamMatcherExpr{
+			expr: &LogQueryExpr{left: &StreamMatcherExpr{
 				matchers: []*labels.Matcher{
 					{
 						Type:  labels.MatchEqual,
@@ -49,7 +49,7 @@ func TestParseExpr(t *testing.T) {
 						Value: "other",
 					},
 				},
-			},
+			}},
 		},
 		// log query expressions with filter
 		{


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/NETOBSERV-171

In short, without this PR, only one matcher injection for multi-tenancy is allowed: e.g. `namespace=foo`
NetObserv is an observability solution dedicated to the network, that stores flow logs in Loki. Implementing multi-tenancy for NetObserv requires injecting more complex matchers for handling flow logs sources and destinations: e.g.
`src-namespace=foo OR dst-namespace=foo` (as a single query injection).

Changes:

- Updated result data from OPA Authz (**OPA breaking change**)
- Query injection needs to handle several matchers, and logical OR
- Fix string escaping issue in Loki reencoder
- Add a few tests
- As an aside, allow building with podman

Related PRs:
- https://github.com/observatorium/opa-openshift/pull/15
- https://github.com/grafana/loki/pull/8192