### PR TITLE
Ensure correct labels values are added during ratelimiting

### DIFF
--- a/api/metrics/legacy/http.go
+++ b/api/metrics/legacy/http.go
@@ -141,23 +141,32 @@ func NewHandler(url *url.URL, upstreamCA []byte, upstreamCert *stdtls.Certificat
 	}
 
 	r.Group(func(r chi.Router) {
+		r.Use(func(handler http.Handler) http.Handler {
+			return server.InjectLabelsCtx(
+				prometheus.Labels{"group": "metricslegacy", "handler": "query"},
+				handler,
+			)
+		})
 		r.Use(c.queryMiddlewares...)
 		r.Handle(QueryRoute,
 			otelhttp.WithRouteTag(
 				c.spanRoutePrefix+QueryRoute,
-				server.InjectLabelsCtx(
-					prometheus.Labels{"group": "metricslegacy", "handler": "query"},
-					legacyProxy,
-				),
+				legacyProxy,
 			),
 		)
+	})
+	r.Group(func(r chi.Router) {
+		r.Use(func(handler http.Handler) http.Handler {
+			return server.InjectLabelsCtx(
+				prometheus.Labels{"group": "metricslegacy", "handler": "query_range"},
+				handler,
+			)
+		})
+		r.Use(c.queryMiddlewares...)
 		r.Handle(QueryRangeRoute,
 			otelhttp.WithRouteTag(
 				c.spanRoutePrefix+QueryRangeRoute,
-				server.InjectLabelsCtx(
-					prometheus.Labels{"group": "metricslegacy", "handler": "query_range"},
-					legacyProxy,
-				),
+				legacyProxy,
 			),
 		)
 	})

--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -213,24 +213,34 @@ func NewHandler(endpoints Endpoints, upstreamCA []byte, upstreamCert *stdtls.Cer
 			}
 		}
 		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "query"},
+					handler,
+				)
+			})
 			r.Use(c.queryMiddlewares...)
 			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
 			r.Handle(QueryRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+QueryRoute,
-					server.InjectLabelsCtx(
-						prometheus.Labels{"group": "metricsv1", "handler": "query"},
-						proxyQuery,
-					),
+					proxyQuery,
 				),
 			)
+		})
+		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "query_range"},
+					handler,
+				)
+			})
+			r.Use(c.queryMiddlewares...)
+			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
 			r.Handle(QueryRangeRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+QueryRangeRoute,
-					server.InjectLabelsCtx(
-						prometheus.Labels{"group": "metricsv1", "handler": "query_range"},
-						proxyQuery,
-					),
+					proxyQuery,
 				),
 			)
 		})
@@ -258,45 +268,69 @@ func NewHandler(endpoints Endpoints, upstreamCA []byte, upstreamCert *stdtls.Cer
 			}
 		}
 		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "series"},
+					handler,
+				)
+			})
 			r.Use(c.readMiddlewares...)
 			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
-			r.Handle(RulesRoute, otelhttp.WithRouteTag(c.spanRoutePrefix+RulesRoute, proxyRead))
 			r.Handle(SeriesRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+SeriesRoute,
-					server.InjectLabelsCtx(
-						prometheus.Labels{"group": "metricsv1", "handler": "series"},
-						proxyRead,
-					),
+					proxyRead,
 				),
 			)
+		})
+		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "label_names"},
+					handler,
+				)
+			})
+			r.Use(c.readMiddlewares...)
+			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
 			r.Handle(LabelNamesRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+LabelNamesRoute,
-					server.InjectLabelsCtx(
-						prometheus.Labels{"group": "metricsv1", "handler": "label_names"},
-						proxyRead,
-					),
+					proxyRead,
 				),
 			)
+		})
+		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "label_values"},
+					handler,
+				)
+			})
+			r.Use(c.readMiddlewares...)
+			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
 			r.Handle(LabelValuesRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+LabelValuesRoute,
-					server.InjectLabelsCtx(
-						prometheus.Labels{"group": "metricsv1", "handler": "label_values"},
-						proxyRead,
-					),
+					proxyRead,
 				),
 			)
+		})
+
+		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "rules"},
+					handler,
+				)
+			})
+			r.Use(c.readMiddlewares...)
+			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
 			// Thanos Query Rules API supports matchers from v0.25 so the WithEnforceTenancyOnMatchers
 			// middleware will not work here if prior versions are used.
 			r.Handle(RulesRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+RulesRoute,
-					server.InjectLabelsCtx(
-						prometheus.Labels{"group": "metricsv1", "handler": "rules"},
-						proxyRead,
-					),
+					proxyRead,
 				),
 			)
 		})
@@ -319,15 +353,18 @@ func NewHandler(endpoints Endpoints, upstreamCA []byte, upstreamCert *stdtls.Cer
 			}
 		}
 		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "ui"},
+					handler,
+				)
+			})
 			r.Use(c.uiMiddlewares...)
 			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
 			r.Mount(UIRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+UIRoute,
-					server.InjectLabelsCtx(
-						prometheus.Labels{"group": "metricsv1", "handler": "ui"},
-						uiProxy,
-					),
+					uiProxy,
 				),
 			)
 		})
@@ -357,15 +394,18 @@ func NewHandler(endpoints Endpoints, upstreamCA []byte, upstreamCert *stdtls.Cer
 			}
 		}
 		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "receive"},
