### PR TITLE
Support BYO/external authentication in OpenShift authenticator

### DIFF
--- a/authentication/openshift.go
+++ b/authentication/openshift.go
@@ -145,19 +145,20 @@ func newOpenshiftAuthenticator(c map[string]interface{}, tenant string,
 	var clientID string
 	var clientSecret string
 
-	for b.Reset(); b.Ongoing(); {
-		clientID, clientSecret, err = openshift.DiscoverCredentials(config.ServiceAccount)
-		if err != nil {
-			level.Error(logger).Log(
-				"tenant", tenant,
-				"msg", errors.Wrap(err, "unable to read serviceaccount credentials"))
-			registrationRetryCount.WithLabelValues(tenant, OpenShiftAuthenticatorType).Inc()
-			b.Wait()
+	if oauthEnabled {
+		for b.Reset(); b.Ongoing(); {
+			clientID, clientSecret, err = openshift.DiscoverCredentials(config.ServiceAccount)
+			if err != nil {
+				level.Error(logger).Log(
+					"tenant", tenant,
+					"msg", errors.Wrap(err, "unable to read serviceaccount credentials"))
+				registrationRetryCount.WithLabelValues(tenant, OpenShiftAuthenticatorType).Inc()
+				b.Wait()
 
-			continue
+				continue
+			}
+			break
 		}
-
-		break
 	}
 
 	authOpts := openshift.DelegatingAuthenticationOptions{
@@ -207,6 +208,8 @@ func newOpenshiftAuthenticator(c map[string]interface{}, tenant string,
 		oauthEnabled:  oauthEnabled,
 	}
 
+	r := chi.NewRouter()
+	r.Use(tracing.WithChiRoutePattern)
 	if oauthEnabled {
 		osAuthenticator.oauth2Config = oauth2.Config{
 			ClientID:     clientID,
@@ -223,15 +226,12 @@ func newOpenshiftAuthenticator(c map[string]interface{}, tenant string,
 			},
 			RedirectURL: config.RedirectURL,
 		}
-		r := chi.NewRouter()
-		r.Use(tracing.WithChiRoutePattern)
+
 		r.Handle(loginRoute, osAuthenticator.openshiftLoginHandler())
 		r.Handle(callbackRoute, osAuthenticator.openshiftCallbackHandler())
-		osAuthenticator.handler = r
-
-	} else {
-		osAuthenticator.handler = chi.NewRouter()
 	}
+
+	osAuthenticator.handler = r
 
 	return osAuthenticator, nil
 }
@@ -539,28 +539,22 @@ func (a OpenShiftAuthenticator) Handler() (string, http.Handler) {
 }
 
 func discoverOAuthEndpoints(client *http.Client, logger log.Logger, tenant string, registrationRetryCount *prometheus.CounterVec, b *backoff.Backoff) (*url.URL, *url.URL, bool) {
-	authURL, tokenURL, err := openshift.DiscoverOAuth(client)
-	if err != nil {
-		if strings.Contains(err.Error(), "got 404") || strings.Contains(err.Error(), "OAuth server not found") {
-			level.Warn(logger).Log(
-				"tenant", tenant,
-				"msg", errors.Wrap(err, "OpenShift OAuth endpoint not available, likely using external OIDC authentication. But bearer token authentication will continue to work"))
-			return nil, nil, false
-		} else {
-			// Other errors, retry with backoff
-			for b.Reset(); b.Ongoing(); {
-				authURL, tokenURL, err = openshift.DiscoverOAuth(client)
-				if err != nil {
-					level.Error(logger).Log(
-						"tenant", tenant,
-						"msg", errors.Wrap(err, "unable to auto discover OpenShift OAuth endpoints"))
-					registrationRetryCount.WithLabelValues(tenant, OpenShiftAuthenticatorType).Inc()
-					b.Wait()
-					continue
-				}
-				break
+	var authURL, tokenURL *url.URL
+	var err error
+	for b.Reset(); b.Ongoing(); {
+		authURL, tokenURL, err = openshift.DiscoverOAuth(client)
+		if err != nil {
+			if errors.Is(err, openshift.ErrOAuthServerNotFound) {
+				return nil, nil, false
 			}
+			level.Error(logger).Log(
+				"tenant", tenant,
+				"msg", errors.Wrap(err, "unable to auto discover OpenShift OAuth endpoints"))
+			registrationRetryCount.WithLabelValues(tenant, OpenShiftAuthenticatorType).Inc()
+			b.Wait()
+			continue
 		}
+		break
 	}
 	return authURL, tokenURL, true
 }

--- a/authentication/openshift.go
+++ b/authentication/openshift.go
@@ -140,37 +140,9 @@ func newOpenshiftAuthenticator(c map[string]interface{}, tenant string,
 		MaxRetries: 0, // Retry indefinitely.
 	})
 
-	var authURL *url.URL
-
-	var tokenURL *url.URL
-
-	authURL, tokenURL, err = openshift.DiscoverOAuth(client)
-	if err != nil {
-		if strings.Contains(err.Error(), "got 404") || strings.Contains(err.Error(), "OAuth server not found") {
-			level.Warn(logger).Log(
-				"tenant", tenant,
-				"msg", errors.Wrap(err, "OpenShift OAuth endpoint not available"))
-		}
-		authURL = nil
-		tokenURL = nil
-	} else {
-		// Other errors
-		for b.Reset(); b.Ongoing(); {
-			authURL, tokenURL, err = openshift.DiscoverOAuth(client)
-			if err != nil {
-				level.Error(logger).Log(
-					"tenant", tenant,
-					"msg", errors.Wrap(err, "unable to auto discover OpenShift OAuth endpoints"))
-				registrationRetryCount.WithLabelValues(tenant, OpenShiftAuthenticatorType).Inc()
-				b.Wait()
-				continue
-			}
-			break
-		}
-	}
+	authURL, tokenURL, oauthEnabled := discoverOAuthEndpoints(client, logger, tenant, registrationRetryCount, b)
 
 	var clientID string
-
 	var clientSecret string
 
 	for b.Reset(); b.Ongoing(); {
@@ -232,10 +204,10 @@ func newOpenshiftAuthenticator(c map[string]interface{}, tenant string,
 		client:        client,
 		config:        config,
 		cookieName:    fmt.Sprintf("observatorium_%s", tenant),
-		oauthEnabled:  authURL != nil && tokenURL != nil,
+		oauthEnabled:  oauthEnabled,
 	}
 
-	if osAuthenticator.oauthEnabled {
+	if oauthEnabled {
 		osAuthenticator.oauth2Config = oauth2.Config{
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
@@ -564,4 +536,31 @@ func (a OpenShiftAuthenticator) GRPCMiddleware() grpc.StreamServerInterceptor {
 
 func (a OpenShiftAuthenticator) Handler() (string, http.Handler) {
 	return "/openshift/{tenant}", a.handler
+}
+
+func discoverOAuthEndpoints(client *http.Client, logger log.Logger, tenant string, registrationRetryCount *prometheus.CounterVec, b *backoff.Backoff) (*url.URL, *url.URL, bool) {
+	authURL, tokenURL, err := openshift.DiscoverOAuth(client)
+	if err != nil {
+		if strings.Contains(err.Error(), "got 404") || strings.Contains(err.Error(), "OAuth server not found") {
+			level.Warn(logger).Log(
+				"tenant", tenant,
+				"msg", errors.Wrap(err, "OpenShift OAuth endpoint not available, likely using external OIDC authentication. But bearer token authentication will continue to work"))
+			return nil, nil, false
+		} else {
+			// Other errors, retry with backoff
+			for b.Reset(); b.Ongoing(); {
+				authURL, tokenURL, err = openshift.DiscoverOAuth(client)
+				if err != nil {
+					level.Error(logger).Log(
+						"tenant", tenant,
+						"msg", errors.Wrap(err, "unable to auto discover OpenShift OAuth endpoints"))
+					registrationRetryCount.WithLabelValues(tenant, OpenShiftAuthenticatorType).Inc()
+					b.Wait()
+					continue
+				}
+				break
+			}
+		}
+	}
+	return authURL, tokenURL, true
 }

--- a/authentication/openshift.go
+++ b/authentication/openshift.go
@@ -77,6 +77,7 @@ type OpenShiftAuthenticator struct {
 	oauth2Config  oauth2.Config
 	cookieName    string
 	handler       http.Handler
+	oauthEnabled  bool
 }
 
 //nolint:funlen
@@ -143,19 +144,29 @@ func newOpenshiftAuthenticator(c map[string]interface{}, tenant string,
 
 	var tokenURL *url.URL
 
-	for b.Reset(); b.Ongoing(); {
-		authURL, tokenURL, err = openshift.DiscoverOAuth(client)
-		if err != nil {
-			level.Error(logger).Log(
+	authURL, tokenURL, err = openshift.DiscoverOAuth(client)
+	if err != nil {
+		if strings.Contains(err.Error(), "got 404") || strings.Contains(err.Error(), "OAuth server not found") {
+			level.Warn(logger).Log(
 				"tenant", tenant,
-				"msg", errors.Wrap(err, "unable to auto discover OpenShift OAuth endpoints"))
-			registrationRetryCount.WithLabelValues(tenant, OpenShiftAuthenticatorType).Inc()
-			b.Wait()
-
-			continue
+				"msg", errors.Wrap(err, "OpenShift OAuth endpoint not available"))
 		}
-
-		break
+		authURL = nil
+		tokenURL = nil
+	} else {
+		// Other errors
+		for b.Reset(); b.Ongoing(); {
+			authURL, tokenURL, err = openshift.DiscoverOAuth(client)
+			if err != nil {
+				level.Error(logger).Log(
+					"tenant", tenant,
+					"msg", errors.Wrap(err, "unable to auto discover OpenShift OAuth endpoints"))
+				registrationRetryCount.WithLabelValues(tenant, OpenShiftAuthenticatorType).Inc()
+				b.Wait()
+				continue
+			}
+			break
+		}
 	}
 
 	var clientID string
@@ -221,7 +232,11 @@ func newOpenshiftAuthenticator(c map[string]interface{}, tenant string,
 		client:        client,
 		config:        config,
 		cookieName:    fmt.Sprintf("observatorium_%s", tenant),
-		oauth2Config: oauth2.Config{
+		oauthEnabled:  authURL != nil && tokenURL != nil,
+	}
+
+	if osAuthenticator.oauthEnabled {
+		osAuthenticator.oauth2Config = oauth2.Config{
 			ClientID:     clientID,
 			ClientSecret: clientSecret,
 			Endpoint: oauth2.Endpoint{
@@ -235,14 +250,16 @@ func newOpenshiftAuthenticator(c map[string]interface{}, tenant string,
 				defaultOAuthScopeListProjects,
 			},
 			RedirectURL: config.RedirectURL,
-		},
-	}
+		}
+		r := chi.NewRouter()
+		r.Use(tracing.WithChiRoutePattern)
+		r.Handle(loginRoute, osAuthenticator.openshiftLoginHandler())
+		r.Handle(callbackRoute, osAuthenticator.openshiftCallbackHandler())
+		osAuthenticator.handler = r
 
-	r := chi.NewRouter()
-	r.Use(tracing.WithChiRoutePattern)
-	r.Handle(loginRoute, osAuthenticator.openshiftLoginHandler())
-	r.Handle(callbackRoute, osAuthenticator.openshiftCallbackHandler())
-	osAuthenticator.handler = r
+	} else {
+		osAuthenticator.handler = chi.NewRouter()
+	}
 
 	return osAuthenticator, nil
 }
@@ -442,6 +459,13 @@ func (a OpenShiftAuthenticator) Middleware() Middleware {
 			// when users went through the OAuth2 flow supported by this
 			// provider. Observatorium stores a self-signed JWT token on a
 			// cookie per tenant to identify the subject of incoming requests.
+			if !a.oauthEnabled {
+				msg := "OAuth authentication not available"
+				level.Debug(a.logger).Log("msg", msg)
+				httperr.PrometheusAPIError(w, msg, http.StatusUnauthorized)
+				return
+			}
+
 			cookie, err := r.Cookie(a.cookieName)
 			if err != nil {
 				tenant, ok := GetTenant(r.Context())

--- a/authentication/openshift.go
+++ b/authentication/openshift.go
@@ -140,27 +140,6 @@ func newOpenshiftAuthenticator(c map[string]interface{}, tenant string,
 		MaxRetries: 0, // Retry indefinitely.
 	})
 
-	authURL, tokenURL, oauthEnabled := discoverOAuthEndpoints(client, logger, tenant, registrationRetryCount, b)
-
-	var clientID string
-	var clientSecret string
-
-	if oauthEnabled {
-		for b.Reset(); b.Ongoing(); {
-			clientID, clientSecret, err = openshift.DiscoverCredentials(config.ServiceAccount)
-			if err != nil {
-				level.Error(logger).Log(
-					"tenant", tenant,
-					"msg", errors.Wrap(err, "unable to read serviceaccount credentials"))
-				registrationRetryCount.WithLabelValues(tenant, OpenShiftAuthenticatorType).Inc()
-				b.Wait()
-
-				continue
-			}
-			break
-		}
-	}
-
 	authOpts := openshift.DelegatingAuthenticationOptions{
 		RemoteKubeConfigFile: config.KubeConfigPath,
 		CacheTTL:             2 * time.Minute,
@@ -194,6 +173,27 @@ func newOpenshiftAuthenticator(c map[string]interface{}, tenant string,
 		cipher, err = openshift.NewCipher([]byte(config.CookieSecret))
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to initialize cookie cipher")
+		}
+	}
+
+	authURL, tokenURL, oauthEnabled := discoverOAuthEndpoints(client, logger, tenant, registrationRetryCount, b)
+
+	var clientID string
+	var clientSecret string
+
+	if oauthEnabled {
+		for b.Reset(); b.Ongoing(); {
+			clientID, clientSecret, err = openshift.DiscoverCredentials(config.ServiceAccount)
+			if err != nil {
+				level.Error(logger).Log(
+					"tenant", tenant,
+					"msg", errors.Wrap(err, "unable to read serviceaccount credentials"))
+				registrationRetryCount.WithLabelValues(tenant, OpenShiftAuthenticatorType).Inc()
+				b.Wait()
+
+				continue
+			}
+			break
 		}
 	}
 

--- a/authentication/openshift/discovery.go
+++ b/authentication/openshift/discovery.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 const (
@@ -20,6 +22,8 @@ const (
 	// ServiceAccountCAPath is the path to the default cluster CA certificate.
 	ServiceAccountCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
+
+var ErrOAuthServerNotFound = errors.Errorf("404 not found")
 
 // GetServiceAccountCACert returns the PEM-encoded CA certificate currently mounted.
 func GetServiceAccountCACert() ([]byte, error) {
@@ -74,7 +78,7 @@ func DiscoverOAuth(client *http.Client) (authURL, tokenURL *url.URL, err error) 
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		if resp.StatusCode == 404 {
-			return nil, nil, fmt.Errorf("OAuth server not found")
+			return nil, nil, ErrOAuthServerNotFound
 		}
 		return nil, nil, fmt.Errorf("got %d %s", resp.StatusCode, body)
 	}

--- a/authentication/openshift/discovery.go
+++ b/authentication/openshift/discovery.go
@@ -73,6 +73,9 @@ func DiscoverOAuth(client *http.Client) (authURL, tokenURL *url.URL, err error) 
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		if resp.StatusCode == 404 {
+			return nil, nil, fmt.Errorf("OAuth server not found")
+		}
 		return nil, nil, fmt.Errorf("got %d %s", resp.StatusCode, body)
 	}
 

--- a/authentication/openshift/discovery.go
+++ b/authentication/openshift/discovery.go
@@ -23,7 +23,7 @@ const (
 	ServiceAccountCAPath = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 )
 
-var ErrOAuthServerNotFound = errors.Errorf("404 not found")
+var ErrOAuthServerNotFound = errors.Errorf("OAuth server not found")
 
 // GetServiceAccountCACert returns the PEM-encoded CA certificate currently mounted.
 func GetServiceAccountCACert() ([]byte, error) {

--- a/authentication/openshift/discovery.go
+++ b/authentication/openshift/discovery.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	oauthWellKnownPath = "/.well-known/oauth-authorization-server"
+	OauthWellKnownPath = "/.well-known/oauth-authorization-server"
 
 	// ServiceAccountNamespacePath is the path to the default serviceaccount namespace.
 	ServiceAccountNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
@@ -54,7 +54,7 @@ func DiscoverCredentials(name string) (string, string, error) {
 // DiscoverOAuth return the authorization and token endpoints of the OpenShift OAuth server.
 // Returns an error if requesting the `/.well-known/oauth-authorization-server` fails.
 func DiscoverOAuth(client *http.Client) (authURL, tokenURL *url.URL, err error) {
-	oauthURL := toKubeAPIURLWithPath(oauthWellKnownPath)
+	oauthURL := toKubeAPIURLWithPath(OauthWellKnownPath)
 
 	req, err := http.NewRequest(http.MethodGet, oauthURL.String(), nil)
 	if err != nil {

--- a/authentication/openshift_test.go
+++ b/authentication/openshift_test.go
@@ -11,13 +11,14 @@ import (
 
 	"github.com/efficientgo/core/backoff"
 	"github.com/go-chi/chi/v5"
-	"github.com/observatorium/api/authentication/openshift"
-	"github.com/observatorium/api/logger"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/observatorium/api/authentication/openshift"
+	"github.com/observatorium/api/logger"
 )
 
-// redirectTransport redirects all requests to the target host
+// redirectTransport redirects all requests to the target host.
 type redirectTransport struct {
 	targetHost string
 	transport  http.RoundTripper
@@ -37,10 +38,12 @@ func TestDiscoverOAuthEndpoints_OAuthEnabled(t *testing.T) {
 
 	r.Get(openshift.OauthWellKnownPath, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(`{
+		if _, err := w.Write([]byte(`{
             "authorization_endpoint": "https://oauth.example.com/authorize",
             "token_endpoint": "https://oauth.example.com/token"
-        }`))
+        }`)); err != nil {
+			t.Fatalf("failed to write response %v", err)
+		}
 	})
 
 	mockAPIServer := httptest.NewServer(r)
@@ -61,7 +64,9 @@ func TestDiscoverOAuthEndpoints_OAuthEnabled(t *testing.T) {
 	t.Setenv("KUBERNETES_SERVICE_PORT", port)
 
 	retryCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "test_retries"},
+		Name: "test_retries_total",
+		Help: "Total number of OAuth discovery retries",
+	},
 		[]string{"tenant", "type"},
 	)
 
@@ -94,7 +99,9 @@ func TestDiscoverOAuthEndpoints_OAuthDisabled(t *testing.T) {
 
 	r.Get(openshift.OauthWellKnownPath, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNotFound)
-		w.Write([]byte("404 page not found"))
+		if _, err := w.Write([]byte("404 page not found")); err != nil {
+			t.Fatalf("failed to write response %v", err)
+		}
 	})
 
 	mockAPIServer := httptest.NewServer(r)
@@ -115,7 +122,9 @@ func TestDiscoverOAuthEndpoints_OAuthDisabled(t *testing.T) {
 	t.Setenv("KUBERNETES_SERVICE_PORT", port)
 
 	retryCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "test_retries"},
+		Name: "test_retries_total",
+		Help: "Total number of OAuth discovery retries",
+	},
 		[]string{"tenant", "type"},
 	)
 

--- a/authentication/openshift_test.go
+++ b/authentication/openshift_test.go
@@ -55,13 +55,12 @@ func TestDiscoverOAuthEndpoints_OAuthEnabled(t *testing.T) {
 	}
 
 	// Split host and port for KUBERNETES env vars
-	host, port, err := net.SplitHostPort(mockURL.Host)
+	host, _, err := net.SplitHostPort(mockURL.Host)
 	if err != nil {
 		t.Fatalf("failed to parse mock server address: %v", err)
 	}
 
 	t.Setenv("KUBERNETES_SERVICE_HOST", host)
-	t.Setenv("KUBERNETES_SERVICE_PORT", port)
 
 	retryCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "test_retries_total",
@@ -113,13 +112,12 @@ func TestDiscoverOAuthEndpoints_OAuthDisabled(t *testing.T) {
 	}
 
 	// Split host and port for KUBERNETES env vars
-	host, port, err := net.SplitHostPort(mockURL.Host)
+	host, _, err := net.SplitHostPort(mockURL.Host)
 	if err != nil {
 		t.Fatalf("failed to parse mock server address: %v", err)
 	}
 
 	t.Setenv("KUBERNETES_SERVICE_HOST", host)
-	t.Setenv("KUBERNETES_SERVICE_PORT", port)
 
 	retryCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "test_retries_total",

--- a/authentication/openshift_test.go
+++ b/authentication/openshift_test.go
@@ -1,0 +1,140 @@
+package authentication
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/efficientgo/core/backoff"
+	"github.com/go-chi/chi/v5"
+	"github.com/observatorium/api/authentication/openshift"
+	"github.com/observatorium/api/logger"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+// redirectTransport redirects all requests to the target host
+type redirectTransport struct {
+	targetHost string
+	transport  http.RoundTripper
+}
+
+func (rt *redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	// Redirect request to mock server while keeping the path
+	req.URL.Host = rt.targetHost
+	req.URL.Scheme = "http"
+	return rt.transport.RoundTrip(req)
+}
+
+func TestDiscoverOAuthEndpoints_OAuthEnabled(t *testing.T) {
+	tenant := "tenant"
+	logger := logger.NewLogger("warn", logger.LogFormatLogfmt, "")
+	r := chi.NewMux()
+
+	r.Get(openshift.OauthWellKnownPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{
+            "authorization_endpoint": "https://oauth.example.com/authorize",
+            "token_endpoint": "https://oauth.example.com/token"
+        }`))
+	})
+
+	mockAPIServer := httptest.NewServer(r)
+	defer mockAPIServer.Close()
+
+	mockURL, err := url.Parse(mockAPIServer.URL)
+	if err != nil {
+		t.Fatalf("failed to parse mock server URL: %v", err)
+	}
+
+	// Split host and port for KUBERNETES env vars
+	host, port, err := net.SplitHostPort(mockURL.Host)
+	if err != nil {
+		t.Fatalf("failed to parse mock server address: %v", err)
+	}
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", host)
+	t.Setenv("KUBERNETES_SERVICE_PORT", port)
+
+	retryCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "test_retries"},
+		[]string{"tenant", "type"},
+	)
+
+	client := &http.Client{
+		Transport: &redirectTransport{
+			targetHost: mockURL.Host,
+			transport:  http.DefaultTransport,
+		},
+	}
+
+	b := backoff.New(context.TODO(), backoff.Config{
+		Min:        500 * time.Millisecond,
+		Max:        5 * time.Second,
+		MaxRetries: 0, // Retry indefinitely.
+	})
+
+	authURL, tokenURL, oauthEnabled := discoverOAuthEndpoints(client, logger, tenant, retryCounter, b)
+
+	assert.NotNil(t, authURL)
+	assert.NotNil(t, tokenURL)
+	assert.True(t, oauthEnabled)
+	assert.Equal(t, authURL.String(), "https://oauth.example.com/authorize")
+	assert.Equal(t, tokenURL.String(), "https://oauth.example.com/token")
+}
+
+func TestDiscoverOAuthEndpoints_OAuthDisabled(t *testing.T) {
+	tenant := "tenant"
+	logger := logger.NewLogger("warn", logger.LogFormatLogfmt, "")
+	r := chi.NewMux()
+
+	r.Get(openshift.OauthWellKnownPath, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("404 page not found"))
+	})
+
+	mockAPIServer := httptest.NewServer(r)
+	defer mockAPIServer.Close()
+
+	mockURL, err := url.Parse(mockAPIServer.URL)
+	if err != nil {
+		t.Fatalf("failed to parse mock server URL: %v", err)
+	}
+
+	// Split host and port for KUBERNETES env vars
+	host, port, err := net.SplitHostPort(mockURL.Host)
+	if err != nil {
+		t.Fatalf("failed to parse mock server address: %v", err)
+	}
+
+	t.Setenv("KUBERNETES_SERVICE_HOST", host)
+	t.Setenv("KUBERNETES_SERVICE_PORT", port)
+
+	retryCounter := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "test_retries"},
+		[]string{"tenant", "type"},
+	)
+
+	client := &http.Client{
+		Transport: &redirectTransport{
+			targetHost: mockURL.Host,
+			transport:  http.DefaultTransport,
+		},
+	}
+
+	b := backoff.New(context.TODO(), backoff.Config{
+		Min:        500 * time.Millisecond,
+		Max:        5 * time.Second,
+		MaxRetries: 0, // Retry indefinitely.
+	})
+
+	authURL, tokenURL, oauthEnabled := discoverOAuthEndpoints(client, logger, tenant, retryCounter, b)
+
+	assert.Nil(t, authURL)
+	assert.Nil(t, tokenURL)
+	assert.False(t, oauthEnabled)
+}


### PR DESCRIPTION
When OpenShift is configured with external OIDC providers (Keycloak, Red Hat SSO, etc.), the OAuth discovery endpoint returns 404 since OAuth server gets disabled. The current code retries indefinitely causing the LokiStack gateway to hang during startup.
This PR:
- adds graceful handling for OpenShift clusters using BYO (Bring Your Own) external authentication where built-in OAuth server is disabled.
- Detects 404 responses from OAuth endpoint and disables OAuth flow.
- Generates a warning message
- Bearer token authentication continues to work.
- Transient errors still retry as before.

### References
- Setting up Keycloak through the operator: https://docs.redhat.com/en/documentation/red_hat_build_of_keycloak/24.0/html-single/operator_guide/index
- Enabling direct authentication with an external OIDC identity provider: https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html-single/authentication_and_authorization/index#external-auth