### PR TITLE
alertmanager: Implement /silence/{silenceID} endpoint

### DIFF
--- a/api/metrics/v1/alertmanager_enforcer.go
+++ b/api/metrics/v1/alertmanager_enforcer.go
@@ -138,79 +138,44 @@ func WithEnforceTenancyOnSilenceMatchers(label string) func(http.Handler) http.H
 	}
 }
 
-// alertmanagerGetSilence returns a silence when it belongs to the tenant.
-func alertmanagerGetSilence(label string, upstream *url.URL, transport http.RoundTripper) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		silID := chi.URLParam(r, "silenceID")
-		if silID == "" {
-			httperr.PrometheusAPIError(w, "bad request", http.StatusBadRequest)
-			return
-		}
-
-		tenantID, ok := authentication.GetTenantID(r.Context())
-		if !ok {
-			httperr.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
-			return
-		}
-
-		sil, err := getSilenceByID(r.Context(), upstream, transport, silID)
-		if err != nil {
-			var notFound *silence.GetSilenceNotFound
-			if errors.As(err, &notFound) {
-				w.WriteHeader(http.StatusNotFound)
+// WithEnforceTenancyOnSilenceID ensures the silence in the path belongs to the tenant
+// before proxying GET or DELETE /api/v2/silence/{id} to Alertmanager.
+// Adapted from https://github.com/prometheus-community/prom-label-proxy/injectproxy/silences.go
+func WithEnforceTenancyOnSilenceID(label string, upstream *url.URL, transport http.RoundTripper) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			silID := chi.URLParam(r, "silenceID")
+			if silID == "" {
+				httperr.PrometheusAPIError(w, "bad request", http.StatusBadRequest)
 				return
 			}
-			httperr.PrometheusAPIError(w, fmt.Sprintf("proxy error: %v", err), http.StatusBadGateway)
-			return
-		}
 
-		if !hasMatcherForLabel(sil.Matchers, label, tenantID) {
-			httperr.PrometheusAPIError(w, "forbidden", http.StatusForbidden)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(sil); err != nil {
-			httperr.PrometheusAPIError(w, fmt.Sprintf("can't encode: %v", err), http.StatusInternalServerError)
-		}
-	})
-}
-
-// alertmanagerDeleteSilence checks silence ownership then proxies DELETE to Alertmanager.
-// Adapted from https://github.com/prometheus-community/prom-label-proxy/blob/main/injectproxy/silences.go
-func alertmanagerDeleteSilence(label string, upstream *url.URL, transport http.RoundTripper, next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		silID := chi.URLParam(r, "silenceID")
-		if silID == "" {
-			httperr.PrometheusAPIError(w, "bad request", http.StatusBadRequest)
-			return
-		}
-
-		tenantID, ok := authentication.GetTenantID(r.Context())
-		if !ok {
-			httperr.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
-			return
-		}
-
-		sil, err := getSilenceByID(r.Context(), upstream, transport, silID)
-		if err != nil {
-			var notFound *silence.GetSilenceNotFound
-			if errors.As(err, &notFound) {
-				w.WriteHeader(http.StatusNotFound)
+			tenantID, ok := authentication.GetTenantID(r.Context())
+			if !ok {
+				httperr.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
 				return
 			}
-			httperr.PrometheusAPIError(w, fmt.Sprintf("proxy error: %v", err), http.StatusBadGateway)
-			return
-		}
 
-		if !hasMatcherForLabel(sil.Matchers, label, tenantID) {
-			httperr.PrometheusAPIError(w, "forbidden", http.StatusForbidden)
-			return
-		}
+			sil, err := getSilenceByID(r.Context(), upstream, transport, silID)
+			if err != nil {
+				var notFound *silence.GetSilenceNotFound
+				if errors.As(err, &notFound) {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				httperr.PrometheusAPIError(w, fmt.Sprintf("proxy error: %v", err), http.StatusBadGateway)
+				return
+			}
 
-		r.URL.RawQuery = ""
-		next.ServeHTTP(w, r)
-	})
+			if !hasMatcherForLabel(sil.Matchers, label, tenantID) {
+				httperr.PrometheusAPIError(w, "forbidden", http.StatusForbidden)
+				return
+			}
+
+			r.URL.RawQuery = ""
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 func getSilenceByID(ctx context.Context, upstream *url.URL, transport http.RoundTripper, id string) (*models.GettableSilence, error) {
@@ -239,9 +204,6 @@ func getSilenceByID(ctx context.Context, upstream *url.URL, transport http.Round
 
 func hasMatcherForLabel(matchers models.Matchers, name, value string) bool {
 	for _, m := range matchers {
-		if m.Name == nil || m.Value == nil || m.IsRegex == nil {
-			continue
-		}
 		if *m.Name == name && !*m.IsRegex && *m.Value == value {
 			return true
 		}

--- a/api/metrics/v1/alertmanager_enforcer.go
+++ b/api/metrics/v1/alertmanager_enforcer.go
@@ -2,12 +2,21 @@ package v1
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"path"
 	"strconv"
 
+	"github.com/go-chi/chi/v5"
+	runtimeclient "github.com/go-openapi/runtime/client"
+	"github.com/go-openapi/strfmt"
+	"github.com/prometheus/alertmanager/api/v2/client"
+	"github.com/prometheus/alertmanager/api/v2/client/silence"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	amlabels "github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/prometheus/model/labels"
@@ -64,10 +73,11 @@ func WithEnforceTenancyOnFilter(label string) func(http.Handler) http.Handler {
 	}
 }
 
-// WithEnforceTenancyOnFilter returns a middleware that ensures that every filter has a tenant label enforced.
+// WithEnforceTenancyOnSilenceMatchers returns a middleware that ensures POST silence requests
+// include the tenant label matcher.
 func WithEnforceTenancyOnSilenceMatchers(label string) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		// https://github.com/prometheus-community/prom-label-proxy/
+		// https://github.com/prometheus-community/prom-label-proxy/injectproxy/silences.go
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			id, ok := authentication.GetTenantID(r.Context())
 			if !ok {
@@ -90,6 +100,7 @@ func WithEnforceTenancyOnSilenceMatchers(label string) func(http.Handler) http.H
 			if sil.ID != "" {
 				// This is an update for an existing silence.
 				httperr.PrometheusAPIError(w, "updates to silence by ID not allowed", http.StatusUnprocessableEntity)
+				return
 			}
 
 			var falsy bool
@@ -125,4 +136,115 @@ func WithEnforceTenancyOnSilenceMatchers(label string) func(http.Handler) http.H
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+// alertmanagerGetSilence returns a silence when it belongs to the tenant.
+func alertmanagerGetSilence(label string, upstream *url.URL, transport http.RoundTripper) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		silID := chi.URLParam(r, "silenceID")
+		if silID == "" {
+			httperr.PrometheusAPIError(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		tenantID, ok := authentication.GetTenantID(r.Context())
+		if !ok {
+			httperr.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
+			return
+		}
+
+		sil, err := getSilenceByID(r.Context(), upstream, transport, silID)
+		if err != nil {
+			var notFound *silence.GetSilenceNotFound
+			if errors.As(err, &notFound) {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			httperr.PrometheusAPIError(w, fmt.Sprintf("proxy error: %v", err), http.StatusBadGateway)
+			return
+		}
+
+		if !hasMatcherForLabel(sil.Matchers, label, tenantID) {
+			httperr.PrometheusAPIError(w, "forbidden", http.StatusForbidden)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(sil); err != nil {
+			httperr.PrometheusAPIError(w, fmt.Sprintf("can't encode: %v", err), http.StatusInternalServerError)
+		}
+	})
+}
+
+// alertmanagerDeleteSilence checks silence ownership then proxies DELETE to Alertmanager.
+// Adapted from https://github.com/prometheus-community/prom-label-proxy/blob/main/injectproxy/silences.go
+func alertmanagerDeleteSilence(label string, upstream *url.URL, transport http.RoundTripper, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		silID := chi.URLParam(r, "silenceID")
+		if silID == "" {
+			httperr.PrometheusAPIError(w, "bad request", http.StatusBadRequest)
+			return
+		}
+
+		tenantID, ok := authentication.GetTenantID(r.Context())
+		if !ok {
+			httperr.PrometheusAPIError(w, "error finding tenant ID", http.StatusInternalServerError)
+			return
+		}
+
+		sil, err := getSilenceByID(r.Context(), upstream, transport, silID)
+		if err != nil {
+			var notFound *silence.GetSilenceNotFound
+			if errors.As(err, &notFound) {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			httperr.PrometheusAPIError(w, fmt.Sprintf("proxy error: %v", err), http.StatusBadGateway)
+			return
+		}
+
+		if !hasMatcherForLabel(sil.Matchers, label, tenantID) {
+			httperr.PrometheusAPIError(w, "forbidden", http.StatusForbidden)
+			return
+		}
+
+		r.URL.RawQuery = ""
+		next.ServeHTTP(w, r)
+	})
+}
+
+func getSilenceByID(ctx context.Context, upstream *url.URL, transport http.RoundTripper, id string) (*models.GettableSilence, error) {
+	if transport == nil {
+		transport = http.DefaultTransport
+	}
+
+	rt := runtimeclient.NewWithClient(
+		upstream.Host,
+		path.Join(upstream.Path, "/api/v2"),
+		[]string{upstream.Scheme},
+		&http.Client{Transport: transport},
+	)
+	amc := client.New(rt, strfmt.Default)
+
+	params := silence.NewGetSilenceParams().WithContext(ctx)
+	params.SetSilenceID(strfmt.UUID(id))
+
+	res, err := amc.Silence.GetSilence(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return res.Payload, nil
+}
+
+func hasMatcherForLabel(matchers models.Matchers, name, value string) bool {
+	for _, m := range matchers {
+		if m.Name == nil || m.Value == nil || m.IsRegex == nil {
+			continue
+		}
+		if *m.Name == name && !*m.IsRegex && *m.Value == value {
+			return true
+		}
+	}
+	return false
 }

--- a/api/metrics/v1/alertmanager_enforcer_test.go
+++ b/api/metrics/v1/alertmanager_enforcer_test.go
@@ -79,7 +79,7 @@ func TestHasMatcherForLabel(t *testing.T) {
 	}
 }
 
-func TestAlertmanagerDeleteSilence(t *testing.T) {
+func TestWithEnforceTenancyOnSilenceID(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -111,11 +111,76 @@ func TestAlertmanagerDeleteSilence(t *testing.T) {
 }`
 	}
 
-	t.Run("allows delete when silence belongs to tenant", func(t *testing.T) {
+	newRouter := func(t *testing.T, upstream http.Handler, next http.Handler) *chi.Mux {
+		t.Helper()
+
+		srv := httptest.NewServer(upstream)
+		t.Cleanup(srv.Close)
+
+		upstreamURL, err := url.Parse(srv.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := chi.NewRouter()
+		r.Use(authentication.WithTenant)
+		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
+		r.With(WithEnforceTenancyOnSilenceID(label, upstreamURL, srv.Client().Transport)).Method(
+			http.MethodGet,
+			"/{tenant}/am/api/v2/silence/{silenceID}",
+			next,
+		)
+		r.With(WithEnforceTenancyOnSilenceID(label, upstreamURL, srv.Client().Transport)).Method(
+			http.MethodDelete,
+			"/{tenant}/am/api/v2/silence/{silenceID}",
+			next,
+		)
+
+		return r
+	}
+
+	newRequest := func(method string) *http.Request {
+		req := httptest.NewRequest(method, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("tenant", tenantName)
+		rctx.URLParams.Add("silenceID", silID)
+		return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	}
+
+	t.Run("proxies get when silence belongs to tenant", func(t *testing.T) {
+		t.Parallel()
+
+		var proxyCalled bool
+		upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet && r.URL.Path == "/api/v2/silence/"+silID {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(silenceJSON(tenantID)))
+				return
+			}
+			http.NotFound(w, r)
+		})
+		next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			proxyCalled = true
+			w.WriteHeader(http.StatusOK)
+		})
+
+		rec := httptest.NewRecorder()
+		newRouter(t, upstream, next).ServeHTTP(rec, newRequest(http.MethodGet))
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+		}
+		if !proxyCalled {
+			t.Fatal("expected request to be proxied")
+		}
+	})
+
+	t.Run("proxies delete when silence belongs to tenant", func(t *testing.T) {
 		t.Parallel()
 
 		var deleteCalled bool
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			switch {
 			case r.Method == http.MethodGet && r.URL.Path == "/api/v2/silence/"+silID:
 				w.Header().Set("Content-Type", "application/json")
@@ -127,36 +192,14 @@ func TestAlertmanagerDeleteSilence(t *testing.T) {
 			default:
 				http.NotFound(w, r)
 			}
-		}))
-		t.Cleanup(upstream.Close)
-
-		upstreamURL, err := url.Parse(upstream.URL)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		r := chi.NewRouter()
-		r.Use(authentication.WithTenant)
-		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
-		deleteHandler := alertmanagerDeleteSilence(
-			label,
-			upstreamURL,
-			upstream.Client().Transport,
-			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				deleteCalled = true
-				w.WriteHeader(http.StatusOK)
-			}),
-		)
-		r.Delete("/{tenant}/am/api/v2/silence/{silenceID}", deleteHandler.ServeHTTP)
-
-		req := httptest.NewRequest(http.MethodDelete, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
-		rctx := chi.NewRouteContext()
-		rctx.URLParams.Add("tenant", tenantName)
-		rctx.URLParams.Add("silenceID", silID)
-		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+		})
+		next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			deleteCalled = true
+			w.WriteHeader(http.StatusOK)
+		})
 
 		rec := httptest.NewRecorder()
-		r.ServeHTTP(rec, req)
+		newRouter(t, upstream, next).ServeHTTP(rec, newRequest(http.MethodDelete))
 
 		if rec.Code != http.StatusOK {
 			t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
@@ -169,7 +212,7 @@ func TestAlertmanagerDeleteSilence(t *testing.T) {
 	t.Run("forbidden when silence belongs to another tenant", func(t *testing.T) {
 		t.Parallel()
 
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upstream := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Method == http.MethodGet && r.URL.Path == "/api/v2/silence/"+silID {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
@@ -177,146 +220,12 @@ func TestAlertmanagerDeleteSilence(t *testing.T) {
 				return
 			}
 			http.NotFound(w, r)
-		}))
-		t.Cleanup(upstream.Close)
-
-		upstreamURL, err := url.Parse(upstream.URL)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		r := chi.NewRouter()
-		r.Use(authentication.WithTenant)
-		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
-		deleteHandler := alertmanagerDeleteSilence(
-			label,
-			upstreamURL,
-			upstream.Client().Transport,
-			http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
-				t.Fatal("delete should not be proxied")
-			}),
-		)
-		r.Delete("/{tenant}/am/api/v2/silence/{silenceID}", deleteHandler.ServeHTTP)
-
-		req := httptest.NewRequest(http.MethodDelete, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
-		rctx := chi.NewRouteContext()
-		rctx.URLParams.Add("tenant", tenantName)
-		rctx.URLParams.Add("silenceID", silID)
-		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+		})
 
 		rec := httptest.NewRecorder()
-		r.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusForbidden {
-			t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
-		}
-	})
-}
-
-func TestAlertmanagerGetSilence(t *testing.T) {
-	t.Parallel()
-
-	const (
-		label      = "tenant_id"
-		tenantName = "test-oidc"
-		tenantID   = "1610b0c3-c509-4592-a256-a1871353dbfa"
-		silID      = "802146e0-1f7a-42a6-ab0e-1e631479970b"
-	)
-
-	silenceJSON := func(tenant string) string {
-		t.Helper()
-		return `{
-  "id": "` + silID + `",
-  "status": {
-    "state": "active"
-  },
-  "updatedAt": "2020-01-15T09:06:23.419Z",
-  "comment": "comment",
-  "createdBy": "author",
-  "endsAt": "2020-02-13T13:00:02.084Z",
-  "matchers": [
-    {
-      "isRegex": false,
-      "name": "` + label + `",
-      "value": "` + tenant + `"
-    }
-  ],
-  "startsAt": "2020-02-13T12:02:01.000Z"
-}`
-	}
-
-	t.Run("returns silence for tenant", func(t *testing.T) {
-		t.Parallel()
-
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodGet && r.URL.Path == "/api/v2/silence/"+silID {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(silenceJSON(tenantID)))
-				return
-			}
-			http.NotFound(w, r)
-		}))
-		t.Cleanup(upstream.Close)
-
-		upstreamURL, err := url.Parse(upstream.URL)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		r := chi.NewRouter()
-		r.Use(authentication.WithTenant)
-		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
-		getHandler := alertmanagerGetSilence(label, upstreamURL, upstream.Client().Transport)
-		r.Get("/{tenant}/am/api/v2/silence/{silenceID}", getHandler.ServeHTTP)
-
-		req := httptest.NewRequest(http.MethodGet, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
-		rctx := chi.NewRouteContext()
-		rctx.URLParams.Add("tenant", tenantName)
-		rctx.URLParams.Add("silenceID", silID)
-		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-
-		rec := httptest.NewRecorder()
-		r.ServeHTTP(rec, req)
-
-		if rec.Code != http.StatusOK {
-			t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
-		}
-	})
-
-	t.Run("forbidden for other tenant silence", func(t *testing.T) {
-		t.Parallel()
-
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Method == http.MethodGet && r.URL.Path == "/api/v2/silence/"+silID {
-				w.Header().Set("Content-Type", "application/json")
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(silenceJSON("other-tenant")))
-				return
-			}
-			http.NotFound(w, r)
-		}))
-		t.Cleanup(upstream.Close)
-
-		upstreamURL, err := url.Parse(upstream.URL)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		r := chi.NewRouter()
-		r.Use(authentication.WithTenant)
-		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
-		getHandler := alertmanagerGetSilence(label, upstreamURL, upstream.Client().Transport)
-		r.Get("/{tenant}/am/api/v2/silence/{silenceID}", getHandler.ServeHTTP)
-
-		req := httptest.NewRequest(http.MethodGet, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
-		rctx := chi.NewRouteContext()
-		rctx.URLParams.Add("tenant", tenantName)
-		rctx.URLParams.Add("silenceID", silID)
-		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
-
-		rec := httptest.NewRecorder()
-		r.ServeHTTP(rec, req)
+		newRouter(t, upstream, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			t.Fatal("request should not be proxied")
+		})).ServeHTTP(rec, newRequest(http.MethodGet))
 
 		if rec.Code != http.StatusForbidden {
 			t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
@@ -326,30 +235,14 @@ func TestAlertmanagerGetSilence(t *testing.T) {
 	t.Run("not found when silence is missing", func(t *testing.T) {
 		t.Parallel()
 
-		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		upstream := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
-		}))
-		t.Cleanup(upstream.Close)
-
-		upstreamURL, err := url.Parse(upstream.URL)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		r := chi.NewRouter()
-		r.Use(authentication.WithTenant)
-		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
-		getHandler := alertmanagerGetSilence(label, upstreamURL, upstream.Client().Transport)
-		r.Get("/{tenant}/am/api/v2/silence/{silenceID}", getHandler.ServeHTTP)
-
-		req := httptest.NewRequest(http.MethodGet, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
-		rctx := chi.NewRouteContext()
-		rctx.URLParams.Add("tenant", tenantName)
-		rctx.URLParams.Add("silenceID", silID)
-		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+		})
 
 		rec := httptest.NewRecorder()
-		r.ServeHTTP(rec, req)
+		newRouter(t, upstream, http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			t.Fatal("request should not be proxied")
+		})).ServeHTTP(rec, newRequest(http.MethodDelete))
 
 		if rec.Code != http.StatusNotFound {
 			t.Fatalf("expected status %d, got %d", http.StatusNotFound, rec.Code)

--- a/api/metrics/v1/alertmanager_enforcer_test.go
+++ b/api/metrics/v1/alertmanager_enforcer_test.go
@@ -1,0 +1,362 @@
+package v1
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/alertmanager/api/v2/models"
+
+	"github.com/observatorium/api/authentication"
+)
+
+func TestHasMatcherForLabel(t *testing.T) {
+	t.Parallel()
+
+	label := "tenant_id"
+	tenantA := "1610b0c3-c509-4592-a256-a1871353dbfa"
+	falsy := false
+	truthy := true
+
+	matchersFor := func(tenantID string) models.Matchers {
+		return models.Matchers{
+			{
+				Name:    strPtr(label),
+				Value:   strPtr(tenantID),
+				IsRegex: &falsy,
+			},
+			{
+				Name:    strPtr("severity"),
+				Value:   strPtr("critical"),
+				IsRegex: &falsy,
+			},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		matchers models.Matchers
+		want     bool
+	}{
+		{
+			name:     "tenant matcher present",
+			matchers: matchersFor(tenantA),
+			want:     true,
+		},
+		{
+			name:     "different tenant",
+			matchers: matchersFor("tenant-b"),
+			want:     false,
+		},
+		{
+			name: "regex tenant matcher",
+			matchers: models.Matchers{
+				{
+					Name:    strPtr(label),
+					Value:   strPtr(tenantA),
+					IsRegex: &truthy,
+				},
+			},
+			want: false,
+		},
+		{
+			name:     "no tenant matcher",
+			matchers: matchersFor(tenantA)[1:],
+			want:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasMatcherForLabel(tc.matchers, label, tenantA); got != tc.want {
+				t.Fatalf("hasMatcherForLabel() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAlertmanagerDeleteSilence(t *testing.T) {
+	t.Parallel()
+
+	const (
+		label      = "tenant_id"
+		tenantName = "test-oidc"
+		tenantID   = "1610b0c3-c509-4592-a256-a1871353dbfa"
+		silID      = "802146e0-1f7a-42a6-ab0e-1e631479970b"
+	)
+
+	silenceJSON := func(tenant string) string {
+		t.Helper()
+		return `{
+  "id": "` + silID + `",
+  "status": {
+    "state": "active"
+  },
+  "updatedAt": "2020-01-15T09:06:23.419Z",
+  "comment": "comment",
+  "createdBy": "author",
+  "endsAt": "2020-02-13T13:00:02.084Z",
+  "matchers": [
+    {
+      "isRegex": false,
+      "name": "` + label + `",
+      "value": "` + tenant + `"
+    }
+  ],
+  "startsAt": "2020-02-13T12:02:01.000Z"
+}`
+	}
+
+	t.Run("allows delete when silence belongs to tenant", func(t *testing.T) {
+		t.Parallel()
+
+		var deleteCalled bool
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch {
+			case r.Method == http.MethodGet && r.URL.Path == "/api/v2/silence/"+silID:
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(silenceJSON(tenantID)))
+			case r.Method == http.MethodDelete && r.URL.Path == "/api/v2/silence/"+silID:
+				deleteCalled = true
+				w.WriteHeader(http.StatusOK)
+			default:
+				http.NotFound(w, r)
+			}
+		}))
+		t.Cleanup(upstream.Close)
+
+		upstreamURL, err := url.Parse(upstream.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := chi.NewRouter()
+		r.Use(authentication.WithTenant)
+		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
+		deleteHandler := alertmanagerDeleteSilence(
+			label,
+			upstreamURL,
+			upstream.Client().Transport,
+			http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				deleteCalled = true
+				w.WriteHeader(http.StatusOK)
+			}),
+		)
+		r.Delete("/{tenant}/am/api/v2/silence/{silenceID}", deleteHandler.ServeHTTP)
+
+		req := httptest.NewRequest(http.MethodDelete, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("tenant", tenantName)
+		rctx.URLParams.Add("silenceID", silID)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+		}
+		if !deleteCalled {
+			t.Fatal("expected delete to be proxied")
+		}
+	})
+
+	t.Run("forbidden when silence belongs to another tenant", func(t *testing.T) {
+		t.Parallel()
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet && r.URL.Path == "/api/v2/silence/"+silID {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(silenceJSON("other-tenant")))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(upstream.Close)
+
+		upstreamURL, err := url.Parse(upstream.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := chi.NewRouter()
+		r.Use(authentication.WithTenant)
+		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
+		deleteHandler := alertmanagerDeleteSilence(
+			label,
+			upstreamURL,
+			upstream.Client().Transport,
+			http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+				t.Fatal("delete should not be proxied")
+			}),
+		)
+		r.Delete("/{tenant}/am/api/v2/silence/{silenceID}", deleteHandler.ServeHTTP)
+
+		req := httptest.NewRequest(http.MethodDelete, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("tenant", tenantName)
+		rctx.URLParams.Add("silenceID", silID)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+		}
+	})
+}
+
+func TestAlertmanagerGetSilence(t *testing.T) {
+	t.Parallel()
+
+	const (
+		label      = "tenant_id"
+		tenantName = "test-oidc"
+		tenantID   = "1610b0c3-c509-4592-a256-a1871353dbfa"
+		silID      = "802146e0-1f7a-42a6-ab0e-1e631479970b"
+	)
+
+	silenceJSON := func(tenant string) string {
+		t.Helper()
+		return `{
+  "id": "` + silID + `",
+  "status": {
+    "state": "active"
+  },
+  "updatedAt": "2020-01-15T09:06:23.419Z",
+  "comment": "comment",
+  "createdBy": "author",
+  "endsAt": "2020-02-13T13:00:02.084Z",
+  "matchers": [
+    {
+      "isRegex": false,
+      "name": "` + label + `",
+      "value": "` + tenant + `"
+    }
+  ],
+  "startsAt": "2020-02-13T12:02:01.000Z"
+}`
+	}
+
+	t.Run("returns silence for tenant", func(t *testing.T) {
+		t.Parallel()
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet && r.URL.Path == "/api/v2/silence/"+silID {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(silenceJSON(tenantID)))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(upstream.Close)
+
+		upstreamURL, err := url.Parse(upstream.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := chi.NewRouter()
+		r.Use(authentication.WithTenant)
+		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
+		getHandler := alertmanagerGetSilence(label, upstreamURL, upstream.Client().Transport)
+		r.Get("/{tenant}/am/api/v2/silence/{silenceID}", getHandler.ServeHTTP)
+
+		req := httptest.NewRequest(http.MethodGet, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("tenant", tenantName)
+		rctx.URLParams.Add("silenceID", silID)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected status %d, got %d", http.StatusOK, rec.Code)
+		}
+	})
+
+	t.Run("forbidden for other tenant silence", func(t *testing.T) {
+		t.Parallel()
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Method == http.MethodGet && r.URL.Path == "/api/v2/silence/"+silID {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(silenceJSON("other-tenant")))
+				return
+			}
+			http.NotFound(w, r)
+		}))
+		t.Cleanup(upstream.Close)
+
+		upstreamURL, err := url.Parse(upstream.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := chi.NewRouter()
+		r.Use(authentication.WithTenant)
+		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
+		getHandler := alertmanagerGetSilence(label, upstreamURL, upstream.Client().Transport)
+		r.Get("/{tenant}/am/api/v2/silence/{silenceID}", getHandler.ServeHTTP)
+
+		req := httptest.NewRequest(http.MethodGet, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("tenant", tenantName)
+		rctx.URLParams.Add("silenceID", silID)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusForbidden {
+			t.Fatalf("expected status %d, got %d", http.StatusForbidden, rec.Code)
+		}
+	})
+
+	t.Run("not found when silence is missing", func(t *testing.T) {
+		t.Parallel()
+
+		upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		t.Cleanup(upstream.Close)
+
+		upstreamURL, err := url.Parse(upstream.URL)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		r := chi.NewRouter()
+		r.Use(authentication.WithTenant)
+		r.Use(authentication.WithTenantID(map[string]string{tenantName: tenantID}))
+		getHandler := alertmanagerGetSilence(label, upstreamURL, upstream.Client().Transport)
+		r.Get("/{tenant}/am/api/v2/silence/{silenceID}", getHandler.ServeHTTP)
+
+		req := httptest.NewRequest(http.MethodGet, "/"+tenantName+"/am/api/v2/silence/"+silID, nil)
+		rctx := chi.NewRouteContext()
+		rctx.URLParams.Add("tenant", tenantName)
+		rctx.URLParams.Add("silenceID", silID)
+		req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+		}
+	})
+}
+
+func strPtr(s string) *string {
+	return &s
+}

--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -41,9 +41,11 @@ const (
 )
 
 type alertmanagerMiddleware struct {
-	alertsReadMiddlewares   []func(http.Handler) http.Handler
-	silenceReadMiddlewares  []func(http.Handler) http.Handler
-	silenceWriteMiddlewares []func(http.Handler) http.Handler
+	alertsReadMiddlewares     []func(http.Handler) http.Handler
+	silenceReadMiddlewares    []func(http.Handler) http.Handler
+	silenceWriteMiddlewares   []func(http.Handler) http.Handler
+	silenceIDReadMiddlewares  []func(http.Handler) http.Handler
+	silenceIDWriteMiddlewares []func(http.Handler) http.Handler
 }
 
 type handlerConfiguration struct {
@@ -135,6 +137,18 @@ func WithAlertmanagerSilenceWriteMiddleware(m ...func(http.Handler) http.Handler
 	}
 }
 
+func WithAlertmanagerSilenceIDReadMiddleware(m ...func(http.Handler) http.Handler) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.alertmanagerMiddleware.silenceIDReadMiddlewares = append(h.alertmanagerMiddleware.silenceIDReadMiddlewares, m...)
+	}
+}
+
+func WithAlertmanagerSilenceIDWriteMiddleware(m ...func(http.Handler) http.Handler) HandlerOption {
+	return func(h *handlerConfiguration) {
+		h.alertmanagerMiddleware.silenceIDWriteMiddlewares = append(h.alertmanagerMiddleware.silenceIDWriteMiddlewares, m...)
+	}
+}
+
 // WithGlobalMiddleware adds a middleware for all operations.
 func WithGlobalMiddleware(m ...func(http.Handler) http.Handler) HandlerOption {
 	return func(h *handlerConfiguration) {
@@ -145,6 +159,8 @@ func WithGlobalMiddleware(m ...func(http.Handler) http.Handler) HandlerOption {
 		h.alertmanagerMiddleware.alertsReadMiddlewares = append(h.alertmanagerMiddleware.alertsReadMiddlewares, m...)
 		h.alertmanagerMiddleware.silenceReadMiddlewares = append(h.alertmanagerMiddleware.silenceReadMiddlewares, m...)
 		h.alertmanagerMiddleware.silenceWriteMiddlewares = append(h.alertmanagerMiddleware.silenceWriteMiddlewares, m...)
+		h.alertmanagerMiddleware.silenceIDReadMiddlewares = append(h.alertmanagerMiddleware.silenceIDReadMiddlewares, m...)
+		h.alertmanagerMiddleware.silenceIDWriteMiddlewares = append(h.alertmanagerMiddleware.silenceIDWriteMiddlewares, m...)
 	}
 }
 
@@ -465,6 +481,11 @@ func NewHandler(endpoints Endpoints, tlsOptions *tls.UpstreamOptions, opts ...Ha
 		})
 
 		alertmanagerSilenceTransport := otelhttp.NewTransport(alertmanagerTransport)
+		enforceTenancyOnSilenceID := WithEnforceTenancyOnSilenceID(
+			c.tenantLabel,
+			endpoints.AlertmanagerEndpoint,
+			alertmanagerSilenceTransport,
+		)
 
 		r.Group(func(r chi.Router) {
 			r.Use(func(handler http.Handler) http.Handler {
@@ -473,15 +494,11 @@ func NewHandler(endpoints Endpoints, tlsOptions *tls.UpstreamOptions, opts ...Ha
 					handler,
 				)
 			})
-			r.Use(c.alertmanagerMiddleware.silenceReadMiddlewares...)
+			r.Use(enforceTenancyOnSilenceID)
+			r.Use(c.alertmanagerMiddleware.silenceIDReadMiddlewares...)
 			r.Use(server.StripTenantPrefixWithSubRoute("/api/metrics/v1", "/am"))
 
-			getSilence := alertmanagerGetSilence(
-				c.tenantLabel,
-				endpoints.AlertmanagerEndpoint,
-				alertmanagerSilenceTransport,
-			)
-			r.Method(http.MethodGet, AlertmanagerSilenceRoute, getSilence)
+			r.Method(http.MethodGet, AlertmanagerSilenceRoute, proxyAlertmanager)
 		})
 
 		r.Group(func(r chi.Router) {
@@ -491,16 +508,11 @@ func NewHandler(endpoints Endpoints, tlsOptions *tls.UpstreamOptions, opts ...Ha
 					handler,
 				)
 			})
-			r.Use(c.alertmanagerMiddleware.silenceWriteMiddlewares...)
+			r.Use(enforceTenancyOnSilenceID)
+			r.Use(c.alertmanagerMiddleware.silenceIDWriteMiddlewares...)
 			r.Use(server.StripTenantPrefixWithSubRoute("/api/metrics/v1", "/am"))
 
-			deleteSilence := alertmanagerDeleteSilence(
-				c.tenantLabel,
-				endpoints.AlertmanagerEndpoint,
-				alertmanagerSilenceTransport,
-				proxyAlertmanager,
-			)
-			r.Method(http.MethodDelete, AlertmanagerSilenceRoute, deleteSilence)
+			r.Method(http.MethodDelete, AlertmanagerSilenceRoute, proxyAlertmanager)
 		})
 	}
 

--- a/api/metrics/v1/http.go
+++ b/api/metrics/v1/http.go
@@ -37,6 +37,7 @@ const (
 
 	AlertmanagerAlertsRoute   = "/am/api/v2/alerts"
 	AlertmanagerSilencesRoute = "/am/api/v2/silences"
+	AlertmanagerSilenceRoute  = "/am/api/v2/silence/{silenceID}"
 )
 
 type alertmanagerMiddleware struct {
@@ -400,6 +401,14 @@ func NewHandler(endpoints Endpoints, tlsOptions *tls.UpstreamOptions, opts ...Ha
 
 	if endpoints.AlertmanagerEndpoint != nil {
 		var proxyAlertmanager http.Handler
+
+		alertmanagerTransport := &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: dialTimeout,
+			}).DialContext,
+			TLSClientConfig: tlsOptions.NewClientConfig(),
+		}
+
 		{
 			middlewares := proxy.Middlewares(
 				proxy.MiddlewareSetUpstream(endpoints.AlertmanagerEndpoint),
@@ -408,17 +417,10 @@ func NewHandler(endpoints Endpoints, tlsOptions *tls.UpstreamOptions, opts ...Ha
 				proxy.MiddlewareMetrics(c.registry, prometheus.Labels{"proxy": "alertmanagerv2"}),
 			)
 
-			t := &http.Transport{
-				DialContext: (&net.Dialer{
-					Timeout: dialTimeout,
-				}).DialContext,
-				TLSClientConfig: tlsOptions.NewClientConfig(),
-			}
-
 			proxyAlertmanager = &httputil.ReverseProxy{
 				Director:  middlewares,
 				ErrorLog:  proxy.Logger(c.logger),
-				Transport: otelhttp.NewTransport(t),
+				Transport: otelhttp.NewTransport(alertmanagerTransport),
 			}
 		}
 
@@ -456,9 +458,49 @@ func NewHandler(endpoints Endpoints, tlsOptions *tls.UpstreamOptions, opts ...Ha
 				)
 			})
 			r.Use(c.alertmanagerMiddleware.silenceWriteMiddlewares...)
+			r.Use(WithEnforceTenancyOnSilenceMatchers(c.tenantLabel))
 			r.Use(server.StripTenantPrefixWithSubRoute("/api/metrics/v1", "/am"))
 
 			r.Method(http.MethodPost, AlertmanagerSilencesRoute, proxyAlertmanager)
+		})
+
+		alertmanagerSilenceTransport := otelhttp.NewTransport(alertmanagerTransport)
+
+		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "silence"},
+					handler,
+				)
+			})
+			r.Use(c.alertmanagerMiddleware.silenceReadMiddlewares...)
+			r.Use(server.StripTenantPrefixWithSubRoute("/api/metrics/v1", "/am"))
+
+			getSilence := alertmanagerGetSilence(
+				c.tenantLabel,
+				endpoints.AlertmanagerEndpoint,
+				alertmanagerSilenceTransport,
+			)
+			r.Method(http.MethodGet, AlertmanagerSilenceRoute, getSilence)
+		})
+
+		r.Group(func(r chi.Router) {
+			r.Use(func(handler http.Handler) http.Handler {
+				return server.InjectLabelsCtx(
+					prometheus.Labels{"group": "metricsv1", "handler": "silence"},
+					handler,
+				)
+			})
+			r.Use(c.alertmanagerMiddleware.silenceWriteMiddlewares...)
+			r.Use(server.StripTenantPrefixWithSubRoute("/api/metrics/v1", "/am"))
+
+			deleteSilence := alertmanagerDeleteSilence(
+				c.tenantLabel,
+				endpoints.AlertmanagerEndpoint,
+				alertmanagerSilenceTransport,
+				proxyAlertmanager,
+			)
+			r.Method(http.MethodDelete, AlertmanagerSilenceRoute, deleteSilence)
 		})
 	}
 

--- a/main.go
+++ b/main.go
@@ -758,7 +758,6 @@ func main() {
 						),
 						metricsv1.WithAlertmanagerSilenceWriteMiddleware(
 							authorization.WithAuthorizers(authorizers, rbac.Write, "metrics"),
-							metricsv1.WithEnforceTenancyOnSilenceMatchers(cfg.metrics.tenantLabel),
 						),
 					),
 					)

--- a/main.go
+++ b/main.go
@@ -759,6 +759,12 @@ func main() {
 						metricsv1.WithAlertmanagerSilenceWriteMiddleware(
 							authorization.WithAuthorizers(authorizers, rbac.Write, "metrics"),
 						),
+						metricsv1.WithAlertmanagerSilenceIDReadMiddleware(
+							authorization.WithAuthorizers(authorizers, rbac.Read, "metrics"),
+						),
+						metricsv1.WithAlertmanagerSilenceIDWriteMiddleware(
+							authorization.WithAuthorizers(authorizers, rbac.Write, "metrics"),
+						),
 					),
 					)
 				})


### PR DESCRIPTION
This commit adds silence/ endpoints for individually getting and deleting silences.

Uses similar prom-label-proxy approach from
https://github.com/prometheus-community/prom-label-proxy/blob/main/injectproxy/silences.go

Tests written with AI.