### PR TITLE
Add support for logs OTLP route

### DIFF
--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -36,6 +36,9 @@ const (
 	volumeRoute            = "/loki/api/v1/index/volume"
 	volumeRangeRoute       = "/loki/api/v1/index/volume_range"
 
+	otlpRoute = "/otlp/v1/logs"
+	pushRoute = "/loki/api/v1/push"
+
 	prometheusRulesRoute  = "/prometheus/api/v1/rules"
 	prometheusAlertsRoute = "/prometheus/api/v1/alerts"
 
@@ -397,7 +400,10 @@ func NewHandler(read, tail, write, rules *url.URL, rulesReadOnly bool, upstreamC
 		}
 		r.Group(func(r chi.Router) {
 			r.Use(c.writeMiddlewares...)
-			const pushRoute = "/loki/api/v1/push"
+			r.Handle(otlpRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "logsv1", "handler": "otlp"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+otlpRoute, proxyWrite),
+			))
 			r.Handle(pushRoute, c.instrument.NewHandler(
 				prometheus.Labels{"group": "logsv1", "handler": "push"},
 				otelhttp.WithRouteTag(c.spanRoutePrefix+pushRoute, proxyWrite),


### PR DESCRIPTION
The following PR enables the Loki OTLP route to allow ingesting logs through OTLP.

cc @pavolloffay 