### PR TITLE
Set minimum Go version to 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/observatorium/api
 
-go 1.23.0
+go 1.22.0
 
 require (
 	github.com/brancz/kube-rbac-proxy v0.16.1


### PR DESCRIPTION
Follow-up to #790 to be able to continue building with Go 1.22 

PTAL @pavolloffay @philipgough 