### PR TITLE
fix: Tempo proxy fails when browser advertises unsupported encodings

### DIFF
--- a/api/traces/v1/http.go
+++ b/api/traces/v1/http.go
@@ -2,8 +2,6 @@ package v1
 
 import (
 	"bytes"
-	"compress/flate"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"net"
@@ -18,6 +16,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
+	"github.com/klauspost/compress/gzhttp"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 
@@ -164,7 +163,7 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo, writeOTLPHttp *url.
 			proxyRead = &httputil.ReverseProxy{
 				Director:  middlewares,
 				ErrorLog:  proxy.Logger(c.logger),
-				Transport: otelhttp.NewTransport(t),
+				Transport: decompressingTransport(otelhttp.NewTransport(t)),
 
 				// This is a key piece, it changes <base href=> tags on text/html content
 				ModifyResponse: jaegerUIResponseModifier,
@@ -261,6 +260,7 @@ func NewV2Handler(read *url.URL, readTemplate string, tempo, writeOTLPHttp *url.
 			Transport: otelhttp.NewTransport(t),
 		}
 		if c.enableRBAC {
+			tempoProxyRead.Transport = decompressingTransport(tempoProxyRead.Transport)
 			tempoProxyRead.ModifyResponse = responseRBACModifier(c.logger)
 		}
 
@@ -316,27 +316,7 @@ func jaegerUIResponseModifier(response *http.Response) error {
 	// Only modify successful HTTP with HTML content
 	if response.StatusCode == http.StatusOK && strings.HasPrefix(response.Header.Get("Content-Type"), "text/html") {
 		// Do man-in-the-middle rewriting of the UI HTML.
-		var err error
-
-		// Uncompressed reader
-		var reader io.ReadCloser
-
-		// Read what Jaeger UI sent back (which might be compressed)
-		switch response.Header.Get("Content-Encoding") {
-		case "gzip":
-			reader, err = gzip.NewReader(response.Body)
-			if err != nil {
-				return err
-			}
-			defer reader.Close()
-		case "deflate":
-			reader = flate.NewReader(response.Body)
-			defer reader.Close()
-		default:
-			reader = response.Body
-		}
-
-		b, err := io.ReadAll(reader)
+		b, err := io.ReadAll(response.Body)
 		if err != nil {
 			return err
 		}
@@ -361,4 +341,20 @@ func jaegerUIResponseModifier(response *http.Response) error {
 	}
 
 	return nil
+}
+
+// decompressingTransport wraps a transport with gzhttp.Transport for transparent decompression.
+// The reverse proxy copies the client's Accept-Encoding, which may include encodings we can't decode.
+// We clear it because gzhttp.Transport only sets its own supported encodings when the header is absent.
+func decompressingTransport(inner http.RoundTripper) http.RoundTripper {
+	return &acceptEncodingClearer{inner: gzhttp.Transport(inner)}
+}
+
+type acceptEncodingClearer struct {
+	inner http.RoundTripper
+}
+
+func (t *acceptEncodingClearer) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.Header.Del("Accept-Encoding")
+	return t.inner.RoundTrip(req)
 }

--- a/api/traces/v1/http_test.go
+++ b/api/traces/v1/http_test.go
@@ -1,0 +1,89 @@
+package v1
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func gzipBytes(t *testing.T, data []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, err := w.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+	return buf.Bytes()
+}
+
+func TestDecompressingTransport(t *testing.T) {
+	body := []byte("hello world")
+
+	t.Run("clears Accept-Encoding and passes through uncompressed response", func(t *testing.T) {
+		var capturedHeader string
+		inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			capturedHeader = req.Header.Get("Accept-Encoding")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(body)),
+				Header:     http.Header{},
+			}, nil
+		})
+
+		transport := decompressingTransport(inner)
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept-Encoding", "br, zstd, gzip")
+
+		resp, err := transport.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.NotEqual(t, "br, zstd, gzip", capturedHeader, "original Accept-Encoding should not be forwarded")
+		assert.Empty(t, resp.Header.Get("Content-Encoding"))
+
+		got, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, body, got)
+	})
+
+	t.Run("transparently decompresses gzip response", func(t *testing.T) {
+		compressed := gzipBytes(t, body)
+		inner := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(bytes.NewReader(compressed)),
+				Header: http.Header{
+					"Content-Encoding": []string{"gzip"},
+				},
+			}, nil
+		})
+
+		transport := decompressingTransport(inner)
+
+		req, err := http.NewRequest("GET", "http://example.com", nil)
+		require.NoError(t, err)
+
+		resp, err := transport.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		got, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Equal(t, body, got)
+		assert.Empty(t, resp.Header.Get("Content-Encoding"))
+	})
+
+}

