### PR TITLE
Initialize all handlers metrics

### DIFF
--- a/api/metrics/legacy/http.go
+++ b/api/metrics/legacy/http.go
@@ -143,8 +143,24 @@ func NewHandler(url *url.URL, upstreamCA []byte, upstreamCert *stdtls.Certificat
 
 	r.Group(func(r chi.Router) {
 		r.Use(c.queryMiddlewares...)
-		r.Handle(QueryRoute, otelhttp.WithRouteTag(c.spanRoutePrefix+QueryRoute, legacyProxy))
-		r.Handle(QueryRangeRoute, otelhttp.WithRouteTag(c.spanRoutePrefix+QueryRangeRoute, legacyProxy))
+		r.Handle(QueryRoute,
+			otelhttp.WithRouteTag(
+				c.spanRoutePrefix+QueryRoute,
+				server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricslegacy", "handler": "query"},
+					legacyProxy,
+				),
+			),
+		)
+		r.Handle(QueryRangeRoute,
+			otelhttp.WithRouteTag(
+				c.spanRoutePrefix+QueryRangeRoute,
+				server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricslegacy", "handler": "query_range"},
+					legacyProxy,
+				),
+			),
+		)
 	})
 
 	r.Group(func(r chi.Router) {

--- a/main.go
+++ b/main.go
@@ -1378,19 +1378,19 @@ type groupHandler struct {
 	handler string
 }
 
-var legacyMetricsGroup = map[string]groupHandler{
-	metricslegacy.QueryRoute:      {"metricslegacy", "query"},
-	metricslegacy.QueryRangeRoute: {"metricslegacy", "query_range"},
+var legacyMetricsGroup = []groupHandler{
+	{"metricslegacy", "query"},
+	{"metricslegacy", "query_range"},
 }
 
-var metricsV1Group = map[string]groupHandler{
-	metricsv1.UIRoute:          {"metricsv1", "ui"},
-	metricsv1.QueryRoute:       {"metricsv1", "query"},
-	metricsv1.QueryRangeRoute:  {"metricsv1", "query_range"},
-	metricsv1.SeriesRoute:      {"metricsv1", "series"},
-	metricsv1.LabelNamesRoute:  {"metricsv1", "labels"},
-	metricsv1.LabelValuesRoute: {"metricsv1", "labelvalues"},
-	metricsv1.ReceiveRoute:     {"metricsv1", "receive"},
-	metricsv1.RulesRoute:       {"metricsv1", "rules"},
-	metricsv1.RulesRawRoute:    {"metricsv1", "rules-raw"},
+var metricsV1Group = []groupHandler{
+	{"metricsv1", "ui"},
+	{"metricsv1", "query"},
+	{"metricsv1", "query_range"},
+	{"metricsv1", "series"},
+	{"metricsv1", "labels"},
+	{"metricsv1", "labelvalues"},
+	{"metricsv1", "receive"},
+	{"metricsv1", "rules"},
+	{"metricsv1", "rules-raw"},
 }

--- a/server/http_instrumentation.go
+++ b/server/http_instrumentation.go
@@ -22,7 +22,7 @@ type httpMetricsCollector struct {
 }
 
 func (m httpMetricsCollector) initializeMetrics(labels prometheus.Labels) {
-	// Check is all hardcodedLabels are present in labels
+	// Check if all hardcodedLabels are present in labels
 	for _, hardcodedLabel := range m.hardcodedLabels {
 		if _, ok := labels[hardcodedLabel]; !ok {
 			panic("missing hardcoded label: " + hardcodedLabel)


### PR DESCRIPTION
This PR initializes all the metrics from the **metrics** APIs (v1 and legacy) to ensure they are present on a restart of the application, even without traffic.

We were having issues with the Pyrra SLOs firing the `SLOMetricAbsent` in these scenarios. This should prevent these alerts.

A small refactor was done to stop trying to guess the group and handler based on the URL path at request time. Instead, these are added through handler wrappers that store the group and handler in the context. The list of groups and handlers are used to initialize the metrics.

A bigger refactor can be done to improve this further, making the registration of the group and handler names of an endpoint initialize the metric. This will require many more changes, including changing interfaces in the code, so I didn't do it in this PR.

Signed-off-by: Douglas Camata <159076+douglascamata@users.noreply.github.com>