### PR TITLE
Fix build tag on e2e test

### DIFF
--- a/test/e2e/redis_rate_limiter_test.go
+++ b/test/e2e/redis_rate_limiter_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package e2e
 
 import (


### PR DESCRIPTION
I might be wrong, but it looks to me as if one of the files in `test/e2e/` is missing the build tag that most of the others have.

I noticed this, because I tend to use `go test ./...` in most projects and this snagged on that file. I know that the workflow in this project is `make test-unit`, but it doesn't hurt when the language default continues to work.