### PR TITLE
Add OTLP HTTP for traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,10 @@ Usage of ./observatorium-api:
     	File containing the TLS client key to authenticate against upstream traces servers. Leave blank to disable mTLS.
   -traces.write-timeout duration
     	The HTTP write timeout for proxied requests to the traces endpoint. (default 2m0s)
-  -traces.write.endpoint string
-    	The endpoint against which to make gRPC write requests for traces.
+  -traces.write.otlpgrpc.endpoint string
+    	The endpoint against which to make OTLP gRPC write requests for traces.
+  -traces.write.otlphttp.endpoint string
+    	The endpoint against which to make OTLP HTTP write requests for traces.
   -web.healthchecks.url string
     	The URL against which to run healthchecks. (default "http://localhost:8080")
   -web.internal.listen string

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -210,13 +210,10 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, writeOTLPH
 			Director:  middlewares,
 			ErrorLog:  proxy.Logger(c.logger),
 			Transport: otelhttp.NewTransport(t),
-
-			// This is a key piece, it changes <base href=> tags on text/html content
-			ModifyResponse: jaegerUIResponseModifier,
 		}
 
 		r.Group(func(r chi.Router) {
-			r.Use(c.tempoMiddlewares...)
+			r.Use(c.writeMiddlewares...)
 			r.Post("/v1/traces", c.instrument.NewHandler(
 				prometheus.Labels{"group": "tracesotlphttpv1api", "handler": "traces"},
 				proxyOTLP))

--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -109,7 +109,7 @@ func (n nopInstrumentHandler) NewHandler(labels prometheus.Labels, handler http.
 // The web UI handler is able to rewrite
 // HTML to change the <base> attribute so that it works with the Observatorium-style
 // "/api/v1/traces/{tenant}/" URLs.
-func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, upstreamCA []byte, upstreamCert *stdtls.Certificate, opts ...HandlerOption) http.Handler {
+func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, writeOTLPHttp *url.URL, upstreamCA []byte, upstreamCert *stdtls.Certificate, opts ...HandlerOption) http.Handler {
 
 	if read == nil && readTemplate == "" && tempo == nil {
 		panic("missing Jaeger read url")
@@ -189,6 +189,39 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, upstreamCA
 				prometheus.Labels{"group": "tracesv1ui", "handler": "ui"},
 				proxyRead))
 		})
+	}
+
+	if writeOTLPHttp != nil {
+		middlewares := proxy.Middlewares(
+			proxy.MiddlewareSetUpstream(writeOTLPHttp),
+			proxy.MiddlewareSetPrefixHeader(),
+			proxy.MiddlewareLogger(c.logger),
+			middlewareMetrics,
+		)
+
+		t := &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: dialTimeout,
+			}).DialContext,
+			TLSClientConfig: tls.NewClientConfig(upstreamCA, upstreamCert),
+		}
+
+		proxyOTLP := &httputil.ReverseProxy{
+			Director:  middlewares,
+			ErrorLog:  proxy.Logger(c.logger),
+			Transport: otelhttp.NewTransport(t),
+
+			// This is a key piece, it changes <base href=> tags on text/html content
+			ModifyResponse: jaegerUIResponseModifier,
+		}
+
+		r.Group(func(r chi.Router) {
+			r.Use(c.tempoMiddlewares...)
+			r.Post("/v1/traces", c.instrument.NewHandler(
+				prometheus.Labels{"group": "tracesotlphttpv1api", "handler": "traces"},
+				proxyOTLP))
+		})
+
 	}
 
 	// if tempo upstream is enabled, configure proxy and route

