### PR TITLE
feat: add routes to enable Log Patterns, Fields, and Labels in Grafana

### DIFF
--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -35,6 +35,9 @@ const (
 	volumeRoute            = "/loki/api/v1/index/volume"
 	volumeRangeRoute       = "/loki/api/v1/index/volume_range"
 	patternsRoute          = "/loki/api/v1/patterns"
+	detectedLabelsRoute    = "/loki/api/v1/detect_labels"
+	detectedFieldRoute     = "/loki/api/v1/detect_field"
+	detectedFieldsRoute    = "/loki/api/v1/detect_fields"
 
 	otlpRoute = "/otlp/v1/logs"
 	pushRoute = "/loki/api/v1/push"
@@ -239,6 +242,18 @@ func NewHandler(read, tail, write, rules *url.URL, rulesReadOnly bool, tlsOption
 			r.Handle(patternsRoute, c.instrument.NewHandler(
 				prometheus.Labels{"group": "logsv1", "handler": "patterns"},
 				otelhttp.WithRouteTag(c.spanRoutePrefix+patternsRoute, proxyRead),
+			))
+			r.Handle(detectedLabelsRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "logsv1", "handler": "detected_labels"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+promSeriesRoute, proxyRead),
+			))
+			r.Handle(detectedFieldRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "logsv1", "handler": "detected_field`"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+promSeriesRoute, proxyRead),
+			))
+			r.Handle(detectedFieldsRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "logsv1", "handler": "detected_fields`"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+promSeriesRoute, proxyRead),
 			))
 		})
 	}

--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -34,6 +34,7 @@ const (
 	rulesPerGroupNameRoute = "/loki/api/v1/rules/{namespace}/{groupName}"
 	volumeRoute            = "/loki/api/v1/index/volume"
 	volumeRangeRoute       = "/loki/api/v1/index/volume_range"
+	patternsRoute          = "/loki/api/v1/patterns"
 
 	otlpRoute = "/otlp/v1/logs"
 	pushRoute = "/loki/api/v1/push"
@@ -234,6 +235,10 @@ func NewHandler(read, tail, write, rules *url.URL, rulesReadOnly bool, tlsOption
 			r.Handle(promSeriesRoute, c.instrument.NewHandler(
 				prometheus.Labels{"group": "logsv1", "handler": "series"},
 				otelhttp.WithRouteTag(c.spanRoutePrefix+promSeriesRoute, proxyRead),
+			))
+			r.Handle(patternsRoute, c.instrument.NewHandler(
+				prometheus.Labels{"group": "logsv1", "handler": "patterns"},
+				otelhttp.WithRouteTag(c.spanRoutePrefix+patternsRoute, proxyRead),
 			))
 		})
 	}

--- a/api/logs/v1/http.go
+++ b/api/logs/v1/http.go
@@ -35,9 +35,9 @@ const (
 	volumeRoute            = "/loki/api/v1/index/volume"
 	volumeRangeRoute       = "/loki/api/v1/index/volume_range"
 	patternsRoute          = "/loki/api/v1/patterns"
-	detectedLabelsRoute    = "/loki/api/v1/detect_labels"
-	detectedFieldRoute     = "/loki/api/v1/detect_field"
-	detectedFieldsRoute    = "/loki/api/v1/detect_fields"
+	detectedLabelsRoute    = "/loki/api/v1/detected_labels"
+	detectedFieldRoute     = "/loki/api/v1/detected_field"
+	detectedFieldsRoute    = "/loki/api/v1/detected_fields"
 
 	otlpRoute = "/otlp/v1/logs"
 	pushRoute = "/loki/api/v1/push"


### PR DESCRIPTION
Add the routes `patterns`, `detected_labels`, `detected_field`, `detected_fields` to support enabling the Patterns, Fields, and Labels tabs in Grafana Drilldown