### PR TITLE
Register missing Jaeger UI routes

### DIFF
--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -184,6 +184,15 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo *url.URL, writeOTLPH
 			r.Get("/search*", c.instrument.NewHandler(
 				prometheus.Labels{"group": "tracesv1ui", "handler": "ui"},
 				proxyRead))
+			r.Get("/trace/*", c.instrument.NewHandler(
+				prometheus.Labels{"group": "tracesv1ui", "handler": "ui"},
+				proxyRead))
+			r.Get("/dependencies", c.instrument.NewHandler(
+				prometheus.Labels{"group": "tracesv1ui", "handler": "ui"},
+				proxyRead))
+			r.Get("/monitor", c.instrument.NewHandler(
+				prometheus.Labels{"group": "tracesv1ui", "handler": "ui"},
+				proxyRead))
 			r.Get("/favicon.ico", c.instrument.NewHandler(
 				prometheus.Labels{"group": "tracesv1ui", "handler": "ui"},
 				proxyRead))


### PR DESCRIPTION
Without these routes, hitting refresh on the trace detail, system architecture or monitor page of Jaeger UI results in a 404.

Navigating to these pages from the /search page does work without this PR, because Jaeger UI is a single-page application. But hitting refresh doesn't work without this PR.

Ref. https://issues.redhat.com/browse/TRACING-4933

cc @rubenvp8510 