### PR TITLE
Add namespace label filter when fetching alerting rules

### DIFF
--- a/api/logs/v1/labels_enforcer.go
+++ b/api/logs/v1/labels_enforcer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/observatorium/api/authorization"
 	"github.com/observatorium/api/httperr"
@@ -130,4 +131,61 @@ func combineLabelMatchers(queryMatchers, authzMatchers []*labels.Matcher) []*lab
 	}
 
 	return matchers
+}
+
+func WithEnforceRulesNamespaceLabel() func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			data, ok := authorization.GetData(r.Context())
+			if !ok {
+				httperr.PrometheusAPIError(w, "error finding authorization label matcher", http.StatusInternalServerError)
+
+				return
+			}
+
+			// Early pass to the next if no authz
+			// label enforcement configured.
+			if data == "" {
+				next.ServeHTTP(w, r)
+
+				return
+			}
+
+			var matchersInfo AuthzResponseData
+			if err := json.Unmarshal([]byte(data), &matchersInfo); err != nil {
+				httperr.PrometheusAPIError(w, "error parsing authorization label matchers", http.StatusInternalServerError)
+
+				return
+			}
+
+			r.URL.RawQuery = enforceNamespaceLabels(matchersInfo.Matchers, r.URL.Query())
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+const (
+	labelsParam      = "labels"
+	matcherNamespace = "kubernetes_namespace_name"
+	namespace        = "namespace"
+)
+
+func enforceNamespaceLabels(matchers []*labels.Matcher, v url.Values) string {
+	ls := make([]string, 0)
+	for _, m := range matchers {
+		// OPA returns a "|" delimited list of namespaces.
+		if m != nil && m.Name == matcherNamespace && (m.Type == labels.MatchEqual || m.Type == labels.MatchRegexp) {
+			ns := strings.Split(m.Value, "|")
+			for _, n := range ns {
+				ls = append(ls, fmt.Sprintf("%s:%s", namespace, n))
+			}
+		}
+	}
+
+	if len(ls) > 0 {
+		v.Set(labelsParam, strings.Join(ls, ","))
+	}
+
+	return v.Encode()
 }

--- a/api/logs/v1/labels_enforcer_test.go
+++ b/api/logs/v1/labels_enforcer_test.go
@@ -124,3 +124,80 @@ func TestEnforceValues(t *testing.T) {
 		})
 	}
 }
+
+func TestEnforceNamespaceLabels(t *testing.T) {
+	tt := []struct {
+		desc            string
+		accessMatchers  []*labels.Matcher
+		namespaceLabels string
+	}{
+		{
+			desc:            "empty access matchers values",
+			accessMatchers:  []*labels.Matcher{},
+			namespaceLabels: "",
+		},
+		{
+			desc: "query with no namespace matcher",
+			accessMatchers: []*labels.Matcher{
+				{
+					Type:  labels.MatchEqual,
+					Name:  "kubernetes_pod_name",
+					Value: "pod-name-.*",
+				},
+			},
+			namespaceLabels: "",
+		},
+		{
+			desc: "query with no equals matchers",
+			accessMatchers: []*labels.Matcher{
+				{
+					Type:  labels.MatchNotRegexp,
+					Name:  "kubernetes_namespace_name",
+					Value: "ns-name",
+				},
+				{
+					Type:  labels.MatchNotEqual,
+					Name:  "kubernetes_namespace_name",
+					Value: "another-ns-name",
+				},
+			},
+			namespaceLabels: "",
+		},
+		{
+			desc: "query with namespace matchers",
+			accessMatchers: []*labels.Matcher{
+				{
+					Type:  labels.MatchEqual,
+					Name:  "kubernetes_namespace_name",
+					Value: "ns-name",
+				},
+				{
+					Type:  labels.MatchRegexp,
+					Name:  "kubernetes_namespace_name",
+					Value: "another-ns-name|last-ns-name",
+				},
+			},
+			namespaceLabels: "labels=namespace:ns-name,namespace:another-ns-name,namespace:last-ns-name",
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			v := enforceNamespaceLabels(tc.accessMatchers, url.Values{})
+
+			if len(tc.accessMatchers) == 0 {
+				// No Access matchers, non need to do more checks.
+				testutil.Equals(t, len(v), 0)
+				return
+			}
+
+			ac, err := url.QueryUnescape(v)
+
+			testutil.Ok(t, err)
+			testutil.Equals(t, tc.namespaceLabels, ac)
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -684,6 +684,7 @@ func main() {
 								logsv1.WithReadMiddleware(logsv1.WithEnforceAuthorizationLabels()),
 								logsv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "logs")),
 								logsv1.WithRulesReadMiddleware(logsv1.WithEnforceTenantAsRuleNamespace()),
+								logsv1.WithRulesReadMiddleware(logsv1.WithEnforceRulesNamespaceLabel()),
 								logsv1.WithRulesWriteMiddleware(logsv1.WithEnforceTenantAsRuleNamespace()),
 								logsv1.WithRulesWriteMiddleware(logsv1.WithEnforceRuleLabels(cfg.logs.tenantLabel)),
 							),


### PR DESCRIPTION
This PR adds a middleware function that adds `namespace` label filter when querying alerting rules. This filter contains the list of namespaces that the user has access to, thus returning only the rules that are in those namespaces.

This PR depends on [grafana/loki/pull/9128](https://github.com/grafana/loki/pull/9128)