### PR TITLE
Expose tempo trace query API using the gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ Usage of ./observatorium-api:
     	File containing the default x509 private key matching --tls.server.cert-file. Leave blank to disable TLS.
   -traces.read.endpoint string
     	The endpoint against which to make HTTP read requests for traces.
+  -traces.tempo.endpoint string
+    	The endpoint against which to make HTTP read requests for traces using traceQL (tempo API).
   -traces.tenant-header string
     	The name of the HTTP header containing the tenant ID to forward to upstream OpenTelemetry collector. (default "X-Tenant")
   -traces.tls.ca-file string

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -218,7 +218,7 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, upstreamCA
 
 		r.Group(func(r chi.Router) {
 			r.Use(c.tempoMiddlewares...)
-			r.Get("/tempo*", c.instrument.NewHandler(
+			r.Get("/tempo/api*", c.instrument.NewHandler(
 				prometheus.Labels{"group": "tracesv1tempo", "handler": "tempo"},
 				tempoProxyRead))
 		})

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -84,7 +84,7 @@ func WithReadMiddleware(m func(http.Handler) http.Handler) HandlerOption {
 // WithTempoMiddleware adds a middleware for all tempo read operations.
 func WithTempoMiddleware(m func(http.Handler) http.Handler) HandlerOption {
 	return func(h *handlerConfiguration) {
-		h.readMiddlewares = append(h.readMiddlewares, m)
+		h.tempoMiddlewares = append(h.tempoMiddlewares, m)
 	}
 }
 

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -205,7 +205,8 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, upstreamCA
 		middlewares := proxy.Middlewares(
 			proxy.MiddlewareRemoveURLPrefix("tempo"),
 			proxy.MiddlewareSetUpstream(tempo),
-			proxy.MiddlewareSetTempoPrefixHeader(),
+			proxy.MiddlewareSetPrefixHeader(),
+			proxy.MiddlewareSetTempoTenantHeader(),
 			proxy.MiddlewareLogger(c.logger),
 			middlewareMetrics,
 		)

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -206,7 +206,6 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, upstreamCA
 			proxy.MiddlewareRemoveURLPrefix("tempo"),
 			proxy.MiddlewareSetUpstream(tempo),
 			proxy.MiddlewareSetPrefixHeader(),
-			proxy.MiddlewareSetTempoTenantHeader(),
 			proxy.MiddlewareLogger(c.logger),
 			middlewareMetrics,
 		)
@@ -220,7 +219,7 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, upstreamCA
 		r.Group(func(r chi.Router) {
 			r.Use(c.tempoMiddlewares...)
 			r.Get("/tempo/api*", c.instrument.NewHandler(
-				prometheus.Labels{"group": "tracesv1tempo", "handler": "tempo"},
+				prometheus.Labels{"group": "tracesv1api", "handler": "traces"},
 				tempoProxyRead))
 		})
 	}

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -193,7 +193,7 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, upstreamCA
 
 	// if tempo upstream is enabled, configure proxy and route
 	if tempo != nil {
-		level.Debug(c.logger).Log("msg", "Configuring upstream Tempo", "queryv2", read)
+		level.Debug(c.logger).Log("msg", "Configuring upstream Tempo", "queryv2", tempo)
 
 		t := &http.Transport{
 			DialContext: (&net.Dialer{
@@ -204,7 +204,6 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, upstreamCA
 
 		middlewares := proxy.Middlewares(
 			proxy.MiddlewareRemoveURLPrefix("tempo"),
-			proxy.MiddlewareAppendURLPrefix("api"),
 			proxy.MiddlewareSetUpstream(tempo),
 			proxy.MiddlewareSetTempoPrefixHeader(),
 			proxy.MiddlewareLogger(c.logger),

--- a/main.go
+++ b/main.go
@@ -172,6 +172,7 @@ type tracesConfig struct {
 
 	readEndpoint         *url.URL
 	writeEndpoint        string
+	tempoEndpoint        *url.URL
 	upstreamWriteTimeout time.Duration
 	upstreamCAFile       string
 	upstreamCertFile     string
@@ -731,7 +732,7 @@ func main() {
 			}
 
 			// Traces.
-			if cfg.traces.enabled && (cfg.traces.readEndpoint != nil || cfg.traces.readTemplateEndpoint != "") {
+			if cfg.traces.enabled && (cfg.traces.readEndpoint != nil || cfg.traces.readTemplateEndpoint != "" || cfg.traces.tempoEndpoint != nil) {
 				r.Group(func(r chi.Router) {
 					r.Use(authentication.WithTenantMiddlewares(pm.Middlewares))
 					r.Use(authentication.WithTenantHeader(cfg.traces.tenantHeader, tenantIDs))
@@ -755,6 +756,7 @@ func main() {
 							tracesv1.NewV2Handler(
 								cfg.traces.readEndpoint,
 								cfg.traces.readTemplateEndpoint,
+								cfg.traces.tempoEndpoint,
 								tracesUpstreamCACert,
 								tracesUpstreamClientCert,
 								tracesv1.Logger(logger),
@@ -763,6 +765,8 @@ func main() {
 								tracesv1.WithSpanRoutePrefix("/api/traces/v1/{tenant}"),
 								tracesv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "traces")),
 								tracesv1.WithReadMiddleware(logsv1.WithEnforceAuthorizationLabels()),
+								tracesv1.WithTempoMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "traces")),
+								tracesv1.WithTempoMiddleware(logsv1.WithEnforceAuthorizationLabels()),
 								tracesv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "traces")),
 							),
 						),
@@ -988,6 +992,7 @@ func parseFlags() (config, error) {
 		rawLogsRuleLabelFilters        string
 		rawLogsAuthExtractSelectors    string
 		rawTracesReadEndpoint          string
+		rawTracesTempoEndpoint         string
 		rawTracesWriteEndpoint         string
 		rawTracingEndpointType         string
 	)
@@ -1075,6 +1080,8 @@ func parseFlags() (config, error) {
 		"The name of the PromQL label that should hold the tenant ID in metrics upstreams.")
 	flag.StringVar(&rawTracesReadEndpoint, "traces.read.endpoint", "",
 		"The endpoint against which to make HTTP read requests for traces.")
+	flag.StringVar(&rawTracesTempoEndpoint, "traces.tempo.endpoint", "",
+		"The endpoint against which to make HTTP read requests for traces using traceQL (tempo API).")
 	flag.StringVar(&cfg.traces.readTemplateEndpoint, "experimental.traces.read.endpoint-template", "",
 		"A template replacing --read.traces.endpoint, such as http://jaeger-{tenant}-query:16686")
 	flag.StringVar(&rawTracesWriteEndpoint, "traces.write.endpoint", "",
@@ -1261,6 +1268,17 @@ func parseFlags() (config, error) {
 		}
 
 		cfg.traces.readEndpoint = tracesReadEndpoint
+	}
+
+	if rawTracesTempoEndpoint != "" {
+		cfg.traces.enabled = true
+
+		tracesTempoEndpoint, err := url.ParseRequestURI(rawTracesTempoEndpoint)
+		if err != nil {
+			return cfg, fmt.Errorf("--traces.read.endpoint %q is invalid: %w", rawTracesReadEndpoint, err)
+		}
+
+		cfg.traces.tempoEndpoint = tracesTempoEndpoint
 	}
 
 	if rawTracesWriteEndpoint != "" {

--- a/main.go
+++ b/main.go
@@ -1275,7 +1275,7 @@ func parseFlags() (config, error) {
 
 		tracesTempoEndpoint, err := url.ParseRequestURI(rawTracesTempoEndpoint)
 		if err != nil {
-			return cfg, fmt.Errorf("--traces.read.endpoint %q is invalid: %w", rawTracesReadEndpoint, err)
+			return cfg, fmt.Errorf("--traces.tempo.endpoint %q is invalid: %w", rawTracesTempoEndpoint, err)
 		}
 
 		cfg.traces.tempoEndpoint = tracesTempoEndpoint

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"context"
 	"fmt"
-	"github.com/observatorium/api/authentication"
 	stdlog "log"
 	"net/http"
 	"net/url"
@@ -13,6 +12,7 @@ import (
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/observatorium/api/authentication"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -12,7 +12,6 @@ import (
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/observatorium/api/authentication"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -63,16 +62,6 @@ func MiddlewareSetPrefixHeader() Middleware {
 		}
 
 		r.Header.Set(PrefixHeader, prefix)
-	}
-}
-
-func MiddlewareSetTempoTenantHeader() Middleware {
-	return func(r *http.Request) {
-		tenant, ok := authentication.GetTenant(r.Context())
-		if !ok {
-			return
-		}
-		r.Header.Set(TempoOrgIDHeaderName, tenant)
 	}
 }
 

--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -459,7 +459,7 @@ func createTempoConfigYAML(
 	e e2e.Environment,
 ) {
 	// Warn if a YAML change introduced a tab character
-	if strings.ContainsRune(otelConfigTpl, '\t') {
+	if strings.ContainsRune(tempoConfig, '\t') {
 		t.Errorf("Tab in the YAML")
 	}
 

--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -23,6 +23,7 @@ const (
 	logs           testType = "logs"
 	traces         testType = "traces"
 	tracesTemplate testType = "tracesTemplate"
+	tracesTempo    testType = "tracesTempo"
 	tenants        testType = "tenants"
 	interactive    testType = "interactive"
 
@@ -34,6 +35,7 @@ const (
 	envAlertmanagerName   = "alertmanager-api"
 	envLogsName           = "logs-tail"
 	envTracesName         = "traces-export"
+	envTracesTempoName    = "traces-tempo"
 	envTracesTemplateName = "traces-template"
 	envTenantsName        = "tenants"
 	envInteractive        = "interactive"
@@ -413,5 +415,60 @@ func createLokiYAML(
 		os.FileMode(0755),
 	)
 
+	testutil.Ok(t, err)
+}
+
+const tempoConfig = `
+server:
+  http_listen_port: 3200
+
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        http:
+        grpc:
+    opencensus:
+
+ingester:
+  max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+
+compactor:
+  compaction:
+    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    wal:
+      path: /tmp/tempo/wal             # where to store the the wal locally
+    local:
+      path: /tmp/tempo/blocks
+`
+
+// createTempoConfigYAML() creates YAML for Tempo inside the Observatorium API boundary.
+func createTempoConfigYAML(
+	t *testing.T,
+	e e2e.Environment,
+) {
+	// Warn if a YAML change introduced a tab character
+	if strings.ContainsRune(otelConfigTpl, '\t') {
+		t.Errorf("Tab in the YAML")
+	}
+
+	yamlContent := []byte(tempoConfig)
+
+	err := os.WriteFile(
+		filepath.Join(e.SharedDir(), configSharedDir, "tempo.yaml"),
+		yamlContent,
+		os.FileMode(0644),
+	)
 	testutil.Ok(t, err)
 }

--- a/test/e2e/helpers.go
+++ b/test/e2e/helpers.go
@@ -100,6 +100,8 @@ func getContainerName(t *testing.T, tt testType, serviceName string) string {
 		return envTracesName + "-" + serviceName
 	case tracesTemplate:
 		return envTracesTemplateName + "-" + serviceName
+	case tracesTempo:
+		return envTracesTempoName + "-" + serviceName
 	default:
 		t.Fatal("invalid test type provided")
 		return ""

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -28,7 +28,7 @@ const (
 
 	jaegerAllInOneImage = "jaegertracing/all-in-one:1.31"
 	otelCollectorImage  = "otel/opentelemetry-collector:0.45.0"
-	tempoImage          = "grafana/tempo:latest"
+	tempoImage          = "grafana/tempo:2.2.4"
 
 	// Note that if the forwarding collector uses OIDC flow instead of hard-coding
 	// the bearer token we would need

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -28,6 +28,8 @@ const (
 
 	jaegerAllInOneImage = "jaegertracing/all-in-one:1.31"
 	otelCollectorImage  = "otel/opentelemetry-collector:0.45.0"
+	tempoImage          = "grafana/tempo:latest"
+
 	// Note that if the forwarding collector uses OIDC flow instead of hard-coding
 	// the bearer token we would need
 	// "otel/opentelemetry-collector-contrib:0.45.0" instead.
@@ -138,6 +140,39 @@ func startServicesForTraces(t *testing.T, e e2e.Environment) (otlpGRPCEndpoint, 
 	testutil.Ok(t, e2e.StartAndWaitReady(otel))
 
 	return otel.InternalEndpoint("grpc"), jaeger.Endpoint("http.query"), jaeger.InternalEndpoint("http.query")
+}
+
+func startTempoServicesForTraces(t *testing.T, e e2e.Environment) (tempoDistributorEndpoint, internalTempoQueryEndpoint, tempoQueryEndpoint string) {
+	prometheus := e2edb.NewPrometheus(e, "prometheus")
+	testutil.Ok(t, e2e.StartAndWaitReady(prometheus))
+
+	createTempoConfigYAML(t, e)
+
+	tempo := e.Runnable("tempo").
+		WithPorts(
+			map[string]int{
+				"http.tempo": 3200, // tempo
+				"grpc.otlp":  4317, // tempo grpc
+				"http.otlp":  4318, // tempo grpc
+
+			}).
+		Init(e2e.StartOptions{
+			Image: tempoImage,
+			Volumes: []string{
+				fmt.Sprintf("%s:/conf/tempo.yaml",
+					filepath.Join(filepath.Join(e.SharedDir(), configSharedDir, "tempo.yaml"))),
+			},
+			Command: e2e.Command{
+				Args: []string{
+					"-config.file=conf/tempo.yaml",
+				},
+			},
+		})
+	createTempoConfigYAML(t, e)
+
+	testutil.Ok(t, e2e.StartAndWaitReady(tempo))
+
+	return tempo.InternalEndpoint("grpc.otlp"), tempo.InternalEndpoint("http.tempo"), tempo.Endpoint("http.tempo")
 }
 
 // startBaseServices starts and waits until all base services required for the test are ready.
@@ -322,6 +357,7 @@ type apiOptions struct {
 	tracesWriteEndpoint  string
 	gRPCListenEndpoint   string
 	jaegerQueryEndpoint  string
+	tempoEndpoint        string
 
 	// "experimental.traces.read.endpoint-template" value.
 	tracesExperimentalTemplateReadEndpoint string
@@ -351,6 +387,12 @@ func withOtelTraceEndpoint(exportEndpoint string) apiOption {
 func withGRPCListenEndpoint(listenEndpoint string) apiOption {
 	return func(o *apiOptions) {
 		o.gRPCListenEndpoint = listenEndpoint
+	}
+}
+
+func withTempoEndpoint(listenEndpoint string) apiOption {
+	return func(o *apiOptions) {
+		o.tempoEndpoint = listenEndpoint
 	}
 }
 
@@ -458,6 +500,10 @@ func newObservatoriumAPIService(
 		ports["grpc"] = gRPCPort
 
 		args = append(args, "--grpc.listen="+opts.gRPCListenEndpoint)
+	}
+
+	if opts.tempoEndpoint != "" {
+		args = append(args, "--traces.tempo.endpoint="+opts.tempoEndpoint)
 	}
 
 	return e2emon.AsInstrumented(e.Runnable("observatorium-api").WithPorts(ports).Init(


### PR DESCRIPTION
This PR introduces a new flag `-traces.tempo.endpoint` which should point to the **Tempo** _Query-frontend_ component in order to expose the tempo query API. (https://grafana.com/docs/tempo/latest/api_docs/) This will allow us to use the TraceQL API with the gateway.

The endpoints will be mapped according to this design document: https://docs.google.com/document/d/1vQ8F9MI8VhnqSyKjBom87axY7OIhDXeTJ4JGa9aDf9s


@pavolloffay  please review