### PR TITLE
Fixes authorization flow for /api/logs/v1/{tenant}/rules

### DIFF
--- a/authorization/http.go
+++ b/authorization/http.go
@@ -2,7 +2,6 @@ package authorization
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 
 	"github.com/go-kit/log"
@@ -138,7 +137,6 @@ func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Per
 			if !ok {
 				selectorsInfo = emptySelectorsInfo
 			}
-			fmt.Printf("selectors: %+v\n", selectorsInfo)
 
 			metadataOnly := isMetadataRequest(r.URL.Path)
 

--- a/authorization/http.go
+++ b/authorization/http.go
@@ -61,7 +61,7 @@ func WithSelectorsInfo(ctx context.Context, info *SelectorsInfo) context.Context
 }
 
 // WithLogsStreamSelectorsExtractor returns a middleware that, when enabled, tries to extract
-// stream selectors from queries, so that they can be used in authorizing the request.
+// stream selectors from queries or rules, so that they can be used in authorizing the request.
 func WithLogsStreamSelectorsExtractor(logger log.Logger, selectorNames []string) func(http.Handler) http.Handler {
 	enabled := len(selectorNames) > 0
 

--- a/authorization/http.go
+++ b/authorization/http.go
@@ -2,6 +2,7 @@ package authorization
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/go-kit/log"
@@ -90,6 +91,53 @@ func WithLogsStreamSelectorsExtractor(logger log.Logger, selectorNames []string)
 	}
 }
 
