### PR TITLE
logs: Per tenant label-based rule filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Usage of ./observatorium-api:
     	The endpoint against which to make read requests for logs.
   -logs.rules.endpoint string
     	The endpoint against which to make rules requests for logs.
+  -logs.rules.label-filters string
+    	Allow the following filters to be applied to user rules queries per tenant (e.g. tenantA:namespace,severity;tenantB:severity).
   -logs.rules.read-only
     	Allow only read-only rule requests for logs.
   -logs.rules.tenant-label string

--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -92,7 +92,7 @@ func WithSpanRoutePrefix(spanRoutePrefix string) HandlerOption {
 	}
 }
 
-// WithSpanRoutePrefix adds a prefix before the value of route tag in tracing spans.
+// WithRulesLabelFilters adds the slice of rule labels filters to the handler configuration.
 func WithRulesLabelFilters(f map[string][]string) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.rulesLabelFilters = f

--- a/api/logs/v1/rules_labels_enforcer.go
+++ b/api/logs/v1/rules_labels_enforcer.go
@@ -1,0 +1,293 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/ghodss/yaml"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/observatorium/api/authentication"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+const (
+	contentTypeApplicationJSON = "application/json"
+	contentTypeApplicationYAML = "application/yaml"
+)
+
+var (
+	errUnknownTenantKey        = errors.New("Uknown tenant key")
+	errUnknownRulesContentType = errors.New("Unknown rules response content type")
+)
+
+type alert struct {
+	Labels      labels.Labels `json:"labels"`
+	Annotations labels.Labels `json:"annotations"`
+	State       string        `json:"state"`
+	ActiveAt    *time.Time    `json:"activeAt,omitempty"`
+	Value       string        `json:"value"`
+}
+
+type alertingRule struct {
+	Name        string        `json:"name"`
+	Query       string        `json:"query"`
+	Duration    float64       `json:"duration"`
+	Labels      labels.Labels `json:"labels"`
+	Annotations labels.Labels `json:"annotations"`
+	Alerts      []*alert      `json:"alerts"`
+	Health      string        `json:"health"`
+	LastError   string        `json:"lastError,omitempty"`
+	// Type of an alertingRule is always "alerting".
+	Type string `json:"type"`
+}
+
+type recordingRule struct {
+	Name      string        `json:"name"`
+	Query     string        `json:"query"`
+	Labels    labels.Labels `json:"labels,omitempty"`
+	Health    string        `json:"health"`
+	LastError string        `json:"lastError,omitempty"`
+	// Type of a recordingRule is always "recording".
+	Type string `json:"type"`
+}
+
+type ruleGroup struct {
+	Name     string  `json:"name"`
+	File     string  `json:"file"`
+	Rules    []rule  `json:"rules"`
+	Interval float64 `json:"interval"`
+}
+
+type rule struct {
+	*alertingRule
+	*recordingRule
+}
+
+func (r *rule) Labels() labels.Labels {
+	if r.alertingRule != nil {
+		return r.alertingRule.Labels
+	}
+	return r.recordingRule.Labels
+}
+
+// MarshalJSON implements the json.Marshaler interface for rule.
+func (r *rule) MarshalJSON() ([]byte, error) {
+	if r.alertingRule != nil {
+		return json.Marshal(r.alertingRule)
+	}
+	return json.Marshal(r.recordingRule)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for rule.
+func (r *rule) UnmarshalJSON(b []byte) error {
+	var ruleType struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(b, &ruleType); err != nil {
+		return err
+	}
+	switch ruleType.Type {
+	case "alerting":
+		var alertingr alertingRule
+		if err := json.Unmarshal(b, &alertingr); err != nil {
+			return err
+		}
+		r.alertingRule = &alertingr
+	case "recording":
+		var recordingr recordingRule
+		if err := json.Unmarshal(b, &recordingr); err != nil {
+			return err
+		}
+		r.recordingRule = &recordingr
+	default:
+		return fmt.Errorf("failed to unmarshal rule: unknown type %q", ruleType.Type)
+	}
+
+	return nil
+}
+
+type rulesData struct {
+	RuleGroups []*ruleGroup `json:"groups"`
+}
+
+type prometheusRulesResponse struct {
+	Status    string    `json:"status"`
+	Data      rulesData `json:"data"`
+	Error     string    `json:"error"`
+	ErrorType string    `json:"errorType"`
+}
+
+type lokiRule struct {
+	Alert       string            `json:"alert,omitempty"`
+	Record      string            `json:"record,omitempty"`
+	Expr        string            `json:"expr,omitempty"`
+	For         string            `json:"for,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+	Labels      map[string]string `json:"labels,omitempty"`
+}
+
+type lokiRuleGroup struct {
+	Name     string     `json:"name"`
+	Interval string     `json:"interval,omitempty"`
+	Limit    int        `json:"limit,omitempty"`
+	Rules    []lokiRule `json:"rules"`
+}
+
+type lokiRulesResponse = map[string][]lokiRuleGroup
+
+func newModifyResponse(logger log.Logger, labelKeys map[string][]string) func(*http.Response) error {
+	return func(res *http.Response) error {
+		tenant, ok := authentication.GetTenant(res.Request.Context())
+		if !ok {
+			return errUnknownTenantKey
+		}
+
+		keys, ok := labelKeys[tenant]
+		if !ok {
+			level.Debug(logger).Log("msg", "Skip applying rule label filters", "tenant", tenant)
+			return nil
+		}
+
+		var (
+			matchers    = extractMatchers(res.Request, keys)
+			contentType = res.Header.Get("Content-Type")
+		)
+
+		matcherStr := fmt.Sprintf("%s", matchers)
+		level.Debug(logger).Log("msg", "filtering using matchers", "tenant", tenant, "matchers", matcherStr)
+
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			level.Error(logger).Log("msg", err)
+			return err
+		}
+		res.Body.Close()
+
+		b, err := filterRules(body, contentType, matchers)
+		if err != nil {
+			level.Error(logger).Log("msg", err)
+			return err
+		}
+
+		res.Body = io.NopCloser(bytes.NewReader(b))
+		res.ContentLength = int64(len(b))
+
+		return nil
+	}
+}
+
+func extractMatchers(r *http.Request, l []string) map[string]string {
+	queryParams := r.URL.Query()
+	matchers := map[string]string{}
+	for _, name := range l {
+		value := queryParams.Get(name)
+		if value != "" {
+			matchers[name] = value
+		}
+	}
+
+	return matchers
+}
+
+func filterRules(body []byte, contentType string, matchers map[string]string) ([]byte, error) {
+	switch contentType {
+	case contentTypeApplicationJSON:
+		var res prometheusRulesResponse
+		err := json.Unmarshal(body, &res)
+		if err != nil {
+			return nil, err
+		}
+
+		return json.Marshal(filterPrometheusRules(res, matchers))
+
+	case contentTypeApplicationYAML:
+		var res lokiRulesResponse
+		if err := yaml.Unmarshal(body, &res); err != nil {
+			return nil, err
+		}
+
+		return yaml.Marshal(filterLokiRules(res, matchers))
+
+	default:
+		return nil, errUnknownRulesContentType
+	}
+}
+
+func filterPrometheusRules(res prometheusRulesResponse, matchers map[string]string) prometheusRulesResponse {
+	if len(matchers) == 0 {
+		res.Data = rulesData{}
+		return res
+	}
+
+	var filtered []*ruleGroup
+
+	for _, rg := range res.Data.RuleGroups {
+		var filteredRules []rule
+
+	rules:
+		for _, rule := range rg.Rules {
+			for key, value := range matchers {
+				ls := rule.Labels()
+				if !ls.Has(key) || ls.Get(key) != value {
+					continue rules
+				}
+			}
+
+			filteredRules = append(filteredRules, rule)
+		}
+
+		if len(filteredRules) > 0 {
+			rg.Rules = filteredRules
+			filtered = append(filtered, rg)
+		}
+	}
+
+	res.Data = rulesData{RuleGroups: filtered}
+
+	return res
+}
+
+func filterLokiRules(res lokiRulesResponse, matchers map[string]string) lokiRulesResponse {
+	if len(matchers) == 0 {
+		return nil
+	}
+
+	filtered := lokiRulesResponse{}
+
+	for name, groups := range res {
+		var filteredGroups []lokiRuleGroup
+
+		for _, group := range groups {
+			var filteredRules []lokiRule
+
+		rules:
+			for _, rule := range group.Rules {
+				for key, value := range matchers {
+					val, ok := rule.Labels[key]
+					if !ok || val != value {
+						continue rules
+					}
+				}
+
+				filteredRules = append(filteredRules, rule)
+			}
+
+			if len(filteredRules) > 0 {
+				group.Rules = filteredRules
+				filteredGroups = append(filteredGroups, group)
+			}
+		}
+
+		if len(filteredGroups) > 0 {
+			filtered[name] = filteredGroups
+		}
+	}
+
+	return filtered
+}

--- a/api/logs/v1/rules_labels_enforcer.go
+++ b/api/logs/v1/rules_labels_enforcer.go
@@ -24,7 +24,7 @@ const (
 )
 
 var (
-	errUnknownTenantKey        = errors.New("Uknown tenant key")
+	errUnknownTenantKey        = errors.New("Unknown tenant key")
 	errUnknownRulesContentType = errors.New("Unknown rules response content type")
 )
 

--- a/api/logs/v1/rules_labels_enforcer.go
+++ b/api/logs/v1/rules_labels_enforcer.go
@@ -13,6 +13,8 @@ import (
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
 	"github.com/observatorium/api/authentication"
+	"github.com/observatorium/api/authorization"
+	"github.com/observatorium/api/httperr"
 	"github.com/prometheus/prometheus/model/labels"
 )
 
@@ -141,6 +143,83 @@ type lokiRuleGroup struct {
 }
 
 type lokiRulesResponse = map[string][]lokiRuleGroup
+
+func WithEnforceRulesLabelFilters(labelKeys map[string][]string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			tenant, ok := authentication.GetTenant(r.Context())
+			if !ok {
+				httperr.PrometheusAPIError(w, "missing tenant id", http.StatusBadRequest)
+
+				return
+			}
+
+			keys, ok := labelKeys[tenant]
+			if !ok || len(keys) == 0 {
+				next.ServeHTTP(w, r)
+
+				return
+			}
+
+			// Check that the user provides each label filter as a non-empty URL parameter
+			queryParams := r.URL.Query()
+			for _, key := range keys {
+				if !queryParams.Has(key) {
+					msg := fmt.Sprintf("missing URL parameter %s", key)
+					httperr.PrometheusAPIError(w, msg, http.StatusBadRequest)
+
+					return
+				}
+			}
+
+			data, ok := authorization.GetData(r.Context())
+			if !ok {
+				httperr.PrometheusAPIError(w, "error finding authorization label matcher", http.StatusInternalServerError)
+
+				return
+			}
+
+			// Early pass to the next if no authz label enforcement configured.
+			if data == "" {
+				next.ServeHTTP(w, r)
+
+				return
+			}
+
+			var matchersInfo AuthzResponseData
+			if err := json.Unmarshal([]byte(data), &matchersInfo); err != nil {
+				httperr.PrometheusAPIError(w, "error parsing authorization label matchers", http.StatusInternalServerError)
+
+				return
+			}
+
+			// If the authorization endpoint provides any matchers, ensure that the URL parameter value
+			// matches an authorization matcher with the same URL parameter key.
+			for _, key := range keys {
+				var (
+					val     = queryParams.Get(key)
+					matched = false
+				)
+
+				for _, matcher := range matchersInfo.Matchers {
+					if matcher.Name == key && matcher.Matches(val) {
+						matched = true
+						break
+					}
+				}
+
+				if !matched {
+					msg := fmt.Sprintf("unauthorized access for URL parameter %q and value %q", key, val)
+					httperr.PrometheusAPIError(w, msg, http.StatusUnauthorized)
+
+					return
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
 
 func newModifyResponse(logger log.Logger, labelKeys map[string][]string) func(*http.Response) error {
 	return func(res *http.Response) error {

--- a/api/logs/v1/rules_labels_enforcer_test.go
+++ b/api/logs/v1/rules_labels_enforcer_test.go
@@ -34,7 +34,7 @@ func TestFilterRules_WithPrometheusAPIRulesResponseBody(t *testing.T) {
 
 	for _, group := range got.Data.RuleGroups {
 		for _, rule := range group.Rules {
-			if val := rule.Labels().Get("namespace"); val != "log-test-0" {
+			if val := rule.GetLabels().Get("namespace"); val != "log-test-0" {
 				t.Errorf("invalid rule for label: %s and value: %s", "namespace", val)
 			}
 		}

--- a/api/logs/v1/rules_labels_enforcer_test.go
+++ b/api/logs/v1/rules_labels_enforcer_test.go
@@ -1,0 +1,366 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/ghodss/yaml"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestFilterRules_WithPrometheusAPIResponseBody(t *testing.T) {
+	contentType := "application/json"
+
+	body, err := os.ReadFile("testdata/rules.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matchers := map[string]string{
+		"namespace": "log-test-0",
+	}
+
+	b, err := filterRules(body, contentType, matchers)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got prometheusRulesResponse
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, group := range got.Data.RuleGroups {
+		for _, rule := range group.Rules {
+			if val := rule.Labels().Get("namespace"); val != "log-test-0" {
+				t.Errorf("invalid rule for label: %s and value: %s", "namespace", val)
+			}
+		}
+	}
+}
+
+func TestFilterRules_WithPrometheusAPIResponseBody_ReturnNothingOnParseError(t *testing.T) {
+	contentType := "application/json"
+	body := []byte(`{`)
+	matchers := map[string]string{
+		"key": "value",
+	}
+
+	b, err := filterRules(body, contentType, matchers)
+	if err == nil {
+		t.Error("missing parse error")
+	}
+
+	if b != nil {
+		t.Errorf("want nil, got: %s", b)
+	}
+}
+
+func TestFilterRules_WithLokiAPIResponseBody(t *testing.T) {
+	contentType := "application/yaml"
+
+	body, err := os.ReadFile("testdata/rules.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matchers := map[string]string{
+		"namespace": "log-test-0",
+	}
+
+	b, err := filterRules(body, contentType, matchers)
+	if err != nil {
+		t.Error(err)
+	}
+
+	var got lokiRulesResponse
+	if err := yaml.Unmarshal(b, &got); err != nil {
+		t.Error(err)
+	}
+
+	for _, groups := range got {
+		for _, group := range groups {
+			for _, rule := range group.Rules {
+				if val := rule.Labels["namespace"]; val != "log-test-0" {
+					t.Errorf("invalid rule for label: %s and value: %s", "namespace", val)
+				}
+			}
+		}
+	}
+}
+
+func TestFilterRules_WithokiAPIResponseBody_ReturnNothingOnParseError(t *testing.T) {
+	contentType := "application/yaml"
+	body := []byte(`invalid`)
+	matchers := map[string]string{
+		"key": "value",
+	}
+
+	b, err := filterRules(body, contentType, matchers)
+	if err == nil {
+		t.Error("missing parse error")
+	}
+
+	if b != nil {
+		t.Errorf("want nil, got: %s", b)
+	}
+}
+
+func TestFilterRules_WithUnknownContentType_ReturnsError(t *testing.T) {
+	contentType := "invalid/content"
+
+	var (
+		body     []byte
+		matchers map[string]string
+	)
+
+	b, err := filterRules(body, contentType, matchers)
+	if !errors.Is(err, errUnknownRulesContentType) {
+		t.Errorf("want %s, got: %s", errUnknownRulesContentType, err)
+	}
+
+	if b != nil {
+		t.Errorf("want nil, got: %s", b)
+	}
+}
+
+func TestFilterPrometheusRules(t *testing.T) {
+	tt := []struct {
+		desc     string
+		matchers map[string]string
+		res      prometheusRulesResponse
+		want     prometheusRulesResponse
+	}{
+		{
+			desc: "without matchers",
+			res: prometheusRulesResponse{
+				Data: rulesData{
+					RuleGroups: []*ruleGroup{
+						{Name: "group-a"},
+					},
+				},
+			},
+			want: prometheusRulesResponse{},
+		},
+		{
+			desc:     "only matching",
+			matchers: map[string]string{"label": "value"},
+			res: prometheusRulesResponse{
+				Data: rulesData{
+					RuleGroups: []*ruleGroup{
+						{
+							Name: "group-a",
+							Rules: []rule{
+								{
+									alertingRule: &alertingRule{
+										Labels: labels.FromMap(map[string]string{"label": "value"}),
+									},
+								},
+								{
+									alertingRule: &alertingRule{
+										Labels: labels.FromMap(map[string]string{"other": "not"}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: prometheusRulesResponse{
+				Data: rulesData{
+					RuleGroups: []*ruleGroup{
+						{
+							Name: "group-a",
+							Rules: []rule{
+								{
+									alertingRule: &alertingRule{
+										Labels: labels.FromMap(map[string]string{"label": "value"}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:     "nothing matching",
+			matchers: map[string]string{"label": "value"},
+			res: prometheusRulesResponse{
+				Data: rulesData{
+					RuleGroups: []*ruleGroup{
+						{
+							Name: "group-a",
+							Rules: []rule{
+								{
+									alertingRule: &alertingRule{
+										Labels: labels.FromMap(map[string]string{"not": "other"}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: prometheusRulesResponse{},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := filterPrometheusRules(tc.res, tc.matchers)
+
+			wantJSON, err := json.MarshalIndent(tc.want, "", "  ")
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			gotJSON, err := json.MarshalIndent(got, "", "  ")
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			if string(wantJSON) != string(gotJSON) {
+				t.Errorf("\nwant: %s\ngot: %s", wantJSON, gotJSON)
+			}
+		})
+	}
+}
+
+func TestFilterLokiRules(t *testing.T) {
+	tt := []struct {
+		desc     string
+		matchers map[string]string
+		res      lokiRulesResponse
+		want     lokiRulesResponse
+	}{
+		{
+			desc: "without matchers",
+			res: lokiRulesResponse{
+				"ns-1": []lokiRuleGroup{
+					{Name: "group-a"},
+				},
+				"ns-2": []lokiRuleGroup{
+					{Name: "group-b"},
+				},
+			},
+		},
+		{
+			desc:     "only matching",
+			matchers: map[string]string{"label": "value"},
+			res: lokiRulesResponse{
+				"ns-1": []lokiRuleGroup{
+					{
+						Name: "group-a",
+						Rules: []lokiRule{
+							{
+								Alert:  "group-a-alert-1",
+								Labels: map[string]string{"label": "value"},
+							},
+							{
+								Alert:  "group-a-alert-2",
+								Labels: map[string]string{"other": "not"},
+							},
+						},
+					},
+				},
+				"ns-2": []lokiRuleGroup{
+					{
+						Name: "group-b",
+						Rules: []lokiRule{
+							{
+								Alert:  "group-b-alert-1",
+								Labels: map[string]string{"label": "value"},
+							},
+							{
+								Alert:  "group-b-alert-2",
+								Labels: map[string]string{"other": "not"},
+							},
+						},
+					},
+				},
+			},
+			want: lokiRulesResponse{
+				"ns-1": []lokiRuleGroup{
+					{
+						Name: "group-a",
+						Rules: []lokiRule{
+							{
+								Alert:  "group-a-alert-1",
+								Labels: map[string]string{"label": "value"},
+							},
+						},
+					},
+				},
+				"ns-2": []lokiRuleGroup{
+					{
+						Name: "group-b",
+						Rules: []lokiRule{
+							{
+								Alert:  "group-b-alert-1",
+								Labels: map[string]string{"label": "value"},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:     "nothing matching",
+			matchers: map[string]string{"label": "value"},
+			res: lokiRulesResponse{
+				"ns-1": []lokiRuleGroup{
+					{
+						Name: "group-a",
+						Rules: []lokiRule{
+							{
+								Alert:  "group-a-alert",
+								Labels: map[string]string{"other": "not"},
+							},
+						},
+					},
+				},
+				"ns-2": []lokiRuleGroup{
+					{
+						Name: "group-b",
+						Rules: []lokiRule{
+							{
+								Alert:  "group-b-alert",
+								Labels: map[string]string{"other": "not"},
+							},
+						},
+					},
+				},
+			},
+			want: lokiRulesResponse{},
+		},
+	}
+
+	for _, tc := range tt {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := filterLokiRules(tc.res, tc.matchers)
+
+			wantJSON, err := json.MarshalIndent(tc.want, "", "  ")
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			gotJSON, err := json.MarshalIndent(got, "", "  ")
+			if err != nil {
+				t.Errorf(err.Error())
+			}
+
+			if string(wantJSON) != string(gotJSON) {
+				t.Errorf("\nwant: %s\ngot: %s", wantJSON, gotJSON)
+			}
+		})
+	}
+}

--- a/api/logs/v1/testdata/alerts.json
+++ b/api/logs/v1/testdata/alerts.json
@@ -1,0 +1,54 @@
+{
+  "status": "success",
+  "data": {
+    "alerts": [
+      {
+        "labels": {
+          "alertname": "HighPercentageErrorAAA",
+          "namespace": "log-test-0",
+          "severity": "critical",
+          "tenantId": "application"
+        },
+        "annotations": {
+          "description": "High Log Test Errors",
+          "summary": "High Log Test Errors"
+        },
+        "state": "pending",
+        "activeAt": "2023-06-01T15:19:21.177797693Z",
+        "value": "3.898305084745763e-01"
+      },
+      {
+        "labels": {
+          "alertname": "HighPercentageError",
+          "namespace": "log-test-0",
+          "severity": "critical",
+          "tenantId": "application"
+        },
+        "annotations": {
+          "description": "High Log Test Errors",
+          "summary": "High Log Test Errors"
+        },
+        "state": "firing",
+        "activeAt": "2023-06-01T15:18:49.705316346Z",
+        "value": "4.203389830508475e-01"
+      },
+      {
+        "labels": {
+          "alertname": "HighPercentageError",
+          "namespace": "log-test-1",
+          "severity": "critical",
+          "tenantId": "application"
+        },
+        "annotations": {
+          "description": "High Log Test Errors",
+          "summary": "High Log Test Errors"
+        },
+        "state": "firing",
+        "activeAt": "2023-06-01T15:18:36.80636328Z",
+        "value": "4.3050847457627117e-01"
+      }
+    ]
+  },
+  "errorType": "",
+  "error": ""
+}

--- a/api/logs/v1/testdata/rules.json
+++ b/api/logs/v1/testdata/rules.json
@@ -1,0 +1,121 @@
+{
+    "status": "success",
+    "data": {
+        "groups": [
+            {
+                "name": "LogTestErrors10m",
+                "file": "log-test-0-log-test-0-717f2906-d28f-4175-9597-f3a40ed64936.yaml",
+                "rules": [
+                    {
+                        "name": "application:logtest0:errors:rate10m",
+                        "query": "sum(rate({kubernetes_namespace_name=\"log-test-0\", kubernetes_pod_name=~\"logger.*\"} |= \"error\"[10m]))",
+                        "labels": {
+                        },
+                        "health": "ok",
+                        "lastError": "",
+                        "type": "recording",
+                        "lastEvaluation": "2023-05-31T16:02:33.697904344Z",
+                        "evaluationTime": 0.002222441
+                    },
+                    {
+                        "name": "application:logtest1:errors:rate10m",
+                        "query": "sum(rate({kubernetes_namespace_name=\"log-test-1\", kubernetes_pod_name=~\"logger.*\"} |= \"error\"[10m]))",
+                        "labels": {
+                        },
+                        "health": "unknown",
+                        "lastError": "",
+                        "type": "recording",
+                        "lastEvaluation": "0001-01-01T00:00:00Z",
+                        "evaluationTime": 0
+                    }
+                ],
+                "interval": 600,
+                "lastEvaluation": "2023-05-31T16:02:33.697883585Z",
+                "evaluationTime": 0.002247922
+            },
+            {
+                "name": "LogTestAAA",
+                "file": "log-test-0-log-test-0-8221e8bb-4cab-4f21-adad-1d197aaf0dee.yaml",
+                "rules": [
+                    {
+                        "state": "inactive",
+                        "name": "HighPercentageErrorAAA",
+                        "query": "((sum(rate({kubernetes_namespace_name=\"log-test-0\", kubernetes_pod_name=~\"logger.*\"} |= \"error\"[1m])) / sum(rate({kubernetes_namespace_name=\"log-test-0\", kubernetes_pod_name=~\"logger.*\"}[1m]))) u003e 0.01)",
+                        "duration": 10,
+                        "labels": {
+                            "namespace": "log-test-0",
+                            "severity": "critical",
+                            "tenantId": "application"
+                        },
+                        "annotations": {
+                            "description": "High Log Test Errors",
+                            "summary": "High Log Test Errors"
+                        },
+                        "alerts": [],
+                        "health": "ok",
+                        "lastError": "",
+                        "type": "alerting",
+                        "lastEvaluation": "2023-05-31T16:03:22.223755769Z",
+                        "evaluationTime": 0.002617669
+                    }
+                ],
+                "interval": 60,
+                "lastEvaluation": "2023-05-31T16:03:22.223732169Z",
+                "evaluationTime": 0.002646403
+            },
+            {
+                "name": "LogTest",
+                "file": "log-test-1-log-test-1-e9f1b6ba-ea21-4604-a58e-38f0772e0f77.yaml",
+                "rules": [
+                    {
+                        "state": "inactive",
+                        "name": "HighPercentageError",
+                        "query": "((sum(rate({kubernetes_namespace_name=\"log-test-1\", kubernetes_pod_name=~\"logger.*\"} |= \"error\"[1m])) / sum(rate({kubernetes_namespace_name=\"log-test-1\", kubernetes_pod_name=~\"logger.*\"}[1m]))) u003e 0.01)",
+                        "duration": 10,
+                        "labels": {
+                            "namespace": "log-test-1",
+                            "severity": "critical",
+                            "tenantId": "application"
+                        },
+                        "annotations": {
+                            "description": "High Log Test Errors",
+                            "summary": "High Log Test Errors"
+                        },
+                        "alerts": [],
+                        "health": "ok",
+                        "lastError": "",
+                        "type": "alerting",
+                        "lastEvaluation": "2023-05-31T16:03:31.743038365Z",
+                        "evaluationTime": 0.002428888
+                    },
+                    {
+                        "state": "inactive",
+                        "name": "HighPercentageError",
+                        "query": "((sum(rate({kubernetes_namespace_name=\"log-test-0\", kubernetes_pod_name=~\"logger.*\"} |= \"error\"[1m])) / sum(rate({kubernetes_namespace_name=\"log-test-0\", kubernetes_pod_name=~\"logger.*\"}[1m]))) u003e 0.01)",
+                        "duration": 10,
+                        "labels": {
+                            "namespace": "log-test-0",
+                            "severity": "critical",
+                            "tenantId": "application"
+                        },
+                        "annotations": {
+                            "description": "High Log Test Errors",
+                            "summary": "High Log Test Errors"
+                        },
+                        "alerts": [],
+                        "health": "ok",
+                        "lastError": "",
+                        "type": "alerting",
+                        "lastEvaluation": "2023-05-31T16:03:39.007922731Z",
+                        "evaluationTime": 0.003047885
+                    }
+                ],
+                "interval": 60,
+                "lastEvaluation": "2023-05-31T16:03:31.743028184Z",
+                "evaluationTime": 0.002444145
+            }
+        ]
+    },
+    "errorType": "",
+    "error": ""
+}

--- a/api/logs/v1/testdata/rules.yaml
+++ b/api/logs/v1/testdata/rules.yaml
@@ -1,0 +1,53 @@
+log-test-0-log-test-0-5d36c48b-c5d4-477d-a565-a0c4513c29f1.yaml:
+    - name: LogTest
+      interval: 1m
+      rules:
+        - alert: HighPercentageError
+          expr: |
+            sum(rate({kubernetes_namespace_name="log-test-0", kubernetes_pod_name=~"logger.*"} |= "error" [1m]))
+              /
+            sum(rate({kubernetes_namespace_name="log-test-0", kubernetes_pod_name=~"logger.*"}[1m]))
+              > 0.01
+          for: 10s
+          labels:
+            namespace: log-test-0
+            severity: critical
+            tenantId: application
+          annotations:
+            description: High Log Test Errors
+            summary: High Log Test Errors
+    - name: LogTestAAA
+      interval: 1m
+      rules:
+        - alert: HighPercentageErrorAAA
+          expr: |
+            sum(rate({kubernetes_namespace_name="log-test-0", kubernetes_pod_name=~"logger.*"} |= "error" [1m]))
+              /
+            sum(rate({kubernetes_namespace_name="log-test-0", kubernetes_pod_name=~"logger.*"}[1m]))
+              > 0.01
+          for: 10s
+          labels:
+            namespace: log-test-0
+            severity: critical
+            tenantId: application
+          annotations:
+            description: High Log Test Errors
+            summary: High Log Test Errors
+log-test-1-log-test-1-b00ddae9-26ed-46dc-a8f4-b46a8f9e7a14.yaml:
+    - name: LogTest
+      interval: 1m
+      rules:
+        - alert: HighPercentageError
+          expr: |
+            sum(rate({kubernetes_namespace_name="log-test-1", kubernetes_pod_name=~"logger.*"} |= "error" [1m]))
+              /
+            sum(rate({kubernetes_namespace_name="log-test-1", kubernetes_pod_name=~"logger.*"}[1m]))
+              > 0.01
+          for: 10s
+          labels:
+            namespace: log-test-1
+            severity: critical
+            tenantId: application
+          annotations:
+            description: High Log Test Errors
+            summary: High Log Test Errors

--- a/main.go
+++ b/main.go
@@ -692,6 +692,7 @@ func main() {
 								logsv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "logs")),
 								logsv1.WithRulesLabelFilters(cfg.logs.rulesLabelFilters),
 								logsv1.WithRulesReadMiddleware(logsv1.WithEnforceTenantAsRuleNamespace()),
+								logsv1.WithRulesReadMiddleware(logsv1.WithEnforceRulesLabelFilters(cfg.logs.rulesLabelFilters)),
 								logsv1.WithRulesWriteMiddleware(logsv1.WithEnforceTenantAsRuleNamespace()),
 								logsv1.WithRulesWriteMiddleware(logsv1.WithEnforceRuleLabels(cfg.logs.tenantLabel)),
 							),

--- a/main.go
+++ b/main.go
@@ -158,7 +158,8 @@ type logsConfig struct {
 	tenantHeader         string
 	tenantLabel          string
 	// Allow only read-only access on rules
-	rulesReadOnly bool
+	rulesReadOnly     bool
+	rulesLabelFilters map[string][]string
 	// enable logs at least one {read,write,tail}Endpoint} is provided.
 	enabled bool
 }
@@ -689,6 +690,7 @@ func main() {
 								logsv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "logs")),
 								logsv1.WithReadMiddleware(logsv1.WithEnforceAuthorizationLabels()),
 								logsv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "logs")),
+								logsv1.WithRulesLabelFilters(cfg.logs.rulesLabelFilters),
 								logsv1.WithRulesReadMiddleware(logsv1.WithEnforceTenantAsRuleNamespace()),
 								logsv1.WithRulesWriteMiddleware(logsv1.WithEnforceTenantAsRuleNamespace()),
 								logsv1.WithRulesWriteMiddleware(logsv1.WithEnforceRuleLabels(cfg.logs.tenantLabel)),
@@ -943,6 +945,7 @@ func parseFlags() (config, error) {
 		rawLogsRulesEndpoint    string
 		rawLogsTailEndpoint     string
 		rawLogsWriteEndpoint    string
+		rawLogsRuleLabelFilters string
 		rawTracesReadEndpoint   string
 		rawTracesWriteEndpoint  string
 		rawTracingEndpointType  string
@@ -991,6 +994,8 @@ func parseFlags() (config, error) {
 		"The endpoint against which to make rules requests for logs.")
 	flag.BoolVar(&cfg.logs.rulesReadOnly, "logs.rules.read-only", false,
 		"Allow only read-only rule requests for logs.")
+	flag.StringVar(&rawLogsRuleLabelFilters, "logs.rules.label-filters", "",
+		"Allow the following filters to be applied to user rules queries per tenant (e.g. tenantA:namespace,severity;tenantB:severity).")
 	flag.DurationVar(&cfg.logs.upstreamWriteTimeout, "logs.write-timeout", logsMiddlewareTimeout,
 		"The HTTP write timeout for proxied requests to the logs endpoint.")
 	flag.StringVar(&cfg.logs.upstreamCAFile, "logs.tls.ca-file", "",
@@ -1131,6 +1136,18 @@ func parseFlags() (config, error) {
 		}
 
 		cfg.logs.rulesEndpoint = logsRulesEndpoint
+	}
+
+	if rawLogsRuleLabelFilters != "" {
+		cfg.logs.rulesLabelFilters = map[string][]string{}
+		tenantFilters := strings.Split(rawLogsRuleLabelFilters, ";")
+
+		for _, f := range tenantFilters {
+			parts := strings.Split(f, ":")
+
+			tenant := parts[0]
+			cfg.logs.rulesLabelFilters[tenant] = strings.Split(parts[1], ",")
+		}
 	}
 
 	if rawLogsTailEndpoint != "" {


### PR DESCRIPTION
This PR introduces the capability to filter log-based rules by applying user-selected labels. The administrator can define which label keys are valid via a CLI flag `--logs.rules.label-filters=tenantA:label-a,label-b;tenantB;label-c` and can be used as URL query parameters. The enforcement applies on the prometheus-compatible `/prometheus/api/v1/rules` as well as on the Loki API `/loki/api/v1/rules`.

cc @xperimental @aminesnow @jgbernalp