### PR TITLE
Fix concurrent map access in HTTP instrumentation

### DIFF
--- a/server/http_instrumentation.go
+++ b/server/http_instrumentation.go
@@ -85,8 +85,6 @@ func (m instrumentedHandlerFactory) InitializeMetrics(labels prometheus.Labels) 
 
 // NewHandler creates a new instrumented HTTP handler with the given extra labels and calling the "next" handlers.
 func (m instrumentedHandlerFactory) NewHandler(extraLabels prometheus.Labels, next http.Handler) http.HandlerFunc {
-	m.labelsMutex = &sync.RWMutex{}
-
 	return func(w http.ResponseWriter, r *http.Request) {
 		m.labelsMutex.Lock()
 		defer m.labelsMutex.Unlock()
@@ -138,6 +136,7 @@ func (m instrumentedHandlerFactory) NewHandler(extraLabels prometheus.Labels, ne
 func NewInstrumentedHandlerFactory(req *prometheus.Registry, hardcodedLabels []string) instrumentedHandlerFactory {
 	return instrumentedHandlerFactory{
 		metricsCollector: newHTTPMetricsCollector(req, hardcodedLabels),
+		labelsMutex:      &sync.RWMutex{},
 	}
 }
 

--- a/server/http_instrumentation_test.go
+++ b/server/http_instrumentation_test.go
@@ -1,0 +1,40 @@
+package server
+
+import (
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+func TestInstrumentedHandlerFactory_ConcurrentAccess(t *testing.T) {
+	r := prometheus.NewRegistry()
+	hardcodedLabels := []string{"group", "handler"}
+	extraLabels := prometheus.Labels{"group": "test", "handler": "concurrency"}
+	handler := http.HandlerFunc(func(wr http.ResponseWriter, r *http.Request) {
+		time.Sleep(time.Duration(rand.Int63n(100) * int64(time.Millisecond)))
+	})
+	numRequests := 1000
+
+	f := NewInstrumentedHandlerFactory(r, hardcodedLabels)
+	h := f.NewHandler(extraLabels, handler)
+
+	wg := &sync.WaitGroup{}
+	wg.Add(numRequests)
+	for i := 0; i < numRequests; i++ {
+		go func() {
+			defer wg.Done()
+
+			wr := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			time.Sleep(time.Duration(rand.Int63n(100) * int64(time.Millisecond)))
+			h(wr, r)
+		}()
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
The Labels map that is used for instrumentation is being read and wrote simultaneously by multiple goroutines, resulting in a panic.
This PR removes the need to use the same variable across different routines.