### PR TITLE
CVE-2026-62147: block Tempo APIs other than /api/search and /api/traces when query RBAC is enabled

### DIFF
--- a/api/traces/v1/trace_rbac.go
+++ b/api/traces/v1/trace_rbac.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strings"
 
 	"github.com/go-kit/log"
@@ -23,23 +24,37 @@ const (
 	serviceAttributeKey   = "service.name"
 )
 
-func WithTraceQLNamespaceSelectAndForbidOtherAPIs() func(http.Handler) http.Handler {
+var allowedTempoAPIs = []*regexp.Regexp{
+	regexp.MustCompile(`^/api/traces/\w+$`),
+	regexp.MustCompile(`^/api/search$`),
+}
+
+func matchesAnyRegex(s string, patterns []*regexp.Regexp) bool {
+	for _, re := range patterns {
+		if re.MatchString(s) {
+			return true
+		}
+	}
+	return false
+}
+
+func WithTraceQLNamespaceSelectAndForbidOtherAPIs(enabled bool) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// do not run if request is not for Tempo
-			if !strings.Contains(r.URL.Path, "/tempo") {
+			if !enabled {
 				next.ServeHTTP(w, r)
 				return
 			}
 
-			// block other APIs than api/search and api/traces
-			if !strings.Contains(r.URL.Path, "/api/traces") &&
-				!strings.Contains(r.URL.Path, "/api/search") {
+			// This middleware is registered at /tempo/...
+			requestedTempoPath := strings.TrimPrefix(r.URL.Path, "/tempo")
+
+			if !matchesAnyRegex(requestedTempoPath, allowedTempoAPIs) {
 				w.WriteHeader(http.StatusForbidden)
 				return
 			}
 
-			if strings.Contains(r.URL.Path, "/api/search") {
+			if requestedTempoPath == "/api/search" {
 				query := r.URL.Query()
 				q := query.Get("q")
 				traceQL, err := url.QueryUnescape(q)
@@ -62,7 +77,7 @@ func WithTraceQLNamespaceSelectAndForbidOtherAPIs() func(http.Handler) http.Hand
 
 func responseRBACModifier(log log.Logger) func(response *http.Response) error {
 	return func(response *http.Response) error {
-		if strings.Contains(response.Request.URL.Path, "/api/traces/") || strings.Contains(response.Request.URL.Path, "/api/search") {
+		if strings.HasPrefix(response.Request.URL.Path, "/api/traces/") || strings.HasPrefix(response.Request.URL.Path, "/api/search") {
 			allowedNamespaces := map[string]bool{}
 			namespaces := apilogsv1.AllowedNamespaces(response.Request.Context())
 			for _, ns := range namespaces {
@@ -77,7 +92,7 @@ func responseRBACModifier(log log.Logger) func(response *http.Response) error {
 				}
 
 				responseBuffer := &bytes.Buffer{}
-				if strings.Contains(response.Request.URL.Path, "/api/traces/") {
+				if strings.HasPrefix(response.Request.URL.Path, "/api/traces/") {
 					trace := &tempopb.Trace{}
 					err = tempopb.UnmarshalFromJSONV1(b, trace)
 					if err != nil {

--- a/api/traces/v1/trace_rbac_test.go
+++ b/api/traces/v1/trace_rbac_test.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/grafana/tempo/pkg/tempopb"
@@ -9,6 +11,37 @@ import (
 	tracev1 "github.com/grafana/tempo/pkg/tempopb/trace/v1"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestForbidOtherAPIs(t *testing.T) {
+	nextHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler := WithTraceQLNamespaceSelectAndForbidOtherAPIs(true)(nextHandler)
+
+	tests := []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{"trace by ID", "/tempo/api/traces/abc123", http.StatusOK},
+		{"search", "/tempo/api/search", http.StatusOK},
+		{"search tags blocked", "/tempo/api/search/tags", http.StatusForbidden},
+		{"search tag values blocked", "/tempo/api/search/tag/name/values", http.StatusForbidden},
+		{"v2 search tags blocked", "/tempo/api/v2/search/tags", http.StatusForbidden},
+		{"metrics blocked", "/tempo/api/metrics/query_range", http.StatusForbidden},
+		{"echo blocked", "/tempo/api/echo", http.StatusForbidden},
+		{"overrides blocked", "/tempo/api/overrides", http.StatusForbidden},
+		{"v2 traces blocked", "/tempo/api/v2/traces/abc123", http.StatusForbidden},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			assert.Equal(t, tt.wantStatus, rec.Code)
+		})
+	}
+}
 
 func TestCleanTrace(t *testing.T) {
 	tests := []struct {

--- a/main.go
+++ b/main.go
@@ -845,9 +845,6 @@ func main() {
 				r.Group(func(r chi.Router) {
 					r.Use(authentication.WithTenantMiddlewares(pm.Middlewares))
 					r.Use(authentication.WithTenantHeader(cfg.traces.tenantHeader, tenantIDs))
-					if cfg.traces.queryRBAC {
-						r.Use(tracesv1.WithTraceQLNamespaceSelectAndForbidOtherAPIs())
-					}
 					r.Use(middleware.Timeout(cfg.traces.upstreamWriteTimeout))
 
 					// There can only be one login UI per tenant.  Let metrics be the default; fall back to search
@@ -877,6 +874,7 @@ func main() {
 								tracesv1.WithSpanRoutePrefix("/api/traces/v1/{tenant}"),
 								tracesv1.WithReadMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "traces")),
 								tracesv1.WithReadMiddleware(logsv1.WithEnforceAuthorizationLabels()),
+								tracesv1.WithTempoMiddleware(tracesv1.WithTraceQLNamespaceSelectAndForbidOtherAPIs(cfg.traces.queryRBAC)),
 								tracesv1.WithTempoMiddleware(authorization.WithAuthorizers(authorizers, rbac.Read, "traces")),
 								tracesv1.WithTempoMiddleware(logsv1.WithEnforceAuthorizationLabels()),
 								tracesv1.WithWriteMiddleware(authorization.WithAuthorizers(authorizers, rbac.Write, "traces")),


### PR DESCRIPTION
The path checks matched `/api/traces` and `/api/search`, but `/api/traces` was a prefix of all routed paths (`/api/traces/v1/<tenant>/tempo/...`).

Move the middleware and define a list of allowed Tempo APIs.