--- a/test/e2e/configs.go
+++ b/test/e2e/configs.go
@@ -228,15 +228,17 @@ func createRulesYAML(
 
 const otelConfigTpl = `
 receivers:
-    otlp/grpc:
+    otlp:
       protocols:
         grpc:
             endpoint: "0.0.0.0:4317"
+        http:
+            endpoint: "0.0.0.0:4318"
 
 exporters:
-    logging:
-        logLevel: debug
-    jaeger:
+    debug:
+        verbosity: detailed
+    otlp:
         endpoint: %[1]s
         tls:
           insecure: true
@@ -250,8 +252,8 @@ service:
 
     pipelines:
         traces/grpc:
-            receivers: [otlp/grpc]
-            exporters: [logging,jaeger]
+            receivers: [otlp]
+            exporters: [debug,otlp]
 `
 
 // createOtelCollectorConfigYAML() creates YAML for an Open Telemetry collector inside the Observatorium API boundary.
@@ -288,8 +290,8 @@ receivers:
             endpoint: 0.0.0.0:4317
 
 exporters:
-    logging:
-      logLevel: debug
+    debug:
+      verbosity: detailed
     otlp:
       endpoint: %[1]s
       # auth:
@@ -310,12 +312,13 @@ service:
     extensions: [health_check]
     telemetry:
       metrics:
-        address: localhost:8889
+        address: :8888
+        level: detailed
     # extensions: [oauth2client]
     pipelines:
       traces:
         receivers: [otlp]
-        exporters: [logging,otlp]
+        exporters: [debug,otlp]
 `
 
 // createOtelForwardingCollectorConfigYAML() creates YAML for an Open Telemetry collector outside the

--- a/test/e2e/interactive_test.go
+++ b/test/e2e/interactive_test.go
@@ -23,7 +23,7 @@ func TestInteractiveSetup(t *testing.T) {
 	readEndpoint, writeEndpoint, readExtEndpoint := startServicesForMetrics(t, e)
 	logsEndpoint, logsExtEndpoint := startServicesForLogs(t, e)
 	rulesEndpoint := startServicesForRules(t, e)
-	internalOtlpEndpoint, httpExternalQueryEndpoint, httpInternalQueryEndpoint := startServicesForTraces(t, e)
+	internalOTLPGRPCEndpoint, internalOTLPHTTPEndpoint, httpExternalQueryEndpoint, httpInternalQueryEndpoint := startServicesForTraces(t, e)
 
 	api, err := newObservatoriumAPIService(
 		e,
@@ -32,7 +32,8 @@ func TestInteractiveSetup(t *testing.T) {
 		withRulesEndpoint("http://"+rulesEndpoint),
 		withRateLimiter(rateLimiterAddr),
 		withGRPCListenEndpoint(":8317"),
-		withOtelTraceEndpoint(internalOtlpEndpoint),
+		withOTLPGRPCTraceEndpoint(internalOTLPGRPCEndpoint),
+		withOTLPHTTPTraceEndpoint(internalOTLPHTTPEndpoint),
 		withJaegerEndpoint("http://"+httpInternalQueryEndpoint),
 	)
 	testutil.Ok(t, err)

--- a/test/e2e/services.go
+++ b/test/e2e/services.go
@@ -26,14 +26,9 @@ const (
 	upImage           = "quay.io/observatorium/up:master-2022-10-27-d8bb06f"
 	alertmanagerImage = "quay.io/prometheus/alertmanager:v0.25.0"
 
-	jaegerAllInOneImage = "jaegertracing/all-in-one:1.31"
-	otelCollectorImage  = "otel/opentelemetry-collector:0.45.0"
+	jaegerAllInOneImage = "jaegertracing/all-in-one:1.57.0"
+	otelCollectorImage  = "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.101.0"
 	tempoImage          = "grafana/tempo:2.2.4"
-
-	// Note that if the forwarding collector uses OIDC flow instead of hard-coding
-	// the bearer token we would need
-	// "otel/opentelemetry-collector-contrib:0.45.0" instead.
-	otelFwdCollectorImage = "otel/opentelemetry-collector:0.45.0"
 
 	dexImage              = "dexidp/dex:v2.30.0"
 	opaImage              = "openpolicyagent/opa:0.47.4-static"
@@ -96,16 +91,16 @@ func startServicesForLogs(t *testing.T, e e2e.Environment) (
 	return loki.InternalEndpoint("http"), loki.Endpoint("http")
 }
 
-func startServicesForTraces(t *testing.T, e e2e.Environment) (otlpGRPCEndpoint, jaegerExternalHttpEndpoint, jaegerInternalHttpEndpoint string) {
+func startServicesForTraces(t *testing.T, e e2e.Environment) (otlpGRPCEndpoint, otlpHTTPEndpoint, jaegerExternalHttpEndpoint, jaegerInternalHttpEndpoint string) {
 	prometheus := e2edb.NewPrometheus(e, "prometheus")
 	testutil.Ok(t, e2e.StartAndWaitReady(prometheus))
 
 	jaeger := e.Runnable("jaeger").
 		WithPorts(
 			map[string]int{
-				"jaeger.grpc": 14250, // Receives traces
-				"grpc.query":  16685, // Query
-				"http.query":  16686, // Query
+				"otlp.grpc":  4317,  // Receiving traces
+				"grpc.query": 16685, // Query
+				"http.query": 16686, // Query
 			}).
 		Init(e2e.StartOptions{
 			Image:   jaegerAllInOneImage,
@@ -115,7 +110,7 @@ func startServicesForTraces(t *testing.T, e e2e.Environment) (otlpGRPCEndpoint, 
 			},
 		})
 
-	createOtelCollectorConfigYAML(t, e, jaeger.InternalEndpoint("jaeger.grpc"))
+	createOtelCollectorConfigYAML(t, e, jaeger.InternalEndpoint("otlp.grpc"))
 
 	otel := e.Runnable("otel-collector").
 		WithPorts(
@@ -139,7 +134,7 @@ func startServicesForTraces(t *testing.T, e e2e.Environment) (otlpGRPCEndpoint, 
 	testutil.Ok(t, e2e.StartAndWaitReady(jaeger))
 	testutil.Ok(t, e2e.StartAndWaitReady(otel))
 
-	return otel.InternalEndpoint("grpc"), jaeger.Endpoint("http.query"), jaeger.InternalEndpoint("http.query")
+	return otel.InternalEndpoint("grpc"), otel.InternalEndpoint("http"), jaeger.Endpoint("http.query"), jaeger.InternalEndpoint("http.query")
 }
 
 func startTempoServicesForTraces(t *testing.T, e e2e.Environment) (tempoDistributorEndpoint, internalTempoQueryEndpoint, tempoQueryEndpoint string) {
@@ -348,16 +343,17 @@ func newOPAService(e e2e.Environment) *e2emon.InstrumentedRunnable {
 }
 
 type apiOptions struct {
-	logsEndpoint         string
-	metricsReadEndpoint  string
-	metricsWriteEndpoint string
-	metricsRulesEndpoint string
-	alertmanagerEndpoint string
-	ratelimiterAddr      string
-	tracesWriteEndpoint  string
-	gRPCListenEndpoint   string
-	jaegerQueryEndpoint  string
-	tempoEndpoint        string
+	logsEndpoint                string
+	metricsReadEndpoint         string
+	metricsWriteEndpoint        string
+	metricsRulesEndpoint        string
+	alertmanagerEndpoint        string
+	ratelimiterAddr             string
+	tracesWriteOTLPGRPCEndpoint string
+	tracesWriteOTLPHTTPEndpoint string
+	gRPCListenEndpoint          string
+	jaegerQueryEndpoint         string
+	tempoEndpoint               string
 
 	// "experimental.traces.read.endpoint-template" value.
 	tracesExperimentalTemplateReadEndpoint string
@@ -378,9 +374,15 @@ func withMetricsEndpoints(readEndpoint string, writeEndpoint string) apiOption {
 	}
 }
 
-func withOtelTraceEndpoint(exportEndpoint string) apiOption {
+func withOTLPGRPCTraceEndpoint(exportEndpoint string) apiOption {
 	return func(o *apiOptions) {
-		o.tracesWriteEndpoint = exportEndpoint
+		o.tracesWriteOTLPGRPCEndpoint = exportEndpoint
+	}
+}
+
+func withOTLPHTTPTraceEndpoint(exportEndpoint string) apiOption {
+	return func(o *apiOptions) {
+		o.tracesWriteOTLPHTTPEndpoint = exportEndpoint
 	}
 }
 
@@ -476,8 +478,11 @@ func newObservatoriumAPIService(
 		args = append(args, "--middleware.rate-limiter.grpc-address="+opts.ratelimiterAddr)
 	}
 
-	if opts.tracesWriteEndpoint != "" {
-		args = append(args, "--traces.write.endpoint="+opts.tracesWriteEndpoint)
+	if opts.tracesWriteOTLPGRPCEndpoint != "" {
+		args = append(args, "--traces.write.otlpgrpc.endpoint="+opts.tracesWriteOTLPGRPCEndpoint)
+	}
+	if opts.tracesWriteOTLPHTTPEndpoint != "" {
+		args = append(args, "--traces.write.otlphttp.endpoint="+opts.tracesWriteOTLPHTTPEndpoint)
 	}
 
 	if opts.tracesExperimentalTemplateReadEndpoint != "" {

--- a/test/e2e/traces_test.go
+++ b/test/e2e/traces_test.go
@@ -19,53 +19,128 @@ import (
 )
 
 const (
-	traceJSON = `
+	traceJSON5B = `
 {
-	"resource_spans": [
-	{
-		"resource": {
-		"attributes": [
-			{
-			"key": "host.name",
-			"value": { "stringValue": "testHost" }
-			}
-		]
-		},
-		"instrumentation_library_spans": [
-		{
-			"spans": [
-			{
-				"trace_id": "5B8EFFF798038103D269B633813FC60C",
-				"span_id": "EEE19B7EC3C1B173",
-				"name": "testSpan",
-				"start_time_unix_nano": 1544712660000000000,
-				"end_time_unix_nano": 1544712661000000000,
-				"attributes": [
-				{
-					"key": "attr1",
-					"value": { "intValue": 55 }
-				}
-				]
-			}
-			]
-		}
-		]
-	}
-	]
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "my.service"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "some scope attribute"
+                }
+              }
+            ]
+          },
+          "spans": [
+            {
+              "traceId": "5B8EFFF798038103D269B633813FC60C",
+              "spanId": "EEE19B7EC3C1B174",
+              "parentSpanId": "EEE19B7EC3C1B173",
+              "name": "I'm a server span",
+              "startTimeUnixNano": "1544712660000000000",
+              "endTimeUnixNano": "1544712661000000000",
+              "kind": 2,
+              "attributes": [
+                {
+                  "key": "my.span.attr",
+                  "value": {
+                    "stringValue": "some value"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}`
+
+	traceJSON6B = `
+{
+  "resourceSpans": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "service.name",
+            "value": {
+              "stringValue": "my.service"
+            }
+          }
+        ]
+      },
+      "scopeSpans": [
+        {
+          "scope": {
+            "name": "my.library",
+            "version": "1.0.0",
+            "attributes": [
+              {
+                "key": "my.scope.attribute",
+                "value": {
+                  "stringValue": "some scope attribute"
+                }
+              }
+            ]
+          },
+          "spans": [
+            {
+              "traceId": "6B8EFFF798038103D269B633813FC60C",
+              "spanId": "EEE19B7EC3C1B174",
+              "parentSpanId": "EEE19B7EC3C1B173",
+              "name": "I'm a server span",
+              "startTimeUnixNano": "1544712660000000000",
+              "endTimeUnixNano": "1544712661000000000",
+              "kind": 2,
+              "attributes": [
+                {
+                  "key": "my.span.attr",
+                  "value": {
+                    "stringValue": "some value"
+                  }
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
 }`
 
 	//nolint:lll
 	// queriedV3Trace is traceJSON returned through Jaeger's V3 API.
-	queriedV3Trace = `{"result":{"resourceSpans":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"testHost"}}]},"instrumentationLibrarySpans":[{"instrumentationLibrary":{},"spans":[{"traceId":"W47/95gDgQPSabYzgT/GDA==","spanId":"7uGbfsPBsXM=","parentSpanId":"AAAAAAAAAAA=","name":"testSpan","kind":"SPAN_KIND_INTERNAL","startTimeUnixNano":"1544712660000000000","endTimeUnixNano":"1544712661000000000","attributes":[{"key":"attr1","value":{"intValue":"55"}},{"key":"internal.span.format","value":{"stringValue":"proto"}}]}]}]}]}}`
+	queriedV3Trace5B = `{"result":{"resourceSpans":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"my.service"}}]},"scopeSpans":[{"scope":{"name":"my.library","version":"1.0.0"},"spans":[{"traceId":"5b8efff798038103d269b633813fc60c","spanId":"eee19b7ec3c1b174","parentSpanId":"eee19b7ec3c1b173","name":"I'm a server span","kind":2,"startTimeUnixNano":"1544712660000000000","endTimeUnixNano":"1544712661000000000","attributes":[{"key":"my.span.attr","value":{"stringValue":"some value"}},{"key":"internal.span.format","value":{"stringValue":"otlp"}}],"status":{}}]}]}]}}`
 
 	//nolint:lll
 	// queriedV2Trace is traceJSON returned through Jaeger's V2 API.
-	queriedV2Trace = `{"data":[{"traceID":"5b8efff798038103d269b633813fc60c","spans":[{"traceID":"5b8efff798038103d269b633813fc60c","spanID":"eee19b7ec3c1b173","operationName":"testSpan","references":[],"startTime":1544712660000000,"duration":1000000,"tags":[{"key":"attr1","type":"int64","value":55},{"key":"internal.span.format","type":"string","value":"proto"}],"logs":[],"processID":"p1","warnings":null}],"processes":{"p1":{"serviceName":"","tags":[{"key":"host.name","type":"string","value":"testHost"}]}},"warnings":null}],"total":0,"limit":0,"offset":0,"errors":null}`
+	queriedV2Trace5B = `{"data":[{"traceID":"5b8efff798038103d269b633813fc60c","spans":[{"traceID":"5b8efff798038103d269b633813fc60c","spanID":"eee19b7ec3c1b174","operationName":"I'm a server span","references":[{"refType":"CHILD_OF","traceID":"5b8efff798038103d269b633813fc60c","spanID":"eee19b7ec3c1b173"}],"startTime":1544712660000000,"duration":1000000,"tags":[{"key":"my.span.attr","type":"string","value":"some value"},{"key":"span.kind","type":"string","value":"server"},{"key":"internal.span.format","type":"string","value":"otlp"}],"logs":[],"processID":"p1","warnings":["invalid parent span IDs=eee19b7ec3c1b173; skipping clock skew adjustment"]}],"processes":{"p1":{"serviceName":"my.service","tags":[{"key":"otel.library.name","type":"string","value":"my.library"},{"key":"otel.library.version","type":"string","value":"1.0.0"}]}},"warnings":null}],"total":0,"limit":0,"offset":0,"errors":null}`
+
+	//nolint:lll
+	// queriedV2Trace is traceJSON returned through Jaeger's V2 API.
+	queriedV2Trace6B = `{"data":[{"traceID":"6b8efff798038103d269b633813fc60c","spans":[{"traceID":"6b8efff798038103d269b633813fc60c","spanID":"eee19b7ec3c1b174","operationName":"I'm a server span","references":[{"refType":"CHILD_OF","traceID":"6b8efff798038103d269b633813fc60c","spanID":"eee19b7ec3c1b173"}],"startTime":1544712660000000,"duration":1000000,"tags":[{"key":"my.span.attr","type":"string","value":"some value"},{"key":"span.kind","type":"string","value":"server"},{"key":"internal.span.format","type":"string","value":"otlp"}],"logs":[],"processID":"p1","warnings":["invalid parent span IDs=eee19b7ec3c1b173; skipping clock skew adjustment"]}],"processes":{"p1":{"serviceName":"my.service","tags":[{"key":"otel.library.name","type":"string","value":"my.library"},{"key":"otel.library.version","type":"string","value":"1.0.0"}]}},"warnings":null}],"total":0,"limit":0,"offset":0,"errors":null}`
 
 	// queriedV2Dependencies is dependencies JSON returned through Jaeger's V2 API.
 	queriedV2Dependencies = `{"data":[],"total":0,"limit":0,"offset":0,"errors":null}`
 
-	tempoTraceResponse = `{"batches":[{"resource":{"attributes":[{"key":"host.name","value":{"stringValue":"testHost"}}]},"scopeSpans":[{"scope":{},"spans":[{"traceId":"W47/95gDgQPSabYzgT/GDA==","spanId":"7uGbfsPBsXM=","name":"testSpan","startTimeUnixNano":"1544712660000000000","endTimeUnixNano":"1544712661000000000","attributes":[{"key":"attr1","value":{"intValue":"55"}}],"status":{}}]}]}]}`
+	tempoTraceResponse5B = `{"batches":[{"resource":{"attributes":[{"key":"service.name","value":{"stringValue":"my.service"}}]},"scopeSpans":[{"scope":{"name":"my.library","version":"1.0.0"},"spans":[{"traceId":"W47/95gDgQPSabYzgT/GDA==","spanId":"7uGbfsPBsXQ=","parentSpanId":"7uGbfsPBsXM=","name":"I'm a server span","kind":"SPAN_KIND_SERVER","startTimeUnixNano":"1544712660000000000","endTimeUnixNano":"1544712661000000000","attributes":[{"key":"my.span.attr","value":{"stringValue":"some value"}}],"status":{}}]}]}]}`
 )
 
 func TestTracesExport(t *testing.T) {
@@ -77,12 +152,13 @@ func TestTracesExport(t *testing.T) {
 
 	prepareConfigsAndCerts(t, traces, e)
 	_, token, _ := startBaseServices(t, e, traces)
-	internalOtlpEndpoint, httpExternalQueryEndpoint, httpInternalQueryEndpoint := startServicesForTraces(t, e)
+	internalOTLPGRPCEndpoint, internalOTLPHTTPEndpoint, httpExternalQueryEndpoint, httpInternalQueryEndpoint := startServicesForTraces(t, e)
 
 	api, err := newObservatoriumAPIService(
 		e,
 		withGRPCListenEndpoint(":8317"),
-		withOtelTraceEndpoint(internalOtlpEndpoint),
+		withOTLPGRPCTraceEndpoint(internalOTLPGRPCEndpoint),
+		withOTLPHTTPTraceEndpoint("http://"+internalOTLPHTTPEndpoint),
 		withJaegerEndpoint("http://"+httpInternalQueryEndpoint),
 
 		// This test doesn't actually write logs, but we need
@@ -92,8 +168,7 @@ func TestTracesExport(t *testing.T) {
 	testutil.Ok(t, err)
 	testutil.Ok(t, e2e.StartAndWaitReady(api))
 
-	t.Run("write-then-query-single-trace", func(t *testing.T) {
-
+	t.Run("write-grpc-then-query-single-trace", func(t *testing.T) {
 		createOtelForwardingCollectorConfigYAML(t, e,
 			api.InternalEndpoint("grpc"),
 			token)
@@ -104,9 +179,10 @@ func TestTracesExport(t *testing.T) {
 					"http":         4318,
 					"grpc":         4317,
 					"health_check": 13133,
+					"telemetry":    8889,
 				}).
 			Init(e2e.StartOptions{
-				Image: otelFwdCollectorImage,
+				Image: otelCollectorImage,
 				Volumes: []string{
 					fmt.Sprintf("%s:/conf/forwarding-collector.yaml",
 						filepath.Join(filepath.Join(e.SharedDir(), configSharedDir, "forwarding-collector.yaml"))),
@@ -131,7 +207,7 @@ func TestTracesExport(t *testing.T) {
 		request, err := http.NewRequest(
 			"POST",
 			fmt.Sprintf("http://%s/v1/traces", otel.Endpoint("http")),
-			bytes.NewBuffer([]byte(traceJSON)))
+			bytes.NewBuffer([]byte(traceJSON5B)))
 		testutil.Ok(t, err)
 		request.Header.Set("Content-Type", "application/json")
 		response, err := client.Do(request)
@@ -148,12 +224,12 @@ func TestTracesExport(t *testing.T) {
 
 		returnedTrace := queryForTraceDirectV3(t,
 			httpExternalQueryEndpoint, "5B8EFFF798038103D269B633813FC60C")
-		assertResponse(t, returnedTrace, queriedV3Trace)
+		assertResponse(t, returnedTrace, queriedV3Trace5B)
 
 		returnedTrace, _ = queryForTraceV2(t, "direct Jaeger v2 query",
 			fmt.Sprintf("http://%s/api/traces", httpExternalQueryEndpoint), "5B8EFFF798038103D269B633813FC60C",
 			false, "", http.StatusOK)
-		assertResponse(t, returnedTrace, queriedV2Trace)
+		assertResponse(t, returnedTrace, queriedV2Trace5B)
 
 		httpObservatoriumQueryEndpoint := fmt.Sprintf("https://%s/api/traces/v1/test-oidc/api", api.Endpoint("https"))
 		httpObservatoriumQueryTraceEndpoint := fmt.Sprintf("%s/traces", httpObservatoriumQueryEndpoint)
@@ -162,7 +238,7 @@ func TestTracesExport(t *testing.T) {
 		returnedTrace, _ = queryForTraceV2(t, "valid Observatorium trace v2 query",
 			httpObservatoriumQueryTraceEndpoint, "5B8EFFF798038103D269B633813FC60C",
 			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
-		assertResponse(t, returnedTrace, queriedV2Trace)
+		assertResponse(t, returnedTrace, queriedV2Trace5B)
 
 		_, returnedStatus := queryForTraceV2(t, "invalid Observatorium trace v2 query",
 			httpObservatoriumQueryTraceEndpoint, "5B8EFFF798038103D269B633813FC60C",
@@ -172,7 +248,7 @@ func TestTracesExport(t *testing.T) {
 		returnedTrace, _ = queryForTraceV2(t, "direct Jaeger v2 query",
 			fmt.Sprintf("http://%s/api/traces", httpExternalQueryEndpoint), "5B8EFFF798038103D269B633813FC60C",
 			false, "", http.StatusOK)
-		assertResponse(t, returnedTrace, queriedV2Trace)
+		assertResponse(t, returnedTrace, queriedV2Trace5B)
 
 		_, returnedStatus = queryJaeger(t, "Observatorium services v2 query",
 			fmt.Sprintf("%s/services", httpObservatoriumQueryEndpoint),
@@ -190,6 +266,38 @@ func TestTracesExport(t *testing.T) {
 			fmt.Sprintf("%s/metrics/calls?service=doesnotexist", httpObservatoriumQueryEndpoint),
 			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
 		testutil.Equals(t, `{"name":"service_call_rate","type":"GAUGE","help":"calls/sec, grouped by service","metrics":[]}`, returnedMetrics)
+	})
+
+	t.Run("write-http-then-query-single-trace", func(t *testing.T) {
+		tlsClientConfig := getTLSClientConfig(t, e)
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: tlsClientConfig}}
+		request, err := http.NewRequest(
+			"POST",
+			fmt.Sprintf("https://%s/api/traces/v1/test-oidc/v1/traces", api.Endpoint("https")),
+			bytes.NewBuffer([]byte(traceJSON6B)))
+		testutil.Ok(t, err)
+		request.Header.Set("x-tenant", "test-oidc")
+		request.Header.Set("authorization", fmt.Sprintf("bearer %s", token))
+		request.Header.Set("Content-Type", "application/json")
+		response, err := client.Do(request)
+		testutil.Ok(t, err)
+		defer response.Body.Close()
+
+		body, err := io.ReadAll(response.Body)
+		testutil.Ok(t, err)
+
+		bodyStr := string(body)
+		assertResponse(t, bodyStr, "{\"partialSuccess\":{}}")
+		testutil.Equals(t, http.StatusOK, response.StatusCode)
+
+		httpObservatoriumQueryEndpoint := fmt.Sprintf("https://%s/api/traces/v1/test-oidc/api", api.Endpoint("https"))
+		httpObservatoriumQueryTraceEndpoint := fmt.Sprintf("%s/traces", httpObservatoriumQueryEndpoint)
+		// We skip TLS verification because Observatorium will present a cert for "e2e_traces_read_export-api",
+		// but we contact it using "localhost".
+		returnedTrace, _ := queryForTraceV2(t, "valid Observatorium trace v2 query",
+			httpObservatoriumQueryTraceEndpoint, "6B8EFFF798038103D269B633813FC60C",
+			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
+		assertResponse(t, returnedTrace, queriedV2Trace6B)
 	})
 }
 
@@ -299,13 +407,13 @@ func TestTracesTemplateQuery(t *testing.T) {
 
 	prepareConfigsAndCerts(t, tracesTemplate, e)
 	_, token, _ := startBaseServices(t, e, tracesTemplate)
-	internalOtlpEndpoint, httpExternalQueryEndpoint, httpInternalQueryEndpoint := startServicesForTraces(t, e)
+	internalOTLPGRPCEndpoint, _, httpExternalQueryEndpoint, httpInternalQueryEndpoint := startServicesForTraces(t, e)
 
 	api, err := newObservatoriumAPIService(
 		e,
 		withGRPCListenEndpoint(":8317"),
 		// Note that we don't include `{tenant}`, because we can't easily do this with DNS on Docker.
-		withOtelTraceEndpoint(internalOtlpEndpoint),
+		withOTLPGRPCTraceEndpoint(internalOTLPGRPCEndpoint),
 		withExperimentalJaegerTemplateEndpoint("http://"+httpInternalQueryEndpoint),
 
 		// This test doesn't actually write logs, but we need
@@ -328,7 +436,7 @@ func TestTracesTemplateQuery(t *testing.T) {
 					"health_check": 13133,
 				}).
 			Init(e2e.StartOptions{
-				Image: otelFwdCollectorImage,
+				Image: otelCollectorImage,
 				Volumes: []string{
 					fmt.Sprintf("%s:/conf/forwarding-collector.yaml",
 						filepath.Join(filepath.Join(e.SharedDir(), configSharedDir, "forwarding-collector.yaml"))),
@@ -353,7 +461,7 @@ func TestTracesTemplateQuery(t *testing.T) {
 		request, err := http.NewRequest(
 			"POST",
 			fmt.Sprintf("http://%s/v1/traces", otel.Endpoint("http")),
-			bytes.NewBuffer([]byte(traceJSON)))
+			bytes.NewBuffer([]byte(traceJSON5B)))
 		testutil.Ok(t, err)
 		request.Header.Set("Content-Type", "application/json")
 		response, err := client.Do(request)
@@ -370,12 +478,12 @@ func TestTracesTemplateQuery(t *testing.T) {
 
 		returnedTrace := queryForTraceDirectV3(t,
 			httpExternalQueryEndpoint, "5B8EFFF798038103D269B633813FC60C")
-		assertResponse(t, returnedTrace, queriedV3Trace)
+		assertResponse(t, returnedTrace, queriedV3Trace5B)
 
 		returnedTrace, _ = queryForTraceV2(t, "direct Jaeger v2 query",
 			fmt.Sprintf("http://%s/api/traces", httpExternalQueryEndpoint), "5B8EFFF798038103D269B633813FC60C",
 			false, "", http.StatusOK)
-		assertResponse(t, returnedTrace, queriedV2Trace)
+		assertResponse(t, returnedTrace, queriedV2Trace5B)
 
 		httpObservatoriumQueryEndpoint := fmt.Sprintf("https://%s/api/traces/v1/test-oidc/api", api.Endpoint("https"))
 		httpObservatoriumQueryTraceEndpoint := fmt.Sprintf("%s/traces", httpObservatoriumQueryEndpoint)
@@ -384,7 +492,7 @@ func TestTracesTemplateQuery(t *testing.T) {
 		returnedTrace, _ = queryForTraceV2(t, "valid Observatorium trace v2 query",
 			httpObservatoriumQueryTraceEndpoint, "5B8EFFF798038103D269B633813FC60C",
 			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
-		assertResponse(t, returnedTrace, queriedV2Trace)
+		assertResponse(t, returnedTrace, queriedV2Trace5B)
 
 		_, returnedStatus := queryForTraceV2(t, "invalid Observatorium trace v2 query",
 			httpObservatoriumQueryTraceEndpoint, "5B8EFFF798038103D269B633813FC60C",
@@ -394,7 +502,7 @@ func TestTracesTemplateQuery(t *testing.T) {
 		returnedTrace, _ = queryForTraceV2(t, "direct Jaeger v2 query",
 			fmt.Sprintf("http://%s/api/traces", httpExternalQueryEndpoint), "5B8EFFF798038103D269B633813FC60C",
 			false, "", http.StatusOK)
-		assertResponse(t, returnedTrace, queriedV2Trace)
+		assertResponse(t, returnedTrace, queriedV2Trace5B)
 
 		_, returnedStatus = queryJaeger(t, "Observatorium services v2 query",
 			fmt.Sprintf("%s/services", httpObservatoriumQueryEndpoint),
@@ -425,7 +533,7 @@ func TestTracesTempo(t *testing.T) {
 	api, err := newObservatoriumAPIService(
 		e,
 		withGRPCListenEndpoint(":8317"),
-		withOtelTraceEndpoint(tempoDistributorEndpoint),
+		withOTLPGRPCTraceEndpoint(tempoDistributorEndpoint),
 		withTempoEndpoint("http://"+internalTempoQueryEndpoint),
 
 		// This test doesn't actually write logs, but we need
@@ -447,9 +555,10 @@ func TestTracesTempo(t *testing.T) {
 					"http":         4318,
 					"grpc":         4317,
 					"health_check": 13133,
+					"telemetry":    8888,
 				}).
 			Init(e2e.StartOptions{
-				Image: otelFwdCollectorImage,
+				Image: otelCollectorImage,
 				Volumes: []string{
 					fmt.Sprintf("%s:/conf/forwarding-collector.yaml",
 						filepath.Join(filepath.Join(e.SharedDir(), configSharedDir, "forwarding-collector.yaml"))),
@@ -474,7 +583,7 @@ func TestTracesTempo(t *testing.T) {
 		request, err := http.NewRequest(
 			"POST",
 			fmt.Sprintf("http://%s/v1/traces", otel.Endpoint("http")),
-			bytes.NewBuffer([]byte(traceJSON)))
+			bytes.NewBuffer([]byte(traceJSON5B)))
 		testutil.Ok(t, err)
 		request.Header.Set("Content-Type", "application/json")
 		response, err := client.Do(request)
@@ -485,7 +594,7 @@ func TestTracesTempo(t *testing.T) {
 		testutil.Ok(t, err)
 
 		bodyStr := string(body)
-		assertResponse(t, bodyStr, "{}")
+		assertResponse(t, bodyStr, "{\"partialSuccess\":{}}")
 
 		testutil.Equals(t, http.StatusOK, response.StatusCode)
 
@@ -496,7 +605,7 @@ func TestTracesTempo(t *testing.T) {
 		returnedTrace, _ := queryForTraceTempo(t, "valid Observatorium trace tempo query",
 			httpObservatoriumTempoEndpoint, "5B8EFFF798038103D269B633813FC60C",
 			true, fmt.Sprintf("bearer %s", token), http.StatusOK)
-		assertResponse(t, returnedTrace, tempoTraceResponse)
+		assertResponse(t, returnedTrace, tempoTraceResponse5B)
 
 	})
 }


### PR DESCRIPTION
Notable changes:
* renames `traces.write.endpoint` to `traces.write.otlpgrpc.endpoint`
* adds `traces.write.otlphttp.endpoint` 
* updates tracing images in e2e tests