### PR TITLE
Show an error message if access is denied

### DIFF
--- a/authorization/http.go
+++ b/authorization/http.go
@@ -24,7 +24,7 @@ const (
 	authorizationSelectorsKey contextKey = "authzQuerySelectors"
 
 	// errorMessageForbidden is the error message presented to the user if the user doesn't have
-	// sufficient permissions to access the requested tenant
+	// sufficient permissions to access the requested tenant.
 	errorMessageForbidden string = "You don't have permission to access this tenant"
 )
 


### PR DESCRIPTION
Currently the user sees a blank page when accessing Jaeger UI, if the current user doesn't have permissions to access the specified tenant.

This PR shows the following error message instead:
```
{"error":"You don't have permission to access this tenant","errorType":"observatorium-api","status":"error"}
```

and this message for generic errors returned by Authorizer.Authorize():
```
{"error":"<status code> <status text>","errorType":"observatorium-api","status":"error"}
