### PR TITLE
NETOBSERV-1020 Fix empty namespace list

### DIFF
--- a/api/logs/v1/labels_enforcer.go
+++ b/api/logs/v1/labels_enforcer.go
@@ -46,6 +46,12 @@ func WithEnforceAuthorizationLabels() func(http.Handler) http.Handler {
 				return
 			}
 
+			if len(matchersInfo.Matchers) == 0 {
+				httperr.PrometheusAPIError(w, "empty authorization label matchers", http.StatusInternalServerError)
+
+				return
+			}
+
 			q, err := enforceValues(matchersInfo, r.URL.Query())
 			if err != nil {
 				httperr.PrometheusAPIError(w, fmt.Sprintf("could not enforce authorization label matchers: %v", err), http.StatusInternalServerError)


### PR DESCRIPTION
cf https://github.com/observatorium/opa-openshift/pull/18

We need to prevent attempts to run queries when the matchers list exists but is empty, which corresponds to having 0 allowed namespaces