### PR TITLE
logs: re-introduce rules filtering for Prometheus API as this is still not supported by Loki

### DIFF
--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -58,6 +58,7 @@ type handlerConfiguration struct {
 	registry              *prometheus.Registry
 	instrument            handlerInstrumenter
 	spanRoutePrefix       string
+	rulesLabelFilters     map[string][]string
 	readMiddlewares       []func(http.Handler) http.Handler
 	writeMiddlewares      []func(http.Handler) http.Handler
 	rulesReadMiddlewares  []func(http.Handler) http.Handler
@@ -128,6 +129,13 @@ func WithGlobalMiddleware(m ...func(http.Handler) http.Handler) HandlerOption {
 	return func(h *handlerConfiguration) {
 		h.writeMiddlewares = append(h.writeMiddlewares, m...)
 		h.readMiddlewares = append(h.readMiddlewares, m...)
+	}
+}
+
+// WithRulesLabelFilters adds the slice of rule labels filters to the handler configuration.
+func WithRulesLabelFilters(f map[string][]string) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.rulesLabelFilters = f
 	}
 }
 
@@ -231,7 +239,7 @@ func NewHandler(read, tail, write, rules *url.URL, rulesReadOnly bool, tlsOption
 	}
 
 	if rules != nil {
-		var proxyRules http.Handler
+		var proxyRules, proxyPrometheusReadRules http.Handler
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(rules),
@@ -247,11 +255,18 @@ func NewHandler(read, tail, write, rules *url.URL, rulesReadOnly bool, tlsOption
 				TLSClientConfig: tlsOptions.NewClientConfig(),
 			}
 
+			proxyPrometheusReadRules = &httputil.ReverseProxy{
+				Director:       middlewares,
+				ErrorLog:       proxy.Logger(c.logger),
+				Transport:      otelhttp.NewTransport(t),
+				ModifyResponse: newModifyResponseProm(c.logger, c.rulesLabelFilters),
+			}
 			proxyRules = &httputil.ReverseProxy{
 				Director:  middlewares,
 				ErrorLog:  proxy.Logger(c.logger),
 				Transport: otelhttp.NewTransport(t),
 			}
+
 		}
 		r.Group(func(r chi.Router) {
 			r.Use(c.readMiddlewares...)
@@ -270,11 +285,11 @@ func NewHandler(read, tail, write, rules *url.URL, rulesReadOnly bool, tlsOption
 			))
 			r.Get(prometheusRulesRoute, c.instrument.NewHandler(
 				prometheus.Labels{"group": "logsv1", "handler": "rules"},
-				otelhttp.WithRouteTag(c.spanRoutePrefix+prometheusRulesRoute, proxyRules),
+				otelhttp.WithRouteTag(c.spanRoutePrefix+prometheusRulesRoute, proxyPrometheusReadRules),
 			))
 			r.Get(prometheusAlertsRoute, c.instrument.NewHandler(
 				prometheus.Labels{"group": "logsv1", "handler": "alerts"},
-				otelhttp.WithRouteTag(c.spanRoutePrefix+prometheusAlertsRoute, proxyRules),
+				otelhttp.WithRouteTag(c.spanRoutePrefix+prometheusAlertsRoute, proxyPrometheusReadRules),
 			))
 			r.Get(promRulesRoute, c.instrument.NewHandler(
 				prometheus.Labels{"group": "logsv1", "handler": "rules"},

--- a/api/logs/v1/rules_prometheus_labels_enforcer.go
+++ b/api/logs/v1/rules_prometheus_labels_enforcer.go
@@ -20,8 +20,8 @@ import (
 const contentTypeApplicationJSON = "application/json"
 
 var (
-	errUnknownTenantKey        = errors.New("Unknown tenant key")
-	errUnknownRulesContentType = errors.New("Unknown rules response content type")
+	errUnknownTenantKey        = errors.New("unknown tenant key")
+	errUnknownRulesContentType = errors.New("unknown rules response content type")
 )
 
 type alert struct {
@@ -253,9 +253,9 @@ func filterPrometheusRuleGroups(groups []*ruleGroup, matchers map[string]string)
 
 	for _, group := range groups {
 		var filteredRules []rule
-		for _, rule := range group.Rules {
-			if hasMatchingLabels(&rule, matchers) {
-				filteredRules = append(filteredRules, rule)
+		for _, r := range group.Rules {
+			if hasMatchingLabels(&r, matchers) {
+				filteredRules = append(filteredRules, r)
 			}
 		}
 
@@ -270,9 +270,9 @@ func filterPrometheusRuleGroups(groups []*ruleGroup, matchers map[string]string)
 
 func filterPrometheusAlerts(alerts []*alert, matchers map[string]string) []*alert {
 	var filtered []*alert
-	for _, alert := range alerts {
-		if hasMatchingLabels(alert, matchers) {
-			filtered = append(filtered, alert)
+	for _, a := range alerts {
+		if hasMatchingLabels(a, matchers) {
+			filtered = append(filtered, a)
 		}
 	}
 

--- a/api/logs/v1/rules_prometheus_labels_enforcer.go
+++ b/api/logs/v1/rules_prometheus_labels_enforcer.go
@@ -1,0 +1,280 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/observatorium/api/authentication"
+	"github.com/observatorium/api/authorization"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+const contentTypeApplicationJSON = "application/json"
+
+var (
+	errUnknownTenantKey        = errors.New("Unknown tenant key")
+	errUnknownRulesContentType = errors.New("Unknown rules response content type")
+)
+
+type alert struct {
+	Labels      labels.Labels `json:"labels"`
+	Annotations labels.Labels `json:"annotations"`
+	State       string        `json:"state"`
+	ActiveAt    *time.Time    `json:"activeAt,omitempty"`
+	Value       string        `json:"value"`
+}
+
+func (a *alert) GetLabels() labels.Labels { return a.Labels }
+
+type alertingRule struct {
+	State          string        `json:"state"`
+	Name           string        `json:"name"`
+	Query          string        `json:"query"`
+	Duration       float64       `json:"duration"`
+	Labels         labels.Labels `json:"labels"`
+	Annotations    labels.Labels `json:"annotations"`
+	Alerts         []*alert      `json:"alerts"`
+	Health         string        `json:"health"`
+	LastError      string        `json:"lastError"`
+	LastEvaluation string        `json:"lastEvaluation"`
+	EvaluationTime float64       `json:"evaluationTime"`
+	// Type of an alertingRule is always "alerting".
+	Type string `json:"type"`
+}
+
+type recordingRule struct {
+	Name           string        `json:"name"`
+	Query          string        `json:"query"`
+	Labels         labels.Labels `json:"labels"`
+	Health         string        `json:"health"`
+	LastError      string        `json:"lastError"`
+	LastEvaluation string        `json:"lastEvaluation"`
+	EvaluationTime float64       `json:"evaluationTime"`
+	// Type of a recordingRule is always "recording".
+	Type string `json:"type"`
+}
+
+type ruleGroup struct {
+	Name           string  `json:"name"`
+	File           string  `json:"file"`
+	Rules          []rule  `json:"rules"`
+	Interval       float64 `json:"interval"`
+	LastEvaluation string  `json:"lastEvaluation"`
+	EvaluationTime float64 `json:"evaluationTime"`
+}
+
+type rule struct {
+	*alertingRule
+	*recordingRule
+}
+
+func (r *rule) GetLabels() labels.Labels {
+	if r.alertingRule != nil {
+		return r.alertingRule.Labels
+	}
+	return r.recordingRule.Labels
+}
+
+// MarshalJSON implements the json.Marshaler interface for rule.
+func (r *rule) MarshalJSON() ([]byte, error) {
+	if r.alertingRule != nil {
+		return json.Marshal(r.alertingRule)
+	}
+	return json.Marshal(r.recordingRule)
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for rule.
+func (r *rule) UnmarshalJSON(b []byte) error {
+	var ruleType struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(b, &ruleType); err != nil {
+		return err
+	}
+	switch ruleType.Type {
+	case "alerting":
+		var alertingr alertingRule
+		if err := json.Unmarshal(b, &alertingr); err != nil {
+			return err
+		}
+		r.alertingRule = &alertingr
+	case "recording":
+		var recordingr recordingRule
+		if err := json.Unmarshal(b, &recordingr); err != nil {
+			return err
+		}
+		r.recordingRule = &recordingr
+	default:
+		return fmt.Errorf("failed to unmarshal rule: unknown type %q", ruleType.Type)
+	}
+
+	return nil
+}
+
+type rulesData struct {
+	RuleGroups []*ruleGroup `json:"groups,omitempty"`
+	Alerts     []*alert     `json:"alerts,omitempty"`
+}
+
+type prometheusRulesResponse struct {
+	Status    string    `json:"status"`
+	Data      rulesData `json:"data"`
+	Error     string    `json:"error"`
+	ErrorType string    `json:"errorType"`
+}
+
+func newModifyResponseProm(logger log.Logger, labelKeys map[string][]string) func(*http.Response) error {
+	return func(res *http.Response) error {
+		tenant, ok := authentication.GetTenant(res.Request.Context())
+		if !ok {
+			return errUnknownTenantKey
+		}
+
+		keys, ok := labelKeys[tenant]
+		if !ok {
+			level.Debug(logger).Log("msg", "Skip applying rule label filters", "tenant", tenant)
+			return nil
+		}
+
+		var (
+			matchers    = extractMatchers(res.Request, keys)
+			contentType = res.Header.Get("Content-Type")
+		)
+
+		data, ok := authorization.GetData(res.Request.Context())
+
+		var matchersInfo AuthzResponseData
+		if ok && data != "" {
+			if err := json.Unmarshal([]byte(data), &matchersInfo); err != nil {
+				return nil
+			}
+		}
+
+		strictMode := len(matchersInfo.Matchers) != 0
+
+		matcherStr := fmt.Sprintf("%s", matchers)
+		level.Debug(logger).Log("msg", "filtering using matchers", "tenant", tenant, "matchers", matcherStr)
+
+		body, err := io.ReadAll(res.Body)
+		if err != nil {
+			level.Error(logger).Log("msg", err)
+			return err
+		}
+		res.Body.Close()
+
+		b, err := filterRules(body, contentType, matchers, strictMode)
+		if err != nil {
+			level.Error(logger).Log("msg", err)
+			return err
+		}
+
+		res.Body = io.NopCloser(bytes.NewReader(b))
+		res.ContentLength = int64(len(b))
+		res.Header.Set("Content-Length", strconv.FormatInt(res.ContentLength, 10))
+
+		return nil
+	}
+}
+
+func extractMatchers(r *http.Request, l []string) map[string]string {
+	queryParams := r.URL.Query()
+	matchers := map[string]string{}
+	for _, name := range l {
+		value := queryParams.Get(name)
+		if value != "" {
+			matchers[name] = value
+		}
+	}
+
+	return matchers
+}
+
+func filterRules(body []byte, contentType string, matchers map[string]string, strictMode bool) ([]byte, error) {
+	switch contentType {
+	case contentTypeApplicationJSON:
+		var res prometheusRulesResponse
+		err := json.Unmarshal(body, &res)
+		if err != nil {
+			return nil, err
+		}
+		return json.Marshal(filterPrometheusResponse(res, matchers, strictMode))
+	default:
+		return nil, errUnknownRulesContentType
+	}
+}
+
+func filterPrometheusResponse(res prometheusRulesResponse, matchers map[string]string, strictEnforce bool) prometheusRulesResponse {
+	if len(matchers) == 0 {
+		if strictEnforce {
+			res.Data = rulesData{}
+		}
+
+		return res
+	}
+
+	if len(res.Data.RuleGroups) > 0 {
+		filtered := filterPrometheusRuleGroups(res.Data.RuleGroups, matchers)
+		res.Data = rulesData{RuleGroups: filtered}
+	}
+
+	if len(res.Data.Alerts) > 0 {
+		filtered := filterPrometheusAlerts(res.Data.Alerts, matchers)
+		res.Data = rulesData{Alerts: filtered}
+	}
+
+	return res
+}
+
+type labeledRule interface {
+	GetLabels() labels.Labels
+}
+
+func hasMatchingLabels(rule labeledRule, matchers map[string]string) bool {
+	for key, value := range matchers {
+		labels := rule.GetLabels().Map()
+		val, ok := labels[key]
+		if !ok || val != value {
+			return false
+		}
+	}
+	return true
+}
+
+func filterPrometheusRuleGroups(groups []*ruleGroup, matchers map[string]string) []*ruleGroup {
+	var filtered []*ruleGroup
+
+	for _, group := range groups {
+		var filteredRules []rule
+		for _, rule := range group.Rules {
+			if hasMatchingLabels(&rule, matchers) {
+				filteredRules = append(filteredRules, rule)
+			}
+		}
+
+		if len(filteredRules) > 0 {
+			group.Rules = filteredRules
+			filtered = append(filtered, group)
+		}
+	}
+
+	return filtered
+}
+
+func filterPrometheusAlerts(alerts []*alert, matchers map[string]string) []*alert {
+	var filtered []*alert
+	for _, alert := range alerts {
+		if hasMatchingLabels(alert, matchers) {
+			filtered = append(filtered, alert)
+		}
+	}
+
+	return filtered
+}

--- a/api/logs/v1/rules_prometheus_labels_enforcer_test.go
+++ b/api/logs/v1/rules_prometheus_labels_enforcer_test.go
@@ -1,0 +1,313 @@
+package http
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/http/httputil"
+	"os"
+	"testing"
+
+	"github.com/go-chi/chi"
+	"github.com/go-kit/log"
+	"github.com/observatorium/api/authentication"
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+func TestFilterRules_WithPrometheusAPIRulesResponseBody(t *testing.T) {
+	contentType := "application/json"
+
+	body, err := os.ReadFile("testdata/rules.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matchers := map[string]string{
+		"namespace": "log-test-0",
+	}
+
+	b, err := filterRules(body, contentType, matchers, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got prometheusRulesResponse
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, group := range got.Data.RuleGroups {
+		for _, rule := range group.Rules {
+			if val := rule.GetLabels().Get("namespace"); val != "log-test-0" {
+				t.Errorf("invalid rule for label: %s and value: %s", "namespace", val)
+			}
+		}
+	}
+}
+
+func TestFilterRules_WithPrometheusAPIAlertsResponseBody(t *testing.T) {
+	contentType := "application/json"
+
+	body, err := os.ReadFile("testdata/alerts.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	matchers := map[string]string{
+		"namespace": "log-test-0",
+	}
+
+	b, err := filterRules(body, contentType, matchers, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got prometheusRulesResponse
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, alert := range got.Data.Alerts {
+		if val := alert.Labels.Get("namespace"); val != "log-test-0" {
+			t.Errorf("invalid rule for label: %s and value: %s", "namespace", val)
+		}
+	}
+}
+
+func TestFilterRules_WithPrometheusAPIResponseBody_ReturnNothingOnParseError(t *testing.T) {
+	contentType := "application/json"
+	body := []byte(`{`)
+	matchers := map[string]string{
+		"key": "value",
+	}
+
+	b, err := filterRules(body, contentType, matchers, true)
+	if err == nil {
+		t.Error("missing parse error")
+	}
+
+	if b != nil {
+		t.Errorf("want nil, got: %s", b)
+	}
+}
+
+func TestFilterRules_WithokiAPIResponseBody_ReturnNothingOnParseError(t *testing.T) {
+	contentType := "application/yaml"
+	body := []byte(`invalid`)
+	matchers := map[string]string{
+		"key": "value",
+	}
+
+	b, err := filterRules(body, contentType, matchers, true)
+	if err == nil {
+		t.Error("missing parse error")
+	}
+
+	if b != nil {
+		t.Errorf("want nil, got: %s", b)
+	}
+}
+
+func TestFilterRules_WithUnknownContentType_ReturnsError(t *testing.T) {
+	contentType := "invalid/content"
+
+	var (
+		body     []byte
+		matchers map[string]string
+	)
+
+	b, err := filterRules(body, contentType, matchers, true)
+	if !errors.Is(err, errUnknownRulesContentType) {
+		t.Errorf("want %s, got: %s", errUnknownRulesContentType, err)
+	}
+
+	if b != nil {
+		t.Errorf("want nil, got: %s", b)
+	}
+}
+
+func TestFilterPrometheusRules(t *testing.T) {
+	tt := []struct {
+		desc          string
+		matchers      map[string]string
+		strictEnforce bool
+		res           prometheusRulesResponse
+		want          prometheusRulesResponse
+	}{
+		{
+			desc:          "without matchers returns empty",
+			strictEnforce: true,
+			res: prometheusRulesResponse{
+				Data: rulesData{
+					RuleGroups: []*ruleGroup{
+						{Name: "group-a"},
+					},
+				},
+			},
+			want: prometheusRulesResponse{},
+		},
+		{
+			desc: "without matchers returns original response",
+			res: prometheusRulesResponse{
+				Data: rulesData{
+					RuleGroups: []*ruleGroup{
+						{Name: "group-a"},
+					},
+				},
+			},
+			want: prometheusRulesResponse{
+				Data: rulesData{
+					RuleGroups: []*ruleGroup{
+						{Name: "group-a"},
+					},
+				},
+			},
+		},
+		{
+			desc:     "only matching",
+			matchers: map[string]string{"label": "value"},
+			res: prometheusRulesResponse{
+				Data: rulesData{
+					RuleGroups: []*ruleGroup{
+						{
+							Name: "group-a",
+							Rules: []rule{
+								{
+									alertingRule: &alertingRule{
+										Labels: labels.FromMap(map[string]string{"label": "value"}),
+									},
+								},
+								{
+									alertingRule: &alertingRule{
+										Labels: labels.FromMap(map[string]string{"other": "not"}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: prometheusRulesResponse{
+				Data: rulesData{
+					RuleGroups: []*ruleGroup{
+						{
+							Name: "group-a",
+							Rules: []rule{
+								{
+									alertingRule: &alertingRule{
+										Labels: labels.FromMap(map[string]string{"label": "value"}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			desc:     "nothing matching",
+			matchers: map[string]string{"label": "value"},
+			res: prometheusRulesResponse{
+				Data: rulesData{
+					RuleGroups: []*ruleGroup{
+						{
+							Name: "group-a",
+							Rules: []rule{
+								{
+									alertingRule: &alertingRule{
+										Labels: labels.FromMap(map[string]string{"not": "other"}),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: prometheusRulesResponse{},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.desc, func(t *testing.T) {
+			t.Parallel()
+
+			got := filterPrometheusResponse(tc.res, tc.matchers, tc.strictEnforce)
+
+			wantJSON, err := json.MarshalIndent(tc.want, "", "  ")
+			if err != nil {
+				t.Errorf("failed to marshal expected JSON: %v", err)
+			}
+
+			gotJSON, err := json.MarshalIndent(got, "", "  ")
+			if err != nil {
+				t.Errorf("failed to marshal actual JSON: %v", err)
+			}
+
+			if string(wantJSON) != string(gotJSON) {
+				t.Errorf("\nwant: %s\ngot: %s", wantJSON, gotJSON)
+			}
+		})
+	}
+}
+
+func TestModifyResponse(t *testing.T) {
+	l := log.NewNopLogger()
+	lk := map[string][]string{
+		"fake": {"namespace"},
+	}
+
+	rules, err := os.ReadFile("testdata/rules.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	originanLen := int64(len(rules))
+
+	filtered, err := os.ReadFile("testdata/rules-log-test-0.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	filteredLen := int64(len(filtered))
+
+	headers := make(http.Header)
+	headers.Add("Content-Type", "application/json")
+
+	res := &http.Response{
+		StatusCode:    http.StatusOK,
+		Header:        headers,
+		Body:          io.NopCloser(bytes.NewReader(rules)),
+		ContentLength: originanLen,
+	}
+
+	proxy := &httputil.ReverseProxy{
+		Director:       func(r *http.Request) {},
+		Transport:      staticResponseRoundTripper{res},
+		ModifyResponse: newModifyResponseProm(l, lk),
+	}
+
+	r := chi.NewRouter()
+	r.Handle("/rules/{tenant}", authentication.WithTenant(proxy))
+
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, httptest.NewRequest("GET", "/rules/fake?namespace=log-test-0", nil))
+
+	result := rr.Result()
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("Broken routing: %s", rr.Result().Status)
+	}
+
+	if result.ContentLength == originanLen || result.ContentLength != filteredLen {
+		t.Errorf("failed to filter rules, original len: %d, want: %d, got: %d", originanLen, filteredLen, result.ContentLength)
+	}
+}
+
+type staticResponseRoundTripper struct {
+	res *http.Response
+}
+
+func (rt staticResponseRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	rt.res.Request = r
+	return rt.res, nil
+}

--- a/main.go
+++ b/main.go
@@ -748,6 +748,7 @@ func main() {
 								logsv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "logs")),
 								logsv1.WithReadMiddleware(logsv1.WithEnforceAuthorizationLabels()),
 								logsv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "logs")),
+								logsv1.WithRulesLabelFilters(cfg.logs.rulesLabelFilters),
 								logsv1.WithRulesReadMiddleware(logsv1.WithEnforceTenantAsRuleNamespace()),
 								logsv1.WithRulesReadMiddleware(logsv1.WithEnforceRulesLabelFilters(cfg.logs.rulesLabelFilters)),
 								logsv1.WithRulesReadMiddleware(logsv1.WithParametersAsLabelsFilterRules(cfg.logs.rulesLabelFilters)),


### PR DESCRIPTION
In https://github.com/observatorium/api/pull/578 we completely removed the filtering code and relied only on the query parameter for Loki to filter the rules. However, the filtering only works for the Loki API and not for the Prometheus API

Fixes https://issues.redhat.com/browse/LOG-6148