### PR TITLE
Adjust log level of 'fallback to read cookie, ...' log message

### DIFF
--- a/authentication/openshift.go
+++ b/authentication/openshift.go
@@ -433,7 +433,7 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 				return
 			}
 
-			level.Info(a.logger).Log("msg", "fallback to read cookie, no serviceaccount bearer token or mTLS certs provided")
+			level.Debug(a.logger).Log("msg", "fallback to read cookie, no serviceaccount bearer token or mTLS certs provided")
 
 			// Next try to authenticate a user via cookie. This case applies
 			// when users went through the OAuth2 flow supported by this


### PR DESCRIPTION
When accessing the Jaeger UI, cookies are used for authentication.
At the moment, every HTTP request to the Jaeger UI prints this message
in the logs:

    fallback to read cookie, no serviceaccount bearer token or mTLS certs provided

which may concern some users. Reading cookies is part of the normal operation,
therefore let's print this message only when the log level is set to debug.