+// WithLogsRulesSelectorsExtractor returns a middleware that, when enabled, tries to extract
+// stream selectors from queries, so that they can be used in authorizing the request.
+func WithLogsRulesSelectorsExtractor(logger log.Logger, selectorNames []string) func(http.Handler) http.Handler {
+	enabled := len(selectorNames) > 0
+    
+	// TODO remove
+	level.Debug(logger).Log("--------enabled", enabled)
+
+	selectorNameMap := make(map[string]bool, len(selectorNames))
+	for _, l := range selectorNames {
+		selectorNameMap[l] = true
+
+		// TODO remove
+		level.Debug(logger).Log("--------selector", l)
+	}
+	
+	
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if ! isRulesRequest(r.URL.Path) {
+				next.ServeHTTP(w, r)
+				level.Debug(logger).Log("notRuleRequest", isRulesRequest(r.URL.Path))
+
+				return
+			}
+
+			level.Debug(logger).Log("enabled", enabled)
+			if !enabled {
+				next.ServeHTTP(w, r)
+
+				return
+			}
+
+			selectorsInfo, err := extractLogRulesSelectors(selectorNameMap, r.URL.Query())
+			level.Debug(logger).Log("selectors", selectorsInfo)
+			if err != nil {
+				// Don't error out, just warn about error and continue with empty selectorsInfo
+				level.Warn(logger).Log("msg", err)
+				selectorsInfo = emptySelectorsInfo
+			}
+
+			next.ServeHTTP(w, r.WithContext(WithSelectorsInfo(r.Context(), selectorsInfo)))
+		})
+	}
+}
+
 // WithAuthorizers returns a middleware that authorizes subjects taken from a request context
 // for the given permission on the given resource for a tenant taken from a request context.
 func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Permission, resource string) func(http.Handler) http.Handler {
@@ -137,6 +185,7 @@ func WithAuthorizers(authorizers map[string]rbac.Authorizer, permission rbac.Per
 			if !ok {
 				selectorsInfo = emptySelectorsInfo
 			}
+			fmt.Printf("selectors: %+v\n", selectorsInfo)
 
 			metadataOnly := isMetadataRequest(r.URL.Path)
 

--- a/authorization/query.go
+++ b/authorization/query.go
@@ -12,14 +12,11 @@ import (
 func extractLogStreamSelectors(selectorNames map[string]bool, values url.Values) (*SelectorsInfo, error) {
 	query := values.Get("query")
 	if query == "" {
-		// If query is empty we will assume it's a possibly a metadata/rules request
-		selectors, err := parseLogRulesSelectors(selectorNames, values)
-		if err != nil {
-			return nil, fmt.Errorf("error extracting selectors from parameters %#q: %w", values, err)
-		}
-	
+		// If query is empty we will assume it's a possibly a rules request
+		selectors := parseLogRulesSelectors(selectorNames, values)
+
 		return &SelectorsInfo{
-			Selectors:   selectors,
+			Selectors: selectors,
 		}, nil
 	}
 

--- a/authorization/query.go
+++ b/authorization/query.go
@@ -12,7 +12,15 @@ import (
 func extractLogStreamSelectors(selectorNames map[string]bool, values url.Values) (*SelectorsInfo, error) {
 	query := values.Get("query")
 	if query == "" {
-		return emptySelectorsInfo, nil
+		// If query is empty we will assume it's a possibly a metadata/rules request
+		selectors, err := parseLogRulesSelectors(selectorNames, values)
+		if err != nil {
+			return nil, fmt.Errorf("error extracting selectors from parameters %#q: %w", values, err)
+		}
+	
+		return &SelectorsInfo{
+			Selectors:   selectors,
+		}, nil
 	}
 
 	selectors, hasWildcard, err := parseLogStreamSelectors(selectorNames, query)

--- a/authorization/rules.go
+++ b/authorization/rules.go
@@ -1,0 +1,65 @@
+package authorization
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+var (
+	rulesAbsolutePaths = map[string]bool{
+		"/loki/api/v1/rule":  true,
+		"/loki/api/v1/rules": true,
+		"/api/prom/rules":    true,
+	}
+
+	rulesPathLabelValuesNewPrefix = "/loki/api/v1/rules/"
+	rulesPathLabelValuesOldPrefix = "/api/prom/rules/"
+)
+
+func isRulesRequest(path string) bool {
+	if absolutePath := rulesAbsolutePaths[path]; absolutePath {
+		return true
+	}
+
+	if (strings.HasPrefix(path, rulesPathLabelValuesNewPrefix) || strings.HasPrefix(path, rulesPathLabelValuesOldPrefix)) {
+		return true
+	}
+
+	return false
+}
+
+func extractLogRulesSelectors(selectorNames map[string]bool, values url.Values) (*SelectorsInfo, error) {
+	selectors, hasWildcard, err := parseLogRulesSelectors(selectorNames, values)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting selectors from query parameters %#q: %w", values, err)
+	}
+
+	return &SelectorsInfo{
+		Selectors:   selectors,
+		HasWildcard: hasWildcard,
+	}, nil
+}
+
+func parseLogRulesSelectors(selectorNames map[string]bool, queryParameter url.Values) (map[string][]string, bool, error) {
+	selectors := make(map[string][]string)
+	appendSelector := func(selector, value string) {
+		values, ok := selectors[selector]
+		if !ok {
+			values = make([]string, 0)
+		}
+
+		values = append(values, value)
+		selectors[selector] = values
+	}
+
+	hasWildcard := false
+	for selector := range selectorNames {
+		values := queryParameter[selector]
+		for _, value := range values {
+			appendSelector(selector, value)
+		}
+	}
+
+	return selectors, hasWildcard, nil
+}

--- a/authorization/rules.go
+++ b/authorization/rules.go
@@ -1,47 +1,10 @@
 package authorization
 
 import (
-	"fmt"
 	"net/url"
-	"strings"
 )
 
-var (
-	rulesAbsolutePaths = map[string]bool{
-		"/loki/api/v1/rule":  true,
-		"/loki/api/v1/rules": true,
-		"/api/prom/rules":    true,
-	}
-
-	rulesPathLabelValuesNewPrefix = "/loki/api/v1/rules/"
-	rulesPathLabelValuesOldPrefix = "/api/prom/rules/"
-)
-
-func isRulesRequest(path string) bool {
-	if absolutePath := rulesAbsolutePaths[path]; absolutePath {
-		return true
-	}
-
-	if (strings.HasPrefix(path, rulesPathLabelValuesNewPrefix) || strings.HasPrefix(path, rulesPathLabelValuesOldPrefix)) {
-		return true
-	}
-
-	return false
-}
-
-func extractLogRulesSelectors(selectorNames map[string]bool, values url.Values) (*SelectorsInfo, error) {
-	selectors, hasWildcard, err := parseLogRulesSelectors(selectorNames, values)
-	if err != nil {
-		return nil, fmt.Errorf("error extracting selectors from query parameters %#q: %w", values, err)
-	}
-
-	return &SelectorsInfo{
-		Selectors:   selectors,
-		HasWildcard: hasWildcard,
-	}, nil
-}
-
-func parseLogRulesSelectors(selectorNames map[string]bool, queryParameter url.Values) (map[string][]string, bool, error) {
+func parseLogRulesSelectors(selectorNames map[string]bool, queryParameter url.Values) (map[string][]string, error) {
 	selectors := make(map[string][]string)
 	appendSelector := func(selector, value string) {
 		values, ok := selectors[selector]
@@ -53,7 +16,6 @@ func parseLogRulesSelectors(selectorNames map[string]bool, queryParameter url.Va
 		selectors[selector] = values
 	}
 
-	hasWildcard := false
 	for selector := range selectorNames {
 		values := queryParameter[selector]
 		for _, value := range values {
@@ -61,5 +23,5 @@ func parseLogRulesSelectors(selectorNames map[string]bool, queryParameter url.Va
 		}
 	}
 
-	return selectors, hasWildcard, nil
+	return selectors, nil
 }

--- a/authorization/rules.go
+++ b/authorization/rules.go
@@ -4,7 +4,7 @@ import (
 	"net/url"
 )
 
-func parseLogRulesSelectors(selectorNames map[string]bool, queryParameter url.Values) (map[string][]string, error) {
+func parseLogRulesSelectors(selectorNames map[string]bool, queryParameter url.Values) map[string][]string {
 	selectors := make(map[string][]string)
 	appendSelector := func(selector, value string) {
 		values, ok := selectors[selector]
@@ -23,5 +23,5 @@ func parseLogRulesSelectors(selectorNames map[string]bool, queryParameter url.Va
 		}
 	}
 
-	return selectors, nil
+	return selectors
 }

--- a/authorization/rules_test.go
+++ b/authorization/rules_test.go
@@ -42,10 +42,7 @@ func Test_parseQueryParametersSelectors(t *testing.T) {
 			queryValues, err := url.ParseQuery(tt.queryParameters)
 			testutil.Ok(t, err)
 
-			gotNamespaces, err := parseLogRulesSelectors(testSelectorLabels, queryValues)
-			if err != nil {
-				t.Errorf("parseLogStreamSelectors() error = %v", err)
-			}
+			gotNamespaces := parseLogRulesSelectors(testSelectorLabels, queryValues)
 			if !reflect.DeepEqual(gotNamespaces, tt.wantSelectors) {
 				t.Errorf("parseLogStreamSelectors() got = %v, want %v", gotNamespaces, tt.wantSelectors)
 			}

--- a/authorization/rules_test.go
+++ b/authorization/rules_test.go
@@ -1,0 +1,54 @@
+package authorization
+
+import (
+	"net/url"
+	"reflect"
+	"testing"
+
+	"github.com/efficientgo/core/testutil"
+)
+
+func Test_parseQueryParametersSelectors(t *testing.T) {
+	testSelectorLabels := map[string]bool{
+		"namespace":             true,
+		"other_namespace_label": true,
+	}
+	tests := []struct {
+		queryParameters string
+		wantSelectors   map[string][]string
+	}{
+		{
+			queryParameters: `namespace=test`,
+			wantSelectors: map[string][]string{
+				"namespace": {"test"},
+			},
+		},
+		{
+			queryParameters: `namespace=test&other_namespace_label=test2`,
+			wantSelectors: map[string][]string{
+				"namespace":             {"test"},
+				"other_namespace_label": {"test2"},
+			},
+		},
+		{
+			queryParameters: `namespace=test&namespace=test2`,
+			wantSelectors: map[string][]string{
+				"namespace": {"test", "test2"},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.queryParameters, func(t *testing.T) {
+			queryValues, err := url.ParseQuery(tt.queryParameters)
+			testutil.Ok(t, err)
+
+			gotNamespaces, _, err := parseLogRulesSelectors(testSelectorLabels, queryValues)
+			if err != nil {
+				t.Errorf("parseLogStreamSelectors() error = %v", err)
+			}
+			if !reflect.DeepEqual(gotNamespaces, tt.wantSelectors) {
+				t.Errorf("parseLogStreamSelectors() got = %v, want %v", gotNamespaces, tt.wantSelectors)
+			}
+		})
+	}
+}

--- a/authorization/rules_test.go
+++ b/authorization/rules_test.go
@@ -42,7 +42,7 @@ func Test_parseQueryParametersSelectors(t *testing.T) {
 			queryValues, err := url.ParseQuery(tt.queryParameters)
 			testutil.Ok(t, err)
 
-			gotNamespaces, _, err := parseLogRulesSelectors(testSelectorLabels, queryValues)
+			gotNamespaces, err := parseLogRulesSelectors(testSelectorLabels, queryValues)
 			if err != nil {
 				t.Errorf("parseLogStreamSelectors() error = %v", err)
 			}

--- a/main.go
+++ b/main.go
@@ -716,7 +716,6 @@ func main() {
 								logsv1.WithGlobalMiddleware(authentication.WithTenantMiddlewares(pm.Middlewares)),
 								logsv1.WithGlobalMiddleware(authentication.WithTenantHeader(cfg.logs.tenantHeader, tenantIDs)),
 								logsv1.WithReadMiddleware(authorization.WithLogsStreamSelectorsExtractor(logger, cfg.logs.authExtractSelectors)),
-								logsv1.WithReadMiddleware(authorization.WithLogsRulesSelectorsExtractor(logger, cfg.logs.authExtractSelectors)),
 								logsv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "logs")),
 								logsv1.WithReadMiddleware(logsv1.WithEnforceAuthorizationLabels()),
 								logsv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "logs")),

--- a/main.go
+++ b/main.go
@@ -716,6 +716,7 @@ func main() {
 								logsv1.WithGlobalMiddleware(authentication.WithTenantMiddlewares(pm.Middlewares)),
 								logsv1.WithGlobalMiddleware(authentication.WithTenantHeader(cfg.logs.tenantHeader, tenantIDs)),
 								logsv1.WithReadMiddleware(authorization.WithLogsStreamSelectorsExtractor(logger, cfg.logs.authExtractSelectors)),
+								logsv1.WithReadMiddleware(authorization.WithLogsRulesSelectorsExtractor(logger, cfg.logs.authExtractSelectors)),
 								logsv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "logs")),
 								logsv1.WithReadMiddleware(logsv1.WithEnforceAuthorizationLabels()),
 								logsv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "logs")),


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/LOG-4530

With the introduced middleware in https://github.com/observatorium/api/pull/555 we did not contemplate the rules api which resulted in rules requests just being denied. This PR improves the pre-existing middleware by setting the selectors based on the URL parameters if no query parameter is found. 