--- a/api/traces/v1/http_test.go
+++ b/api/traces/v1/http_test.go
@@ -43,7 +43,7 @@ func TestDecompressingTransport(t *testing.T) {
 
 		transport := decompressingTransport(inner)
 
-		req, err := http.NewRequest("GET", "http://example.com", nil)
+		req, err := http.NewRequest("GET", "http://localhost", nil)
 		require.NoError(t, err)
 		req.Header.Set("Accept-Encoding", "br, zstd, gzip")
 
@@ -73,7 +73,7 @@ func TestDecompressingTransport(t *testing.T) {
 
 		transport := decompressingTransport(inner)
 
-		req, err := http.NewRequest("GET", "http://example.com", nil)
+		req, err := http.NewRequest("GET", "http://localhost", nil)
 		require.NoError(t, err)
 
 		resp, err := transport.RoundTrip(req)

--- a/api/traces/v1/http_test.go
+++ b/api/traces/v1/http_test.go
@@ -85,5 +85,4 @@ func TestDecompressingTransport(t *testing.T) {
 		assert.Equal(t, body, got)
 		assert.Empty(t, resp.Header.Get("Content-Encoding"))
 	})
-
 }

--- a/api/traces/v1/trace_rbac.go
+++ b/api/traces/v1/trace_rbac.go
@@ -2,8 +2,6 @@ package v1
 
 import (
 	"bytes"
-	"compress/flate"
-	"compress/gzip"
 	"fmt"
 	"io"
 	"net/http"
@@ -73,26 +71,7 @@ func responseRBACModifier(log log.Logger) func(response *http.Response) error {
 			level.Debug(log).Log("AllowedNamespaces", fmt.Sprintf("%v", allowedNamespaces))
 
 			if response.StatusCode == http.StatusOK {
-				// Uncompressed reader
-				var reader io.ReadCloser
-				var err error
-
-				// Read what Jaeger UI sent back (which might be compressed)
-				switch response.Header.Get("Content-Encoding") {
-				case "gzip":
-					reader, err = gzip.NewReader(response.Body)
-					if err != nil {
-						return err
-					}
-					defer reader.Close()
-				case "deflate":
-					reader = flate.NewReader(response.Body)
-					defer reader.Close()
-				default:
-					reader = response.Body
-				}
-
-				b, err := io.ReadAll(reader)
+				b, err := io.ReadAll(response.Body)
 				if err != nil {
 					return err
 				}

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.3
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0
+	github.com/klauspost/compress v1.18.2
 	github.com/metalmatze/signal v0.0.0-20210307161603-1c9aa721a97a
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/mwitkow/grpc-proxy v0.0.0-20250813121105-2866842de9a5


### PR DESCRIPTION
Previously, the reverse proxy forwarded the browser's Accept-Encoding header to Tempo. If the browser advertised an encoding we couldn't decompress (e.g. zstd), the response arrived in that encoding and our ModifyResponse handlers failed to read it.

Now we let gzhttp.Transport set only the encodings it can transparently decompress, removing the manual gzip/deflate decompression in ModifyResponse handlers.