+					handler,
+				)
+			})
 			r.Use(c.writeMiddlewares...)
 			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
 			r.Handle(ReceiveRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+ReceiveRoute,
-					server.InjectLabelsCtx(
-						prometheus.Labels{"group": "metricsv1", "handler": "receive"},
-						proxyWrite,
-					),
+					proxyWrite,
 				),
 			)
 		})
@@ -381,29 +421,35 @@ func NewHandler(endpoints Endpoints, upstreamCA []byte, upstreamCert *stdtls.Cer
 		rh := rulesHandler{client: client, logger: c.logger, tenantLabel: c.tenantLabel}
 
 		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "rules"},
+					handler,
+				)
+			})
 			r.Use(c.uiMiddlewares...)
 			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
 			r.Method(http.MethodGet, RulesRawRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+RulesRawRoute,
-					server.InjectLabelsCtx(
-						prometheus.Labels{"group": "metricsv1", "handler": "rules"},
-						http.HandlerFunc(rh.get),
-					),
+					http.HandlerFunc(rh.get),
 				),
 			)
 		})
 
 		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "rules-raw"},
+					handler,
+				)
+			})
 			r.Use(c.writeMiddlewares...)
 			r.Use(server.StripTenantPrefix("/api/metrics/v1"))
 			r.Method(http.MethodPut, RulesRawRoute,
 				otelhttp.WithRouteTag(
 					c.spanRoutePrefix+RulesRawRoute,
-					server.InjectLabelsCtx(
-						prometheus.Labels{"group": "metricsv1", "handler": "rules-raw"},
-						http.HandlerFunc(rh.put),
-					),
+					http.HandlerFunc(rh.put),
 				),
 			)
 		})
@@ -434,41 +480,50 @@ func NewHandler(endpoints Endpoints, upstreamCA []byte, upstreamCert *stdtls.Cer
 		}
 
 		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "alerts"},
+					handler,
+				)
+			})
 			r.Use(c.alertmanagerMiddleware.alertsReadMiddlewares...)
 			r.Use(server.StripTenantPrefixWithSubRoute("/api/metrics/v1", "/am"))
 
 			r.Method(http.MethodGet, AlertmanagerAlertsRoute, otelhttp.WithRouteTag(
 				c.spanRoutePrefix+AlertmanagerAlertsRoute,
-				server.InjectLabelsCtx(
-					prometheus.Labels{"group": "metricsv1", "handler": "alerts"},
-					proxyAlertmanager,
-				),
+				proxyAlertmanager,
 			))
 		})
 
 		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "silences"},
+					handler,
+				)
+			})
 			r.Use(c.alertmanagerMiddleware.silenceReadMiddlewares...)
 			r.Use(server.StripTenantPrefixWithSubRoute("/api/metrics/v1", "/am"))
 
 			r.Method(http.MethodGet, AlertmanagerSilencesRoute, otelhttp.WithRouteTag(
 				c.spanRoutePrefix+AlertmanagerSilencesRoute,
-				server.InjectLabelsCtx(
-					prometheus.Labels{"group": "metricsv1", "handler": "silences"},
-					proxyAlertmanager,
-				),
+				proxyAlertmanager,
 			))
 		})
 
 		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "silences"},
+					handler,
+				)
+			})
 			r.Use(c.alertmanagerMiddleware.silenceWriteMiddlewares...)
 			r.Use(server.StripTenantPrefixWithSubRoute("/api/metrics/v1", "/am"))
 
 			r.Method(http.MethodPost, AlertmanagerSilencesRoute, otelhttp.WithRouteTag(
 				c.spanRoutePrefix+AlertmanagerSilencesRoute,
-				server.InjectLabelsCtx(
-					prometheus.Labels{"group": "metricsv1", "handler": "silences"},
-					proxyAlertmanager,
-				),
+				proxyAlertmanager,
 			))
 		})
 	}

--- a/ratelimit/http.go
+++ b/ratelimit/http.go
@@ -127,7 +127,6 @@ func (l rateLimiter) Handler(next http.Handler) http.Handler {
 			httperr.PrometheusAPIError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-
 		next.ServeHTTP(w, r)
 	})
 }

--- a/ratelimit/http_test.go
+++ b/ratelimit/http_test.go
@@ -111,9 +111,11 @@ func TestWithLocalRateLimiter(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			r := chi.NewMux()
+
 			reg := prometheus.NewRegistry()
 			hardcodedLabels := []string{"group", "handler"}
 			f := server.NewInstrumentedHandlerFactory(reg, hardcodedLabels)
+
 			rlmw := WithLocalRateLimiter(c.configs...)
 			r.Use(func(handler http.Handler) http.Handler {
 				return f.NewHandler(nil, handler)


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOBS-914

Currently, Obs API does not have good per-tenant instrumentation to visualize requests that get rejected early (due to rate limits or other cases)

The issue is that when the rate limit middleware or other middlewares return on error, the context does not hold information about the group or handler as the labels are set when the route is handled at the end. So when the control returns back to the instrumentation handler ([line101](https://github.com/observatorium/api/blob/56abe030cbbe3e50a614dacf793fa673317b937b/server/http_instrumentation.go#L101)) the context does not hold the label values and will be reported as `unknown`. 

With this PR we ensure that the labels are set with the group and handler in context before the middlewares run and the instrumentation handler can pick up the values