### PR TITLE
Fix UI route to match on pattern

### DIFF
--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -321,7 +321,7 @@ func NewHandler(endpoints Endpoints, upstreamCA []byte, upstreamCert *stdtls.Cer
 		r.Group(func(r chi.Router) {
 			r.Use(c.uiMiddlewares...)
 			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
-			r.Handle(UIRoute,
+			r.Mount(UIRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+UIRoute,
 					server.InjectLabelsCtx(


### PR DESCRIPTION
r.Mount matches on a pattern, whereas r.Handle wants an exact match. For the UI route, we need to match on pattern, as we load static files and other routes via the UI route (think /store, /flags, /static etc).

This bug shows up with 404 and a `X-Content-Type-Options: nosniff` header, which is actually misleading.