### PR TITLE
Clean & fix metrics initialization 

### DIFF
--- a/api/metrics/legacy/http.go
+++ b/api/metrics/legacy/http.go
@@ -146,7 +146,6 @@ func NewHandler(url *url.URL, upstreamCA []byte, upstreamCert *stdtls.Certificat
 			otelhttp.WithRouteTag(
 				c.spanRoutePrefix+QueryRoute,
 				server.InjectLabelsCtx(
-					c.logger,
 					prometheus.Labels{"group": "metricslegacy", "handler": "query"},
 					legacyProxy,
 				),
@@ -156,7 +155,6 @@ func NewHandler(url *url.URL, upstreamCA []byte, upstreamCert *stdtls.Certificat
 			otelhttp.WithRouteTag(
 				c.spanRoutePrefix+QueryRangeRoute,
 				server.InjectLabelsCtx(
-					c.logger,
 					prometheus.Labels{"group": "metricslegacy", "handler": "query_range"},
 					legacyProxy,
 				),

--- a/api/metrics/legacy/http.go
+++ b/api/metrics/legacy/http.go
@@ -114,7 +114,6 @@ func NewHandler(url *url.URL, upstreamCA []byte, upstreamCert *stdtls.Certificat
 	}
 
 	r := chi.NewRouter()
-	r.Use(server.InstrumentationMiddleware(c.labelParser))
 	r.Use(func(handler http.Handler) http.Handler {
 		return c.instrument.NewHandler(nil, handler)
 	})
@@ -147,6 +146,7 @@ func NewHandler(url *url.URL, upstreamCA []byte, upstreamCert *stdtls.Certificat
 			otelhttp.WithRouteTag(
 				c.spanRoutePrefix+QueryRoute,
 				server.InjectLabelsCtx(
+					c.logger,
 					prometheus.Labels{"group": "metricslegacy", "handler": "query"},
 					legacyProxy,
 				),
@@ -156,6 +156,7 @@ func NewHandler(url *url.URL, upstreamCA []byte, upstreamCert *stdtls.Certificat
 			otelhttp.WithRouteTag(
 				c.spanRoutePrefix+QueryRangeRoute,
 				server.InjectLabelsCtx(
+					c.logger,
 					prometheus.Labels{"group": "metricslegacy", "handler": "query_range"},
 					legacyProxy,
 				),

--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -181,7 +181,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+QueryRoute,
 					server.InjectLabelsCtx(
-						c.logger,
 						prometheus.Labels{"group": "metricsv1", "handler": "query"},
 						proxyQuery,
 					),
@@ -191,7 +190,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+QueryRangeRoute,
 					server.InjectLabelsCtx(
-						c.logger,
 						prometheus.Labels{"group": "metricsv1", "handler": "query_range"},
 						proxyQuery,
 					),
@@ -229,7 +227,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+SeriesRoute,
 					server.InjectLabelsCtx(
-						c.logger,
 						prometheus.Labels{"group": "metricsv1", "handler": "series"},
 						proxyRead,
 					),
@@ -239,7 +236,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+LabelNamesRoute,
 					server.InjectLabelsCtx(
-						c.logger,
 						prometheus.Labels{"group": "metricsv1", "handler": "label_names"},
 						proxyRead,
 					),
@@ -249,7 +245,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+LabelValuesRoute,
 					server.InjectLabelsCtx(
-						c.logger,
 						prometheus.Labels{"group": "metricsv1", "handler": "label_values"},
 						proxyRead,
 					),
@@ -261,7 +256,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+RulesRoute,
 					server.InjectLabelsCtx(
-						c.logger,
 						prometheus.Labels{"group": "metricsv1", "handler": "rules"},
 						proxyRead,
 					),
@@ -293,7 +287,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+UIRoute,
 					server.InjectLabelsCtx(
-						c.logger,
 						prometheus.Labels{"group": "metricsv1", "handler": "ui"},
 						uiProxy,
 					),
@@ -332,7 +325,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+ReceiveRoute,
 					server.InjectLabelsCtx(
-						c.logger,
 						prometheus.Labels{"group": "metricsv1", "handler": "receive"},
 						proxyWrite,
 					),
@@ -357,7 +349,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+RulesRawRoute,
 					server.InjectLabelsCtx(
-						c.logger,
 						prometheus.Labels{"group": "metricsv1", "handler": "rules"},
 						http.HandlerFunc(rh.get),
 					),
@@ -372,7 +363,6 @@ func NewHandler(read, write, rulesEndpoint *url.URL, upstreamCA []byte, upstream
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+RulesRawRoute,
 					server.InjectLabelsCtx(
-						c.logger,
 						prometheus.Labels{"group": "metricsv1", "handler": "rules-raw"},
 						http.HandlerFunc(rh.put),
 					),

--- a/main.go
+++ b/main.go
@@ -524,7 +524,7 @@ func main() {
 		r.Use(server.Logger(logger))
 
 		hardcodedLabels := []string{"group", "handler"}
-		instrumenter := server.NewInstrumentedHandlerFactory(reg, hardcodedLabels, logger)
+		instrumenter := server.NewInstrumentedHandlerFactory(reg, hardcodedLabels)
 
 		// Initializing the metrics of all handler to ensure Pyrra's `MetricSLOAbsent`
 		// alerts won't fire for endpoints with no traffic for a while after a

--- a/main.go
+++ b/main.go
@@ -524,7 +524,7 @@ func main() {
 		r.Use(server.Logger(logger))
 
 		hardcodedLabels := []string{"group", "handler"}
-		instrumenter := server.NewInstrumentedHandlerFactory(reg, hardcodedLabels)
+		instrumenter := server.NewInstrumentedHandlerFactory(reg, hardcodedLabels, logger)
 
 		// Initializing the metrics of all handler to ensure Pyrra's `MetricSLOAbsent`
 		// alerts won't fire for endpoints with no traffic for a while after a


### PR DESCRIPTION
This fixes some issues from #547. Metrics were not properly counting due to middleware ordering, copies, and shadowing. 

Unfortunately I didn't catch this before because my e2e tests were using an old image of the project. Now this is also fixed in my environment and I can test things properly.