### PR TITLE
logsv1: Enfore authz matcher on label values

### DIFF
--- a/api/logs/v1/labels_enforcer.go
+++ b/api/logs/v1/labels_enforcer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/observatorium/api/authorization"
 	"github.com/observatorium/api/httperr"
@@ -46,7 +47,7 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 				return
 			}
 
-			q, err := enforceValues(matchersInfo, r.URL.Query())
+			q, err := enforceValues(matchersInfo, r.URL)
 			if err != nil {
 				httperr.PrometheusAPIError(w, fmt.Sprintf("could not enforce authorization label matchers: %v", err), http.StatusInternalServerError)
 
@@ -61,20 +62,52 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 
 const queryParam = "query"
 
-func enforceValues(mInfo AuthzResponseData, v url.Values) (values string, err error) {
+func enforceValues(mInfo AuthzResponseData, u *url.URL) (values string, err error) {
+	switch {
+	case strings.HasSuffix(u.Path, "/values"):
+		return enforceValuesOnLabelValues(mInfo, u.Query())
+	default:
+		return enforceValuesOnQuery(mInfo, u.Query())
+	}
+}
+
+func enforceValuesOnLabelValues(mInfo AuthzResponseData, v url.Values) (values string, err error) {
+	lm, err := initAuthzMatchers(mInfo.Matchers)
+	if err != nil {
+		return "", err
+	}
+
+	var expr logqlv2.Expr = &logqlv2.StreamMatcherExpr{}
+	expr.(*logqlv2.StreamMatcherExpr).SetMatchers(lm)
+
+	if q := v.Get(queryParam); q != "" {
+		expr, err = logqlv2.ParseExpr(q)
+		if err != nil {
+			return "", fmt.Errorf("failed parsing LogQL expression: %w", err)
+		}
+
+		switch le := expr.(type) {
+		case *logqlv2.LogQueryExpr:
+			matchers := combineLabelMatchers(le.Matchers(), lm)
+			le.SetMatchers(matchers)
+		default:
+			// Do nothing
+		}
+	}
+
+	v.Set(queryParam, expr.String())
+
+	return v.Encode(), nil
+}
+
+func enforceValuesOnQuery(mInfo AuthzResponseData, v url.Values) (values string, err error) {
 	if v.Get(queryParam) == "" {
 		return v.Encode(), nil
 	}
 
-	lm := mInfo.Matchers
-	// Fix label matchers to include a non nil FastRegexMatcher for regex types.
-	for i, m := range lm {
-		nm, err := labels.NewMatcher(m.Type, m.Name, m.Value)
-		if err != nil {
-			return "", fmt.Errorf("failed parsing label matcher: %w", err)
-		}
-
-		lm[i] = nm
+	lm, err := initAuthzMatchers(mInfo.Matchers)
+	if err != nil {
+		return "", err
 	}
 
 	expr, err := logqlv2.ParseExpr(v.Get(queryParam))
@@ -130,4 +163,18 @@ func combineLabelMatchers(queryMatchers, authzMatchers []*labels.Matcher) []*lab
 	}
 
 	return matchers
+}
+
+func initAuthzMatchers(lm []*labels.Matcher) ([]*labels.Matcher, error) {
+	// Fix label matchers to include a non nil FastRegexMatcher for regex types.
+	for i, m := range lm {
+		nm, err := labels.NewMatcher(m.Type, m.Name, m.Value)
+		if err != nil {
+			return nil, fmt.Errorf("failed parsing label matcher: %w", err)
+		}
+
+		lm[i] = nm
+	}
+
+	return lm, nil
 }

--- a/api/logs/v1/labels_enforcer_test.go
+++ b/api/logs/v1/labels_enforcer_test.go
@@ -1,6 +1,7 @@
 package http
 
 import (
+	"fmt"
 	"net/url"
 	"sort"
 	"testing"
@@ -11,7 +12,89 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 )
 
-func TestEnforceValues(t *testing.T) {
+func TestEnforceValuesOnLabelValues(t *testing.T) {
+	tt := []struct {
+		desc           string
+		accessMatchers []*labels.Matcher
+		urlValues      url.Values
+		expValues      url.Values
+	}{
+		{
+			desc: "empty url values",
+			accessMatchers: []*labels.Matcher{
+				{
+					Type:  labels.MatchRegexp,
+					Name:  "kubernetes_namespace_name",
+					Value: "log-test-0",
+				},
+			},
+			urlValues: url.Values{},
+			expValues: url.Values{
+				"query": []string{`{kubernetes_namespace_name=~"log-test-0"}`},
+			},
+		},
+
+		{
+			desc: "user defined query",
+			accessMatchers: []*labels.Matcher{
+				{
+					Type:  labels.MatchRegexp,
+					Name:  "kubernetes_namespace_name",
+					Value: "log-test-0",
+				},
+			},
+			urlValues: url.Values{
+				"query": []string{`{foo="bar"}`},
+			},
+			expValues: url.Values{
+				"query": []string{`{foo="bar", kubernetes_namespace_name=~"log-test-0"}`},
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			ou, err := url.Parse(fmt.Sprintf("/loki/api/v1/label/foo/values?%s", tc.urlValues.Encode()))
+			testutil.Ok(t, err)
+
+			v, err := enforceValues(AuthzResponseData{Matchers: tc.accessMatchers}, ou)
+			testutil.Ok(t, err)
+
+			u, err := url.ParseQuery(v)
+			testutil.Ok(t, err)
+
+			expr, err := logqlv2.ParseExpr(u.Get("query"))
+			testutil.Ok(t, err)
+
+			expected, err := logqlv2.ParseExpr(tc.expValues.Get("query"))
+			testutil.Ok(t, err)
+
+			smExpr, ok := expr.(*logqlv2.LogQueryExpr)
+			testutil.Assert(t, ok)
+
+			smExpected, ok := expected.(*logqlv2.LogQueryExpr)
+			testutil.Assert(t, ok)
+
+			m := smExpr.Matchers()
+			mExp := smExpected.Matchers()
+
+			sort.Slice(m, func(i, j int) bool {
+				return m[i].Name < m[j].Name
+			})
+
+			sort.Slice(mExp, func(i, j int) bool {
+				return mExp[i].Name < mExp[j].Name
+			})
+
+			testutil.Equals(t, m, mExp)
+		})
+	}
+}
+
+func TestEnforceValuesOnQuery(t *testing.T) {
 	tt := []struct {
 		desc           string
 		accessMatchers []*labels.Matcher
@@ -85,7 +168,10 @@ func TestEnforceValues(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			t.Parallel()
 
-			v, err := enforceValues(AuthzResponseData{Matchers: tc.accessMatchers}, tc.urlValues)
+			ou, err := url.Parse(fmt.Sprintf("/loki/api/v1/query_range?%s", tc.urlValues.Encode()))
+			testutil.Ok(t, err)
+
+			v, err := enforceValues(AuthzResponseData{Matchers: tc.accessMatchers}, ou)
 			testutil.Ok(t, err)
 
 			if len(tc.urlValues.Encode()) == 0 {

--- a/logql/v2/ast.go
+++ b/logql/v2/ast.go
@@ -493,6 +493,10 @@ func (l *LogQueryExpr) Matchers() []*labels.Matcher {
 	return l.left.matchers
 }
 
+func (l *LogQueryExpr) SetMatchers(lm []*labels.Matcher) {
+	l.left.SetMatchers(lm)
+}
+
 func (l *LogQueryExpr) AppendPipelineMatchers(matchers []*labels.Matcher, chainOp string) {
 	if len(matchers) == 0 {
 		return


### PR DESCRIPTION
**What this PR does / why we need it**:
The current state of the logsv1 API enforces only authorization matchers on instant and range queries. This allows to limit users to search within a tenant by rewriting the LogQL stream selectors with label matchers provided by the authorization process (e.g. limit to accessible kubernetes namespaces). However the users are still able to access all label values within a tenant (e.g. all namespace names) although they have via RBAC access only to a limited set. This issue can be characterized simply as information intrusion w/o breaking the tenancy model per se.

The following PR adds support to apply authorization label matchers to the Loki Label Values API as effective filters. It applies the label matchers to the query parameter provided by:
- https://github.com/grafana/loki/pull/8824

In particular the Loki Labels/Label-Values API works in two ways:
- For queries answered by the ingester (live unflushed data) the active streams are queried in memory for labels keys or label values for a given label key. The additional authorization label matchers are used as a second pass filter to eliminate streams that don't match.
- For queries on historical data the querier will execute queries only on the index files. Authorization label matchers are used in an and expression to k-set operation against each index.

**Special notes for your reviewer**:

Container images for testing:
- Loki: v2.8.0
- Observatorium-API: [quay.io/periklis/observatorium-api:authz-matcher-on-labels-values-2023-03-17-v0.1.2-355-g4151849d](quay.io/periklis/observatorium-api:authz-matcher-on-labels-values-2023-03-17-v0.1.2-355-g4151849d)

cc @xperimental 