### PR TITLE
Fix `/api/v1/rules` endpoint to return correct response

### DIFF
--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -294,7 +294,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 		r.Group(func(r chi.Router) {
 			r.Use(c.uiMiddlewares...)
 			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
-			r.Method(http.MethodGet, RulesRoute, otelhttp.WithRouteTag(c.spanRoutePrefix+RulesRawRoute, http.HandlerFunc(rh.get)))
 			r.Method(http.MethodGet, RulesRawRoute, otelhttp.WithRouteTag(c.spanRoutePrefix+RulesRawRoute, http.HandlerFunc(rh.get)))
 		})
 


### PR DESCRIPTION
After #430, a bug was introduced whereby `/api/metrics/v1/<tenant>/api/v1/rules` GET requests were being handled by the rules/raw GET handler instead of the `proxyRead` handler.

This led to /api/v1/rules response being only YAML and without rule health data. On Querier UI this shows up as,
![Screenshot from 2023-01-24 11-38-12](https://user-images.githubusercontent.com/51132453/214223439-ccc2388f-5e00-4690-98e6-5c3ebce8de84.png)

In our e2e tests, we don't start Thanos Ruler and hence don't check this endpoint, will add one in next PRs (as it needs some refactoring).