### PR TITLE
Do not return error when selector extraction fails

### DIFF
--- a/authorization/query.go
+++ b/authorization/query.go
@@ -1,6 +1,7 @@
 package authorization
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 
@@ -16,7 +17,7 @@ func extractLogStreamSelectors(selectorNames map[string]bool, values url.Values)
 
 	selectors, hasWildcard, err := parseLogStreamSelectors(selectorNames, query)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error extracting selectors from query %#q: %w", query, err)
 	}
 
 	return &SelectorsInfo{

--- a/main.go
+++ b/main.go
@@ -715,7 +715,7 @@ func main() {
 								logsv1.WithWriteMiddleware(writePathRedirectProtection),
 								logsv1.WithGlobalMiddleware(authentication.WithTenantMiddlewares(pm.Middlewares)),
 								logsv1.WithGlobalMiddleware(authentication.WithTenantHeader(cfg.logs.tenantHeader, tenantIDs)),
-								logsv1.WithReadMiddleware(authorization.WithLogsStreamSelectorsExtractor(cfg.logs.authExtractSelectors)),
+								logsv1.WithReadMiddleware(authorization.WithLogsStreamSelectorsExtractor(logger, cfg.logs.authExtractSelectors)),
 								logsv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "logs")),
 								logsv1.WithReadMiddleware(logsv1.WithEnforceAuthorizationLabels()),
 								logsv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "logs")),


### PR DESCRIPTION
This PR changes the behaviour of the "selector extraction" introduced in #555 . Instead of returning an error to the user when the extraction fails, it is just logged as a warning and processing continues as if no selectors were found.

The reasoning behind is change is that our LogQL parser might lag behind in features after the "real one" in Loki and so we might return an error for a valid query or a different error for an invalid query, because the parser implementations do not match 100%. The new code will also log the query that caused the error, so that it can be debugged.