### PR TITLE
Add support for Grafana Loki Ruler discovery when enforcing tenants

### DIFF
--- a/api/logs/v1/rules.go
+++ b/api/logs/v1/rules.go
@@ -30,7 +30,15 @@ func WithEnforceTenantAsRuleNamespace() func(http.Handler) http.Handler {
 				return
 			}
 
+			// Exclude ruler discovery calls from Grafana:
+			// See: https://github.com/grafana/grafana/blob/842ce144292bdf6b51ba2e13961c0986969005e4/public/app/features/alerting/unified/api/ruler.ts#L93-L100
+			group := chi.URLParam(r, "groupName")
 			namespace := chi.URLParam(r, "namespace")
+			if namespace == "test" && group == "test" {
+				httperr.PrometheusAPIError(w, "page not found", http.StatusNotFound)
+				return
+			}
+
 			if namespace != "" && tenant != namespace {
 				httperr.PrometheusAPIError(w, "error tenant not matching namespace", http.StatusBadRequest)
 				return


### PR DESCRIPTION
The Unified Alerting UI on Grafana is using extensively blackbox probing to discover ruler support across supported datasources, especially the ones that implement the Prometheus Rules API. In #388 we introduced the capability to enforce that the rules namespace is always the same as the tenant. This applies in managed use cases like the Loki Operator where we control in predefined tenant modes (i.e. `openshift-logging`, `openshift-network`) the amount and naming of tenants. For example in `openshift-logging` we have predefined tenants `application`, `infrastructure` and `audit` which map one to one to the allowed rules namespaces.

_Reminder_: Namespaces in Loki Ruler represent simply filesystem directory when local storage is used, e.g. when mounting the rules through a Kubernetes ConfigMap into the Ruler container filesystem.