### PR TITLE
Update modfile to use go1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/observatorium/api
 
-go 1.18
+go 1.20
 
 require (
 	github.com/brancz/kube-rbac-proxy v0.14.1


### PR DESCRIPTION
With this [PR](https://github.com/observatorium/api/pull/498), the project now requires that the minimum go version be 1.20 in order to build.

```
# k8s.io/apiserver/pkg/authentication/token/cache
../deps/gomod/pkg/mod/k8s.io/apiserver@v0.27.1/pkg/authentication/token/cache/cached_token_authenticator.go:286:29: undefined: unsafe.StringData
../deps/gomod/pkg/mod/k8s.io/apiserver@v0.27.1/pkg/authentication/token/cache/cached_token_authenticator.go:297:16: undefined: unsafe.String
../deps/gomod/pkg/mod/k8s.io/apiserver@v0.27.1/pkg/authentication/token/cache/cached_token_authenticator.go:297:30: undefined: unsafe.SliceData
note: module requires Go 1.20
```

cc: @periklis @xperimental 