### PR TITLE
Split request timeouts per signal handler

### DIFF
--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -19,8 +19,7 @@ import (
 )
 
 const (
-	ReadTimeout  = 15 * time.Minute
-	WriteTimeout = time.Minute
+	dialTimeout = 30 * time.Second // Set as in http.DefaultTransport
 )
 
 const (
@@ -163,7 +162,7 @@ func NewHandler(read, tail, write, rules *url.URL, rulesReadOnly bool, upstreamC
 
 			t := &http.Transport{
 				DialContext: (&net.Dialer{
-					Timeout: ReadTimeout,
+					Timeout: dialTimeout,
 				}).DialContext,
 				TLSClientConfig: tls.NewClientConfig(upstreamCA, upstreamCert),
 			}
@@ -231,7 +230,7 @@ func NewHandler(read, tail, write, rules *url.URL, rulesReadOnly bool, upstreamC
 
 			t := &http.Transport{
 				DialContext: (&net.Dialer{
-					Timeout: ReadTimeout,
+					Timeout: dialTimeout,
 				}).DialContext,
 				TLSClientConfig: tls.NewClientConfig(upstreamCA, upstreamCert),
 			}
@@ -324,7 +323,7 @@ func NewHandler(read, tail, write, rules *url.URL, rulesReadOnly bool, upstreamC
 
 			t := &http.Transport{
 				DialContext: (&net.Dialer{
-					Timeout: ReadTimeout,
+					Timeout: dialTimeout,
 				}).DialContext,
 				TLSClientConfig: tls.NewClientConfig(upstreamCA, upstreamCert),
 			}
@@ -360,7 +359,7 @@ func NewHandler(read, tail, write, rules *url.URL, rulesReadOnly bool, upstreamC
 
 			t := &http.Transport{
 				DialContext: (&net.Dialer{
-					Timeout: WriteTimeout,
+					Timeout: dialTimeout,
 				}).DialContext,
 				TLSClientConfig: tls.NewClientConfig(upstreamCA, upstreamCert),
 			}

--- a/api/metrics/legacy/http.go
+++ b/api/metrics/legacy/http.go
@@ -22,7 +22,7 @@ const (
 	QueryRoute      = "/api/v1/query"
 	QueryRangeRoute = "/api/v1/query_range"
 
-	readTimeout = 15 * time.Minute
+	dialTimeout = 30 * time.Second // Set as in http.DefaultTransport
 )
 
 type handlerConfiguration struct {
@@ -129,7 +129,7 @@ func NewHandler(url *url.URL, upstreamCA []byte, upstreamCert *stdtls.Certificat
 
 		t := &http.Transport{
 			DialContext: (&net.Dialer{
-				Timeout: readTimeout,
+				Timeout: dialTimeout,
 			}).DialContext,
 			TLSClientConfig: tls.NewClientConfig(upstreamCA, upstreamCert),
 		}

--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -21,8 +21,7 @@ import (
 )
 
 const (
-	readTimeout  = 15 * time.Minute
-	writeTimeout = time.Minute
+	dialTimeout = 30 * time.Second // Set as in http.DefaultTransport
 )
 
 const (
@@ -182,7 +181,7 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				Transport: otelhttp.NewTransport(
 					&http.Transport{
 						DialContext: (&net.Dialer{
-							Timeout: readTimeout,
+							Timeout: dialTimeout,
 						}).DialContext,
 					},
 				),
@@ -206,7 +205,7 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 
 			t := &http.Transport{
 				DialContext: (&net.Dialer{
-					Timeout: readTimeout,
+					Timeout: dialTimeout,
 				}).DialContext,
 				TLSClientConfig: tls.NewClientConfig(upstreamCA, upstreamCert),
 			}
@@ -264,7 +263,7 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 
 			t := &http.Transport{
 				DialContext: (&net.Dialer{
-					Timeout: writeTimeout,
+					Timeout: dialTimeout,
 				}).DialContext,
 				TLSClientConfig: tls.NewClientConfig(upstreamCA, upstreamCert),
 			}

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	ReadTimeout = 15 * time.Minute
+	dialTimeout = 30 * time.Second // Set as in http.DefaultTransport
 )
 
 type handlerConfiguration struct {
@@ -135,7 +135,7 @@ func NewV2Handler(read *url.URL, readTemplate string, upstreamCA []byte, upstrea
 
 		t := &http.Transport{
 			DialContext: (&net.Dialer{
-				Timeout: ReadTimeout,
+				Timeout: dialTimeout,
 			}).DialContext,
 			TLSClientConfig: tls.NewClientConfig(upstreamCA, upstreamCert),
 		}


### PR DESCRIPTION
### Problem statement
Previously the per signal handlers used arbitrary chosen timeout values to express how long a proxied request to the corresponding upstream should take. However due to conceptual misunderstandings (e.g. request read timeout set as dialer timeout) or global middleware configuration (e.g. `middleware.Timeout(2 * time.Minute)`) the effective timeout was set to **2 Minutes** (configured in the `http.Server.WriteTimeout`). 

In general the current behavior treats all signal handlers equally and in turn unfairly. For example range queries to Loki can in general take longer than those to Thanos, because processing logs (e.g. parsing, filtering, aggregating) might take longer. I

### Proposed solution
The following implementation splits the timeouts per signal handler group (logs, metrics, traces) and keeps for sanity some global server timeouts to prevent misuse by faulty HTTP clients. I.e.:
1. The global HTTP header timeout is set to `1 second`
2. The global HTTP request read timeout (incl. processing the HTTP request body) is set to `5 seconds`
3. The global HTTP request write timeout (incl. writing the HTTP response body) is set to `12 minutes` as per slowest signal handler is the range query handler for Loki (See below)

For each signal group a request context timeout is set and passed to the upstream HTTP client as below:
1. **Metrics**: `2 minutes` (Note: Keeping the old value and leaving this for further investigation by the metrics API maintainers cc @douglascamata @PhilipGough @saswatamcode)
2. **Logs**: `10 minutes`
3. **Traces**: `2 minutes` (Note: Keeping the old value and leaving this for further investigation by the traces API maintainers cc @pavolloffay) 

#### Further notes
The previously called `readTimeout` in each handler implementation used as Dialer Timeout is renamed as `dialTimeout` and set to `30 seconds` for every signal group (logs, metrics, traces). This value seems good enough as it is usually set when using the `http.DefaultTransport` used by `http.DefaultClient` for terminating TCP connects.

### Open Questions

- [ ]  Should we enable users to configure the timeouts per CLI arguments? (AFAICS this was previously possible but got removed)
- [ ] Do we have enough logging in place for request context timeouts? This needs further investigation to improve debugging slow queries.